### PR TITLE
Align history entity mapping with database schema

### DIFF
--- a/API_WEB/ModelsDB/CSDL_NE.cs
+++ b/API_WEB/ModelsDB/CSDL_NE.cs
@@ -28,7 +28,8 @@ namespace API_WEB.ModelsDB
         public virtual DbSet<SearchList> SearchLists { get; set; } = null!;
         public virtual DbSet<SearchListItem> SearchListItems { get; set; } = null!;
         public DbSet<CheckList> CheckLists { get; set; }
-        public virtual DbSet<ScrapList> ScrapLists { get; set; }
+        public virtual DbSet<ScrapList> ScrapLists { get; set; } = null!;
+        public virtual DbSet<HistoryScrapList> HistoryScrapLists { get; set; } = null!;
         public DbSet<InternalTaskCounter> InternalTaskCounters { get; set; }
         public virtual DbSet<HistoryMaterial> HistoryMaterials { get; set; }
         public virtual DbSet<SumMaterial> SumMaterials { get; set; }

--- a/API_WEB/ModelsDB/HistoryScrapList.cs
+++ b/API_WEB/ModelsDB/HistoryScrapList.cs
@@ -1,0 +1,96 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace API_WEB.ModelsDB
+{
+    [Table("HistoryScrapList")]
+    public class HistoryScrapList
+    {
+        [Key]
+        [Column("ID")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Column("SN")]
+        [Required]
+        [StringLength(50)]
+        public string SN { get; set; } = null!;
+
+        [Column("KanBanStatus")]
+        [Required]
+        [StringLength(50)]
+        public string KanBanStatus { get; set; } = null!;
+
+        [Column("Sloc")]
+        [Required]
+        [StringLength(50)]
+        public string Sloc { get; set; } = null!;
+
+        [Column("TaskNumber")]
+        [StringLength(50)]
+        public string? TaskNumber { get; set; }
+
+        [Column("PO")]
+        [StringLength(50)]
+        public string? PO { get; set; }
+
+        [Column("CreateBy")]
+        [Required]
+        [StringLength(50)]
+        public string CreatedBy { get; set; } = null!;
+
+        [Column("Cost")]
+        [Required]
+        [StringLength(50)]
+        public string Cost { get; set; } = null!;
+
+        [Column("InternalTask")]
+        [Required]
+        [StringLength(50)]
+        public string InternalTask { get; set; } = null!;
+
+        [Column("Description")]
+        [Required]
+        [StringLength(100)]
+        public string Desc { get; set; } = null!;
+
+        [Column("CreateTime")]
+        [Required]
+        public DateTime CreateTime { get; set; }
+
+        [Column("ApproveScrapPerson")]
+        [Required]
+        [StringLength(50)]
+        public string ApproveScrapperson { get; set; } = null!;
+
+        [Column("ApplyTaskStatus")]
+        [Required]
+        public int ApplyTaskStatus { get; set; }
+
+        [Column("FindBoardStatus")]
+        [Required]
+        [StringLength(50)]
+        public string FindBoardStatus { get; set; } = null!;
+
+        [Column("Remark")]
+        [StringLength(50)]
+        public string? Remark { get; set; }
+
+        [Column("Purpose")]
+        [Required]
+        [StringLength(50)]
+        public string Purpose { get; set; } = null!;
+
+        [Column("Category")]
+        [Required]
+        [StringLength(50)]
+        public string Category { get; set; } = null!;
+
+        [Column("ApplyTime")]
+        public DateTime? ApplyTime { get; set; }
+
+        [Column("SpeApproveTime")]
+        public string? SpeApproveTime { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a HistoryScrapList entity that mirrors ScrapList to store update history with a primary key
- capture every ScrapList change inside ScrapController so new snapshots are recorded alongside the updates
- map HistoryScrapList.Id to the database ID column and initialize the DbSet properties to avoid nullability issues at runtime

## Testing
- Not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_b_68e54a12f16c8326a06146e2357b2582