### PR TITLE
Add history search for ScrapList records

### DIFF
--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -37,6 +37,46 @@ namespace API_WEB.Controllers.Scrap
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
+        private async Task AddHistoryEntriesAsync(IEnumerable<ScrapList> records)
+        {
+            if (records == null)
+            {
+                return;
+            }
+
+            var historyEntries = records
+                .Where(record => record != null)
+                .Select(record => new HistoryScrapList
+                {
+                    SN = record.SN,
+                    KanBanStatus = record.KanBanStatus,
+                    Sloc = record.Sloc,
+                    TaskNumber = record.TaskNumber,
+                    PO = record.PO,
+                    CreatedBy = record.CreatedBy,
+                    Cost = record.Cost,
+                    InternalTask = record.InternalTask,
+                    Desc = record.Desc,
+                    CreateTime = record.CreateTime,
+                    ApproveScrapperson = record.ApproveScrapperson,
+                    ApplyTaskStatus = record.ApplyTaskStatus,
+                    FindBoardStatus = record.FindBoardStatus,
+                    Remark = record.Remark,
+                    Purpose = record.Purpose,
+                    Category = record.Category,
+                    ApplyTime = record.ApplyTime,
+                    SpeApproveTime = record.SpeApproveTime
+                })
+                .ToList();
+
+            if (!historyEntries.Any())
+            {
+                return;
+            }
+
+            await _sqlContext.HistoryScrapLists.AddRangeAsync(historyEntries);
+        }
+
         // API INPUT-SN
         [HttpPost("input-sn")]
         public async Task<IActionResult> InputSN([FromBody] InputSNRequest request)
@@ -315,6 +355,7 @@ namespace API_WEB.Controllers.Scrap
                 }
 
                 // Lưu thay đổi vào bảng ScrapList
+                await AddHistoryEntriesAsync(validSNs);
                 await _sqlContext.SaveChangesAsync();
 
                 return Ok(new { message, internalTask = newInternalTask });
@@ -557,8 +598,9 @@ namespace API_WEB.Controllers.Scrap
                 if (request.SaveApplyStatus == "1")
                 {
                     var currentTime = DateTime.Now; // Lấy thời gian hiện tại
-                    var recordsToUpdate = _sqlContext.ScrapLists
-                        .Where(s => request.InternalTasks.Contains(s.InternalTask) && s.ApplyTaskStatus == 0);
+                    var recordsToUpdate = await _sqlContext.ScrapLists
+                        .Where(s => request.InternalTasks.Contains(s.InternalTask) && s.ApplyTaskStatus == 0)
+                        .ToListAsync();
 
                     foreach (var record in recordsToUpdate)
                     {
@@ -566,6 +608,7 @@ namespace API_WEB.Controllers.Scrap
                         record.ApplyTime = currentTime; // Cập nhật ApplyTime
                     }
 
+                    await AddHistoryEntriesAsync(recordsToUpdate);
                     await _sqlContext.SaveChangesAsync();
                 }
 
@@ -746,8 +789,9 @@ namespace API_WEB.Controllers.Scrap
                 if (request.SaveApplyStatus == "1")
                 {
                     var currentTime = DateTime.Now; // Lấy thời gian hiện tại
-                    var recordsToUpdate = _sqlContext.ScrapLists
-                        .Where(s => request.SNs.Contains(s.SN) && s.ApplyTaskStatus == 0);
+                    var recordsToUpdate = await _sqlContext.ScrapLists
+                        .Where(s => request.SNs.Contains(s.SN) && s.ApplyTaskStatus == 0)
+                        .ToListAsync();
 
                     foreach (var record in recordsToUpdate)
                     {
@@ -755,6 +799,7 @@ namespace API_WEB.Controllers.Scrap
                         record.ApplyTime = currentTime; // Cập nhật ApplyTime
                     }
 
+                    await AddHistoryEntriesAsync(recordsToUpdate);
                     await _sqlContext.SaveChangesAsync();
                 }
 
@@ -841,6 +886,7 @@ namespace API_WEB.Controllers.Scrap
                     record.ApplyTime = DateTime.Now;
                 }
 
+                await AddHistoryEntriesAsync(recordsToUpdate);
                 await _sqlContext.SaveChangesAsync();
 
                 return Ok(new { message = "Cập nhật TaskNumber và PO thành công cho các SN." });
@@ -931,6 +977,7 @@ namespace API_WEB.Controllers.Scrap
                     }
                 }
 
+                await AddHistoryEntriesAsync(recordsToUpdate);
                 await _sqlContext.SaveChangesAsync();
 
                 return Ok(new { message = "Cập nhật Cost thành công cho các Board SN." });
