### PR TITLE
Resolve scrap history merge conflicts

### DIFF
--- a/API_WEB/Controllers/Repositories/KhoScrapController.cs
+++ b/API_WEB/Controllers/Repositories/KhoScrapController.cs
@@ -591,10 +591,6 @@ namespace API_WEB.Controllers.Repositories
 
             try
             {
-<<<<<<< HEAD
-=======
-                int maxSlots = 160;
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
                 request.SerialNumbers = request.SerialNumbers.Distinct().ToList();
 
                 //Kiem tra SerialNumber trong ScrapList
@@ -602,31 +598,15 @@ namespace API_WEB.Controllers.Repositories
                     .Where(sl => request.SerialNumbers.Contains(sl.SN))
                     .Select(sl => sl.SN)
                     .ToListAsync();
-<<<<<<< HEAD
-
                 if (validSerials.Any())
-=======
-                var invalidSerials = request.SerialNumbers.Except(validSerials).ToList();
-                if (!invalidSerials.Any())
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
                 {
                     return BadRequest(new
                     {
                         success = false,
-<<<<<<< HEAD
                         message = "Một số Serial Number đã tồn tại trong ScrapList — không thể nhập Kho OK.",
                         invalidSerials = validSerials
                     });
                 }
-
-
-=======
-                        message = "Serial Number tồn tại trong ScrapList",
-                        invalidSerials
-                    });
-                }
-
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
                 var existingProducts = await _sqlContext.KhoOks
                     .Where(p => request.SerialNumbers.Contains(p.SERIAL_NUMBER))
                     .ToDictionaryAsync(p => p.SERIAL_NUMBER);

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -1027,8 +1027,6 @@ namespace API_WEB.Controllers.Scrap
             }
         }
 
-<<<<<<< HEAD
-=======
         // API: Tìm kiếm lịch sử ScrapList theo danh sách SN
         [HttpPost("history-by-sn")]
         public async Task<IActionResult> GetHistoryBySn([FromBody] HistoryBySnRequest request)
@@ -1091,8 +1089,6 @@ namespace API_WEB.Controllers.Scrap
                 return StatusCode(500, new { message = "Đã xảy ra lỗi khi tìm kiếm lịch sử SN.", error = ex.Message });
             }
         }
-
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
         // API: Lấy dữ liệu FindBoardStatus từ ScrapList
         [HttpGet("get-find-board-status")]
         public async Task<IActionResult> GetFindBoardStatus()
@@ -1235,14 +1231,10 @@ namespace API_WEB.Controllers.Scrap
             public List<string> TaskNumber { get; set; } = new List<string>();
         }
 
-<<<<<<< HEAD
-=======
         public class HistoryBySnRequest
         {
             public List<string> SNs { get; set; } = new List<string>();
         }
-
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 
         // API: Cập nhật trạng thái FindBoardStatus trong bảng ScrapList
         [HttpPost("update-status-find-board")]

--- a/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
@@ -17,10 +17,7 @@
                 <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
                 <!--<option value="UPDATE_STATUS">UPDATE STATUS</option>-->
                 <option value="SEARCH_STATUS">Tìm kiếm</option>
-<<<<<<< HEAD
-=======
                 <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
             </select>
         </form>
     </div>
@@ -110,8 +107,6 @@
                 </div>
             </div>
         </form>
-<<<<<<< HEAD
-=======
 
         <!-- Form SEARCH HISTORY -->
         <form id="search-history-form" method="post" class="hidden" data-search-type="SEARCH_HISTORY">
@@ -129,7 +124,6 @@
                 </div>
             </div>
         </form>
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
     </div>
 </div>
 
@@ -141,11 +135,8 @@
     <div id="update-status-result" class="hidden"></div>-->
     <!--hiển thị của chức năng search data-->
     <div id="search-status-result" class="hidden"></div>
-<<<<<<< HEAD
-=======
     <!--hiển thị của chức năng history search-->
     <div id="history-search-result" class="hidden"></div>
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 </div>
 
 @section Scripts {

--- a/PESystem/wwwroot/assets/Areas/Repositories/js/import.js
+++ b/PESystem/wwwroot/assets/Areas/Repositories/js/import.js
@@ -242,12 +242,9 @@
             const receiveResult = await receiveResponse.json();
             showInfo("Trạng thái nhận bản:" + receiveResult.message);
 
-<<<<<<< HEAD
-=======
             if (receiveResult.message.replace(/"/g, '') === "OK") {
                 location.reload();
             }
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
         } catch (error) {
             console.error("Lỗi khi xử lý yêu cầu:", error);
             showError("Error!");

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/progress.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/progress.js
@@ -3,13 +3,8 @@ let selectedSNs = new Set(); // Lưu các SN đã chọn (cho SEARCH_STATUS)
 
 // Hàm để ẩn tất cả các form và khu vực kết quả
 function hideAllElements() {
-<<<<<<< HEAD
-    const forms = ["task-stock-status-form", "search-status-form"]; // bo  "update-status-form",
-    const results = ["task-stock-status-result", "search-status-result"]; // "update-status-result",
-=======
     const forms = ["task-stock-status-form", "search-status-form", "search-history-form"]; // bo  "update-status-form",
     const results = ["task-stock-status-result", "search-status-result", "history-search-result"]; // "update-status-result",
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 
     forms.forEach(formId => {
         const form = document.getElementById(formId);
@@ -34,19 +29,13 @@ function hideAllElements() {
     const statusOptions = document.getElementById("status-options");
     const searchStatusUpdate = document.getElementById("search-status-update");
     const searchStatusOptions = document.getElementById("search-status-options");
-<<<<<<< HEAD
-=======
     const historySearchUpdate = document.getElementById("history-search-update");
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 
     if (snStatusUpdate) snStatusUpdate.value = "";
     if (statusOptions) statusOptions.selectedIndex = 0;
     if (searchStatusUpdate) searchStatusUpdate.value = "";
     if (searchStatusOptions) searchStatusOptions.selectedIndex = 0;
-<<<<<<< HEAD
-=======
     if (historySearchUpdate) historySearchUpdate.value = "";
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 }
 
 // Hàm tạo và tải xuống file Excel
@@ -74,8 +63,6 @@ function exportToExcel(noInternalTaskData, hasInternalTaskNoTaskNumberData, hasT
     XLSX.writeFile(workbook, filename);
 }
 
-<<<<<<< HEAD
-=======
 function exportHistoryToExcel(historyData, filename) {
     if (!Array.isArray(historyData) || !historyData.length) {
         throw new Error("No history data to export");
@@ -110,8 +97,6 @@ function exportHistoryToExcel(historyData, filename) {
 
     XLSX.writeFile(workbook, filename);
 }
-
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 // Hàm hiển thị bảng với phân trang
 function renderTableWithPagination(data, resultDiv, tableHeaders, rowTemplate, extraHtml = "", tableIdPrefix = "") {
     const rowsPerPage = 10; // Số dòng mỗi trang
@@ -473,8 +458,6 @@ async function searchStatus(searchType, searchValues) {
     }
 }
 
-<<<<<<< HEAD
-=======
 // Hàm gọi API và hiển thị bảng lịch sử cho HistoryScrapList theo danh sách SN
 async function searchHistoryBySN(snValues) {
     const resultDiv = document.getElementById("history-search-result");
@@ -604,8 +587,6 @@ async function searchHistoryBySN(snValues) {
         window.historySearchData = null;
     }
 }
-
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
 // Ẩn tất cả các form và khu vực kết quả ngay lập tức khi trang tải
 hideAllElements();
 
@@ -637,12 +618,9 @@ document.addEventListener("DOMContentLoaded", function () {
         }*/ else if (selectedValue === "SEARCH_STATUS") {
             document.getElementById("search-status-form").classList.remove("hidden");
             document.getElementById("search-status-result").classList.remove("hidden");
-<<<<<<< HEAD
-=======
         } else if (selectedValue === "SEARCH_HISTORY") {
             document.getElementById("search-history-form").classList.remove("hidden");
             document.getElementById("history-search-result").classList.remove("hidden");
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2
         }
     });
 
@@ -875,9 +853,6 @@ document.addEventListener("DOMContentLoaded", function () {
             console.error("Error:", error);
         }
     });
-<<<<<<< HEAD
-});
-=======
 
     // Xử lý sự kiện khi nhấn nút "Search history" trong form SEARCH_HISTORY
     document.getElementById("history-search-btn").addEventListener("click", async function () {
@@ -947,4 +922,3 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 });
->>>>>>> ee026503a5b0a67515bc63ae57925ef803d917c2


### PR DESCRIPTION
## Summary
- keep the history lookup API and request type in `ScrapController` while removing conflict markers
- ensure Kho OK import validation rejects serial numbers already present in ScrapList
- expose the history search UI and client logic, including Excel export hooks, and reload Kho import after successful receiving status

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e61609a3ac8326b05287564e2c1bf0