@@ -977,6 +1024,69 @@ namespace API_WEB.Controllers.Scrap
             catch (Exception ex)
             {
                 return StatusCode(500, new { message = "Đã xảy ra lỗi khi lấy dữ liệu lịch sử.", error = ex.Message });
+            }
+        }
+
+        // API: Tìm kiếm lịch sử ScrapList theo danh sách SN
+        [HttpPost("history-by-sn")]
+        public async Task<IActionResult> GetHistoryBySn([FromBody] HistoryBySnRequest request)
+        {
+            try
+            {
+                if (request?.SNs == null || !request.SNs.Any())
+                {
+                    return BadRequest(new { message = "Danh sách SN không được để trống." });
+                }
+
+                var normalizedSNs = request.SNs
+                    .Where(sn => !string.IsNullOrWhiteSpace(sn))
+                    .Select(sn => sn.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (!normalizedSNs.Any())
+                {
+                    return BadRequest(new { message = "Không có SN hợp lệ để tìm kiếm." });
+                }
+
+                var historyRecords = await _sqlContext.HistoryScrapLists
+                    .Where(history => normalizedSNs.Contains(history.SN))
+                    .OrderByDescending(history => history.Id)
+                    .ToListAsync();
+
+                var foundSNs = new HashSet<string>(historyRecords.Select(history => history.SN), StringComparer.OrdinalIgnoreCase);
+                var missingSNs = normalizedSNs
+                    .Where(sn => !foundSNs.Contains(sn))
+                    .ToList();
+
+                var result = historyRecords.Select(history => new
+                {
+                    history.Id,
+                    history.SN,
+                    history.KanBanStatus,
+                    history.Sloc,
+                    history.TaskNumber,
+                    history.PO,
+                    CreatedBy = history.CreatedBy,
+                    history.Cost,
+                    history.InternalTask,
+                    Description = history.Desc,
+                    CreateTime = history.CreateTime.ToString("yyyy-MM-dd HH:mm:ss"),
+                    ApproveScrapPerson = history.ApproveScrapperson,
+                    history.ApplyTaskStatus,
+                    history.FindBoardStatus,
+                    history.Remark,
+                    history.Purpose,
+                    history.Category,
+                    ApplyTime = history.ApplyTime.HasValue ? history.ApplyTime.Value.ToString("yyyy-MM-dd HH:mm:ss") : "N/A",
+                    history.SpeApproveTime
+                }).ToList();
+
+                return Ok(new { data = result, missingSNs });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "Đã xảy ra lỗi khi tìm kiếm lịch sử SN.", error = ex.Message });
             }
         }
 
@@ -1122,6 +1232,11 @@ namespace API_WEB.Controllers.Scrap
             public List<string> TaskNumber { get; set; } = new List<string>();
         }
 
+        public class HistoryBySnRequest
+        {
+            public List<string> SNs { get; set; } = new List<string>();
+        }
+
 
         // API: Cập nhật trạng thái FindBoardStatus trong bảng ScrapList
         [HttpPost("update-status-find-board")]
@@ -1171,6 +1286,7 @@ namespace API_WEB.Controllers.Scrap
                 }
 
                 // Lưu thay đổi vào cơ sở dữ liệu
+                await AddHistoryEntriesAsync(scrapRecords);
                 await _sqlContext.SaveChangesAsync();
 
                 return Ok(new { message = $"Cập nhật trạng thái FindBoardStatus thành công cho {scrapRecords.Count} bản ghi." });
@@ -1452,6 +1568,14 @@ namespace API_WEB.Controllers.Scrap
                 {
                     _sqlContext.ScrapLists.UpdateRange(updateSNs);
                 }
+                if (scrapListEntries.Any())
+                {
+                    await AddHistoryEntriesAsync(scrapListEntries);
+                }
+                if (updateSNs.Any())
+                {
+                    await AddHistoryEntriesAsync(updateSNs);
+                }
                 await _sqlContext.SaveChangesAsync();
 
                 string message = "Lưu danh sách SN thành công.";
@@ -1610,6 +1734,7 @@ namespace API_WEB.Controllers.Scrap
                 }
 
                 // Lưu thay đổi vào cơ sở dữ liệu
+                await AddHistoryEntriesAsync(updatedRecords);
                 await _sqlContext.SaveChangesAsync();
 
                 // Chuẩn bị dữ liệu để gọi API bên thứ ba
@@ -1713,6 +1838,7 @@ namespace API_WEB.Controllers.Scrap
                     record.ApplyTime = DateTime.Now; // Cập nhật thời gian áp dụng
                 }
 
+                await AddHistoryEntriesAsync(existingSNs);
                 await _sqlContext.SaveChangesAsync();
 
                 return Ok(new { message = "Cập nhật ApplyTaskStatus thành công cho danh sách SN." });
@@ -1906,6 +2032,7 @@ namespace API_WEB.Controllers.Scrap
 
                 // Lưu vào bảng ScrapList
                 _sqlContext.ScrapLists.AddRange(scrapListEntries);
+                await AddHistoryEntriesAsync(scrapListEntries);
                 await _sqlContext.SaveChangesAsync();
 
                 return Ok(new { message = $"Đã insert thành công {scrapListEntries.Count} SN vào bảng ScrapList." });

--- a/API_WEB/ModelsDB/CSDL_NE.cs
+++ b/API_WEB/ModelsDB/CSDL_NE.cs
@@ -29,6 +29,7 @@ namespace API_WEB.ModelsDB
         public virtual DbSet<SearchListItem> SearchListItems { get; set; } = null!;
         public DbSet<CheckList> CheckLists { get; set; }
         public virtual DbSet<ScrapList> ScrapLists { get; set; }
+        public virtual DbSet<HistoryScrapList> HistoryScrapLists { get; set; }
         public DbSet<InternalTaskCounter> InternalTaskCounters { get; set; }
         public virtual DbSet<HistoryMaterial> HistoryMaterials { get; set; }
         public virtual DbSet<SumMaterial> SumMaterials { get; set; }

--- a/API_WEB/ModelsDB/HistoryScrapList.cs
+++ b/API_WEB/ModelsDB/HistoryScrapList.cs
@@ -1,0 +1,95 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace API_WEB.ModelsDB
+{
+    [Table("HistoryScrapList")]
+    public class HistoryScrapList
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Column("SN")]
+        [Required]
+        [StringLength(50)]
+        public string SN { get; set; } = null!;
+
+        [Column("KanBanStatus")]
+        [Required]
+        [StringLength(50)]
+        public string KanBanStatus { get; set; } = null!;
+
+        [Column("Sloc")]
+        [Required]
+        [StringLength(50)]
+        public string Sloc { get; set; } = null!;
+
+        [Column("TaskNumber")]
+        [StringLength(50)]
+        public string? TaskNumber { get; set; }
+
+        [Column("PO")]
+        [StringLength(50)]
+        public string? PO { get; set; }
+
+        [Column("CreateBy")]
+        [Required]
+        [StringLength(50)]
+        public string CreatedBy { get; set; } = null!;
+
+        [Column("Cost")]
+        [Required]
+        [StringLength(50)]
+        public string Cost { get; set; } = null!;
+
+        [Column("InternalTask")]
+        [Required]
+        [StringLength(50)]
+        public string InternalTask { get; set; } = null!;
+
+        [Column("Description")]
+        [Required]
+        [StringLength(100)]
+        public string Desc { get; set; } = null!;
+
+        [Column("CreateTime")]
+        [Required]
+        public DateTime CreateTime { get; set; }
+
+        [Column("ApproveScrapPerson")]
+        [Required]
+        [StringLength(50)]
+        public string ApproveScrapperson { get; set; } = null!;
+
+        [Column("ApplyTaskStatus")]
+        [Required]
+        public int ApplyTaskStatus { get; set; }
+
+        [Column("FindBoardStatus")]
+        [Required]
+        [StringLength(50)]
+        public string FindBoardStatus { get; set; } = null!;
+
+        [Column("Remark")]
+        [StringLength(50)]
+        public string? Remark { get; set; }
+
+        [Column("Purpose")]
+        [Required]
+        [StringLength(50)]
+        public string Purpose { get; set; } = null!;
+
+        [Column("Category")]
+        [Required]
+        [StringLength(50)]
+        public string Category { get; set; } = null!;
+
+        [Column("ApplyTime")]
+        public DateTime? ApplyTime { get; set; }
+
+        [Column("SpeApproveTime")]
+        public string? SpeApproveTime { get; set; }
+    }
+}

--- a/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
@@ -17,6 +17,7 @@
                 <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
                 <!--<option value="UPDATE_STATUS">UPDATE STATUS</option>-->
                 <option value="SEARCH_STATUS">Tìm kiếm</option>
+                <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
             </select>
         </form>
     </div>
@@ -106,6 +107,22 @@
                 </div>
             </div>
         </form>
+
+        <!-- Form SEARCH HISTORY -->
+        <form id="search-history-form" method="post" class="hidden" data-search-type="SEARCH_HISTORY">
+            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
+                <div class="col-md-3">
+                    <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
+                </div>
+                <div class="col-md-3">
+                    <div class="mb-2">
+                        <label class="form-label">Tra cứu lịch sử SN</label>
+                        <p class="form-text">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</p>
+                    </div>
+                    <button id="history-search-btn" class="md-2 btn btn-ne" type="button">Search history</button>
+                </div>
+            </div>
+        </form>
     </div>
 </div>
 
@@ -117,6 +134,8 @@
     <div id="update-status-result" class="hidden"></div>-->
     <!--hiển thị của chức năng search data-->
     <div id="search-status-result" class="hidden"></div>
+    <!--hiển thị của chức năng history search-->
+    <div id="history-search-result" class="hidden"></div>
 </div>
 
 @section Scripts {

--- a/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
@@ -120,6 +120,7 @@
                         <p class="form-text">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</p>
                     </div>
                     <button id="history-search-btn" class="md-2 btn btn-ne" type="button">Search history</button>
+                    <button id="history-download-btn" class="md-2 btn btn-ne" type="button">Download Excel</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- add a HistoryScrapList entity and DbContext mapping to store snapshots of ScrapList records
- update ScrapController endpoints to insert history rows whenever ScrapList data is created or modified
- add an API and UI workflow so users can search HistoryScrapList by a list of SNs from the progress page

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68e5d9929adc8326993d70590a94669a