### PR TITLE
Fix Replace BGA status queries for EF Core

### DIFF
--- a/API_WEB/Controllers/BGA/ReplaceBgaController.cs
+++ b/API_WEB/Controllers/BGA/ReplaceBgaController.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using API_WEB.ModelsDB;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace API_WEB.Controllers.BGA
+{
+    [Route("api/bga-replace")]
+    [ApiController]
+    public class ReplaceBgaController : ControllerBase
+    {
+        private readonly CSDL_NE _sqlContext;
+
+        private static readonly Dictionary<int, int> _nextStatusMap = new()
+        {
+            { 4, 10 },
+            { 10, 11 },
+            { 11, 12 },
+            { 12, 13 },
+            { 13, 14 },
+            { 14, 15 },
+            { 15, 16 },
+            { 16, 17 }, // Will be overridden when processing x-ray result
+            { 17, 3 }
+        };
+
+        private static readonly Dictionary<int, string> _statusDescriptions = new()
+        {
+            { 4, "Waiting approve replace BGA" },
+            { 10, "Check in barking" },
+            { 11, "Check out barking" },
+            { 12, "VI after barking" },
+            { 13, "Remove BGA, clean pad" },
+            { 14, "Check VI BGA pad" },
+            { 15, "Replace BGA" },
+            { 16, "Xray" },
+            { 17, "ICT, FT" },
+            { 3, "Replaced BGA ok" }
+        };
+
+        private static string GetStatusName(int status)
+        {
+            return _statusDescriptions.TryGetValue(status, out var name)
+                ? name
+                : status.ToString();
+        }
+
+        public ReplaceBgaController(CSDL_NE sqlContext)
+        {
+            _sqlContext = sqlContext;
+        }
+
+        private IQueryable<ScrapList> QueryBgaScrapLists()
+        {
+            return _sqlContext.ScrapLists
+                .AsNoTracking()
+                .Where(s => s.Category != null && EF.Functions.Like(s.Category, "%BGA%"));
+        }
+
+        private IQueryable<HistoryScrapList> QueryBgaHistory()
+        {
+            return _sqlContext.HistoryScrapLists
+                .AsNoTracking()
+                .Where(h => h.Category != null && EF.Functions.Like(h.Category, "%BGA%"));
+        }
+
+        private static List<string> NormalizeSerialNumbers(IEnumerable<string>? serialNumbers)
+        {
+            return serialNumbers?
+                .Where(sn => !string.IsNullOrWhiteSpace(sn))
+                .Select(sn => sn.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList()
+                ?? new List<string>();
+        }
+
+        private static bool IsBgaCategory(string? category)
+        {
+            return !string.IsNullOrWhiteSpace(category) && category.Contains("BGA", StringComparison.OrdinalIgnoreCase);
+        }
+
+        [HttpGet("status")]
+        public async Task<IActionResult> GetByStatus([FromQuery] int status)
+        {
+            if (!_statusDescriptions.ContainsKey(status))
+            {
+                return BadRequest(new { message = "Trạng thái không hợp lệ." });
+            }
+
+            var records = await QueryBgaScrapLists()
+                .Where(s => s.ApplyTaskStatus == status)
+                .OrderBy(s => s.SN)
+                .Select(s => new
+                {
+                    s.SN,
+                    s.TaskNumber,
+                    s.InternalTask,
+                    s.Desc,
+                    s.ApplyTaskStatus,
+                    s.FindBoardStatus,
+                    s.ApproveScrapperson,
+                    s.ApplyTime
+                })
+                .ToListAsync();
+
+            if (!records.Any())
+            {
+                return NotFound(new { message = "Không có dữ liệu cho trạng thái được yêu cầu." });
+            }
+
+            var response = records
+                .Select(record => new
+                {
+                    record.SN,
+                    record.TaskNumber,
+                    record.InternalTask,
+                    record.Desc,
+                    record.ApplyTaskStatus,
+                    StatusName = GetStatusName(record.ApplyTaskStatus),
+                    record.FindBoardStatus,
+                    record.ApproveScrapperson,
+                    record.ApplyTime
+                })
+                .ToList();
+
+            return Ok(response);
+        }
+
+        [HttpGet("dashboard/status-summary")]
+        public async Task<IActionResult> GetStatusSummary()
+        {
+            var summary = await QueryBgaScrapLists()
+                .GroupBy(s => s.ApplyTaskStatus)
+                .Select(g => new
+                {
+                    Status = g.Key,
+                    Count = g.Count()
+                })
+                .OrderBy(item => item.Status)
+                .ToListAsync();
+
+            var response = summary
+                .Select(item => new
+                {
+                    item.Status,
+                    item.Count,
+                    StatusName = GetStatusName(item.Status)
+                })
+                .ToList();
+
+            return Ok(response);
+        }
+
+        [HttpGet("dashboard/barking-aging")]
+        public async Task<IActionResult> GetBarkingAging()
+        {
+            var now = DateTime.Now;
+
+            var records = await QueryBgaScrapLists()
+                .Where(s => s.ApplyTaskStatus == 11)
+                .OrderByDescending(s => s.ApplyTime)
+                .Select(s => new
+                {
+                    s.SN,
+                    s.ApplyTime
+                })
+                .ToListAsync();
+
+            var payload = records
+                .Select(record => new
+                {
+                    sn = record.SN,
+                    applyTime = record.ApplyTime,
+                    hours = record.ApplyTime.HasValue
+                        ? Math.Round((now - record.ApplyTime.Value).TotalHours, 2)
+                        : (double?)null
+                })
+                .ToList();
+
+            return Ok(payload);
+        }
+
+        [HttpPost("status/bulk")]
+        public async Task<IActionResult> GetStatusForList([FromBody] BulkSnRequest request)
+        {
+            var normalizedSNs = NormalizeSerialNumbers(request?.SNs);
+            if (!normalizedSNs.Any())
+            {
+                return BadRequest(new { message = "Danh sách SN không hợp lệ." });
+            }
+
+            var scrapRecords = await QueryBgaScrapLists()
+                .Where(s => normalizedSNs.Contains(s.SN))
+                .ToListAsync();
+
+            var result = normalizedSNs
+                .Select(sn =>
+                {
+                    var record = scrapRecords.FirstOrDefault(s => string.Equals(s.SN, sn, StringComparison.OrdinalIgnoreCase));
+                    if (record == null)
+                    {
+                        return new
+                        {
+                            sn,
+                            isValid = false,
+                            message = "Không tìm thấy SN trong Replace BGA."
+                        };
+                    }
+
+                    var statusName = _statusDescriptions.ContainsKey(record.ApplyTaskStatus)
+                        ? _statusDescriptions[record.ApplyTaskStatus]
+                        : record.ApplyTaskStatus.ToString();
+
+                    return new
+                    {
+                        sn = record.SN,
+                        record.TaskNumber,
+                        record.InternalTask,
+                        record.Desc,
+                        record.ApplyTaskStatus,
+                        statusName,
+                        record.FindBoardStatus,
+                        record.ApproveScrapperson,
+                        record.ApplyTime,
+                        isValid = true
+                    };
+                })
+                .ToList();
+
+            return Ok(result);
+        }
+
+        [HttpPost("history")]
+        public async Task<IActionResult> GetHistory([FromBody] BulkSnRequest request)
+        {
+            var normalizedSNs = NormalizeSerialNumbers(request?.SNs);
+            if (!normalizedSNs.Any())
+            {
+                return BadRequest(new { message = "Danh sách SN không hợp lệ." });
+            }
+
+            var histories = await QueryBgaHistory()
+                .Where(h => normalizedSNs.Contains(h.SN))
+                .OrderBy(h => h.SN)
+                .ThenByDescending(h => h.ApplyTime ?? h.CreateTime)
+                .Select(h => new
+                {
+                    h.SN,
+                    h.TaskNumber,
+                    h.InternalTask,
+                    h.Desc,
+                    h.ApplyTaskStatus,
+                    h.FindBoardStatus,
+                    h.ApproveScrapperson,
+                    h.ApplyTime,
+                    h.CreateTime
+                })
+                .ToListAsync();
+
+            var response = histories
+                .Select(history => new
+                {
+                    history.SN,
+                    history.TaskNumber,
+                    history.InternalTask,
+                    history.Desc,
+                    history.ApplyTaskStatus,
+                    StatusName = GetStatusName(history.ApplyTaskStatus),
+                    history.FindBoardStatus,
+                    history.ApproveScrapperson,
+                    history.ApplyTime,
+                    history.CreateTime
+                })
+                .ToList();
+
+            return Ok(response);
+        }
+
+        [HttpPost("update-status")]
+        public async Task<IActionResult> UpdateStatus([FromBody] UpdateBgaStatusRequest request)
+        {
+            if (request == null || request.SNs == null || !request.SNs.Any())
+            {
+                return BadRequest(new { message = "Danh sách SN không được để trống." });
+            }
+
+            if (!_statusDescriptions.ContainsKey(request.CurrentStatus) || request.CurrentStatus == 3)
+            {
+                return BadRequest(new { message = "Trạng thái hiện tại không hợp lệ." });
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Remark))
+            {
+                return BadRequest(new { message = "Remark không được để trống." });
+            }
+
+            request.Remark = request.Remark.Trim();
+            if (request.Remark.Length > 50)
+            {
+                return BadRequest(new { message = "Remark không được dài quá 50 ký tự." });
+            }
+
+            var normalizedSNs = request.SNs
+                .Where(sn => !string.IsNullOrWhiteSpace(sn))
+                .Select(sn => sn.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (!normalizedSNs.Any())
+            {
+                return BadRequest(new { message = "Danh sách SN không hợp lệ." });
+            }
+
+            var scrapRecords = await _sqlContext.ScrapLists
+                .Where(s => normalizedSNs.Contains(s.SN))
+                .ToListAsync();
+
+            var nonBgaRecords = scrapRecords
+                .Where(record => !IsBgaCategory(record?.Category))
+                .Select(record => record?.SN)
+                .Where(sn => !string.IsNullOrEmpty(sn))
+                .Cast<string>()
+                .ToList();
+
+            if (nonBgaRecords.Any())
+            {
+                return BadRequest(new
+                {
+                    message = "Một số SN không thuộc Replace BGA.",
+                    details = nonBgaRecords
+                });
+            }
+
+            var missingSNs = normalizedSNs
+                .Except(scrapRecords.Select(s => s.SN), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (missingSNs.Any())
+            {
+                return NotFound(new { message = $"Không tìm thấy các SN: {string.Join(", ", missingSNs)}." });
+            }
+
+            var invalidStatusSNs = scrapRecords
+                .Where(s => s.ApplyTaskStatus != request.CurrentStatus)
+                .Select(s => $"{s.SN} (trạng thái hiện tại: {s.ApplyTaskStatus})")
+                .ToList();
+
+            if (invalidStatusSNs.Any())
+            {
+                return BadRequest(new
+                {
+                    message = "Một số SN không ở trạng thái yêu cầu để cập nhật.",
+                    details = invalidStatusSNs
+                });
+            }
+
+            int nextStatus;
+            if (request.CurrentStatus == 16)
+            {
+                if (string.IsNullOrWhiteSpace(request.XrayResult))
+                {
+                    return BadRequest(new { message = "Vui lòng chọn kết quả Xray (OK hoặc NG)." });
+                }
+
+                var normalizedResult = request.XrayResult.Trim().ToUpperInvariant();
+                if (normalizedResult == "OK")
+                {
+                    nextStatus = 17;
+                }
+                else if (normalizedResult == "NG")
+                {
+                    nextStatus = 13;
+                }
+                else
+                {
+                    return BadRequest(new { message = "Giá trị XrayResult chỉ được phép là OK hoặc NG." });
+                }
+            }
+            else
+            {
+                if (!_nextStatusMap.TryGetValue(request.CurrentStatus, out nextStatus))
+                {
+                    return BadRequest(new { message = "Không xác định được trạng thái tiếp theo." });
+                }
+            }
+
+            foreach (var record in scrapRecords)
+            {
+                record.ApplyTaskStatus = nextStatus;
+                record.FindBoardStatus = request.Remark;
+                record.ApplyTime = DateTime.Now;
+            }
+
+            await AddHistoryEntriesAsync(scrapRecords);
+            await _sqlContext.SaveChangesAsync();
+
+            var nextStatusName = _statusDescriptions.ContainsKey(nextStatus)
+                ? _statusDescriptions[nextStatus]
+                : nextStatus.ToString();
+
+            return Ok(new
+            {
+                message = $"Cập nhật thành công {scrapRecords.Count} SN sang trạng thái '{nextStatusName}'.",
+                nextStatus,
+                nextStatusName
+            });
+        }
+
+        private async Task AddHistoryEntriesAsync(IEnumerable<ScrapList> records)
+        {
+            if (records == null)
+            {
+                return;
+            }
+
+            var historyEntries = records
+                .Where(record => record != null)
+                .Select(record => new HistoryScrapList
+                {
+                    SN = record.SN,
+                    KanBanStatus = record.KanBanStatus,
+                    Sloc = record.Sloc,
+                    TaskNumber = record.TaskNumber,
+                    PO = record.PO,
+                    CreatedBy = record.CreatedBy,
+                    Cost = record.Cost,
+                    InternalTask = record.InternalTask,
+                    Desc = record.Desc,
+                    CreateTime = record.CreateTime,
+                    ApproveScrapperson = record.ApproveScrapperson,
+                    ApplyTaskStatus = record.ApplyTaskStatus,
+                    FindBoardStatus = record.FindBoardStatus,
+                    Remark = record.Remark,
+                    Purpose = record.Purpose,
+                    Category = record.Category,
+                    ApplyTime = record.ApplyTime,
+                    SpeApproveTime = record.SpeApproveTime
+                })
+                .ToList();
+
+            if (!historyEntries.Any())
+            {
+                return;
+            }
+
+            await _sqlContext.HistoryScrapLists.AddRangeAsync(historyEntries);
+        }
+    }
+
+    public class UpdateBgaStatusRequest
+    {
+        public List<string> SNs { get; set; } = new();
+        public int CurrentStatus { get; set; }
+        public string? Remark { get; set; }
+        public string? XrayResult { get; set; }
+    }
+
+    public class BulkSnRequest
+    {
+        public List<string>? SNs { get; set; }
+    }
+}
+

--- a/API_WEB/Controllers/BGA/ReplaceBgaController.cs
+++ b/API_WEB/Controllers/BGA/ReplaceBgaController.cs
@@ -205,6 +205,14 @@ namespace API_WEB.Controllers.BGA
                         return new
                         {
                             sn,
+                            TaskNumber = (string?)null,
+                            InternalTask = (string?)null,
+                            Desc = (string?)null,
+                            ApplyTaskStatus = (int?)null,
+                            statusName = (string?)null,
+                            FindBoardStatus = (string?)null,
+                            ApproveScrapperson = (string?)null,
+                            ApplyTime = (DateTime?)null,
                             isValid = false,
                             message = "Không tìm thấy SN trong Replace BGA."
                         };
@@ -225,7 +233,8 @@ namespace API_WEB.Controllers.BGA
                         record.FindBoardStatus,
                         record.ApproveScrapperson,
                         record.ApplyTime,
-                        isValid = true
+                        isValid = true,
+                        message = (string?)null
                     };
                 })
                 .ToList();

--- a/PESystem/Areas/BGA/Controllers/HomeController.cs
+++ b/PESystem/Areas/BGA/Controllers/HomeController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PESystem.Areas.BGA.Controllers
+{
+    [Area("BGA")]
+    [Authorize]
+    public class HomeController : Controller
+    {
+        public IActionResult Index()
+        {
+            return RedirectToAction(nameof(Process));
+        }
+
+        public IActionResult Process()
+        {
+            return View();
+        }
+
+        public IActionResult Dashboard()
+        {
+            return View();
+        }
+
+        public IActionResult Actions()
+        {
+            return View();
+        }
+
+        public IActionResult Search()
+        {
+            return View();
+        }
+    }
+}

--- a/PESystem/Areas/BGA/Views/Home/Actions.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Actions.cshtml
@@ -1,0 +1,100 @@
+@{
+    ViewData["Title"] = "Thao tác trạng thái";
+    Layout = "~/Areas/BGA/Views/Shared/layout_bga.cshtml";
+}
+
+<section class="container-fluid py-4">
+    <div class="row mb-4">
+        <div class="col-12">
+            <h1 class="fw-bold text-primary mb-1">Thao tác xác nhận trạng thái</h1>
+            <p class="text-muted mb-0">Cập nhật trạng thái và remark cho các SN được chọn.</p>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-12 col-lg-7 col-xxl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-gradient text-white">
+                    <h5 class="mb-0">Cập nhật trạng thái Replace BGA</h5>
+                </div>
+                <div class="card-body">
+                    <div class="mb-3">
+                        <label for="current-status" class="form-label fw-semibold">Trạng thái hiện tại</label>
+                        <select id="current-status" class="form-select">
+                            <option value="4">4 - Waiting approve replace BGA</option>
+                            <option value="10">10 - Check in barking</option>
+                            <option value="11">11 - Check out barking</option>
+                            <option value="12">12 - VI after barking</option>
+                            <option value="13">13 - Remove BGA, clean pad</option>
+                            <option value="14">14 - Check VI BGA pad</option>
+                            <option value="15">15 - Replace BGA</option>
+                            <option value="16">16 - Xray</option>
+                            <option value="17">17 - ICT, FT</option>
+                        </select>
+                    </div>
+
+                    <div id="xray-result-group" class="mb-3 d-none">
+                        <label class="form-label fw-semibold d-block">Kết quả Xray</label>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" type="radio" name="xray-result" id="xray-ok" value="OK">
+                            <label class="form-check-label" for="xray-ok">OK</label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" type="radio" name="xray-result" id="xray-ng" value="NG">
+                            <label class="form-check-label" for="xray-ng">NG</label>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="sn-input" class="form-label fw-semibold">Danh sách SN</label>
+                        <textarea id="sn-input" class="form-control" rows="6" placeholder="Nhập mỗi SN trên một dòng hoặc tách bằng dấu phẩy"></textarea>
+                        <div class="form-text">Trạng thái hiện tại của từng SN sẽ hiển thị ở bảng bên dưới.</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="remark-input" class="form-label fw-semibold">Remark</label>
+                        <input id="remark-input" type="text" class="form-control" maxlength="50" placeholder="Nhập remark (tối đa 50 ký tự)">
+                    </div>
+
+                    <div class="d-grid gap-2">
+                        <button id="update-status-btn" class="btn btn-primary">Xác nhận trạng thái</button>
+                        <div id="update-status-feedback" class="alert mt-3 d-none" role="alert"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-lg-5 col-xxl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-light d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">Trạng thái hiện tại của SN</h5>
+                    <span class="badge bg-secondary" id="preview-total">0 SN</span>
+                </div>
+                <div class="card-body">
+                    <div id="status-preview-feedback" class="alert d-none" role="alert"></div>
+                    <div class="table-responsive" style="max-height: 420px; overflow-y: auto;">
+                        <table class="table table-hover align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>#</th>
+                                    <th>SN</th>
+                                    <th>Trạng thái</th>
+                                    <th>Remark</th>
+                                </tr>
+                            </thead>
+                            <tbody id="status-preview-body">
+                                <tr class="text-muted">
+                                    <td colspan="4" class="text-center">Nhập SN để xem trạng thái hiện tại.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+@section Scripts {
+    <script src="~/assets/Areas/BGA/js/actions.js"></script>
+}

--- a/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
@@ -1,0 +1,47 @@
+@{
+    ViewData["Title"] = "Dashboard Replace BGA";
+    Layout = "~/Areas/BGA/Views/Shared/layout_bga.cshtml";
+}
+
+<section class="container-fluid py-4">
+    <div class="row mb-4">
+        <div class="col-12 d-flex flex-wrap align-items-center justify-content-between gap-2">
+            <div>
+                <h1 class="fw-bold text-primary mb-1">Dashboard Replace BGA</h1>
+                <p class="text-muted mb-0">Theo dõi số lượng theo ApplyScrapStatus và thời gian Barking.</p>
+            </div>
+            <div class="d-flex align-items-center gap-3">
+                <small class="text-muted">Cập nhật lần cuối: <span id="dashboard-last-updated">Chưa tải</span></small>
+                <button id="refresh-dashboard-btn" class="btn btn-outline-primary btn-sm"><i class="fas fa-sync-alt me-1"></i>Refresh</button>
+            </div>
+        </div>
+    </div>
+    <div class="row g-4">
+        <div class="col-12 col-lg-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-gradient text-white">
+                    <h5 class="mb-0">Số lượng theo ApplyScrapStatus</h5>
+                </div>
+                <div class="card-body">
+                    <div id="status-chart-empty" class="alert alert-info d-none" role="alert"></div>
+                    <canvas id="status-chart" height="220" class="d-none"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-gradient text-white">
+                    <h5 class="mb-0">Thời gian Barking (ApplyScrapStatus = 11)</h5>
+                </div>
+                <div class="card-body">
+                    <div id="barking-age-empty" class="alert alert-info d-none" role="alert"></div>
+                    <canvas id="barking-age-chart" height="220" class="d-none"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+@section Scripts {
+    <script src="~/assets/Areas/BGA/js/dashboard.js"></script>
+}

--- a/PESystem/Areas/BGA/Views/Home/Process.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Process.cshtml
@@ -1,0 +1,62 @@
+@{
+    ViewData["Title"] = "Replace BGA process";
+    Layout = "~/Areas/BGA/Views/Shared/layout_bga.cshtml";
+}
+
+<section class="container-fluid py-4">
+    <div class="row mb-4">
+        <div class="col-12">
+            <h1 class="fw-bold text-primary mb-1">Replace BGA process</h1>
+            <p class="text-muted mb-0">Tài liệu và luồng kiểm soát Replace BGA.</p>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-12 col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Tài liệu quy trình (PDF)</h5>
+                </div>
+                <div class="card-body">
+                    <div class="ratio ratio-4x3 border rounded overflow-hidden">
+                        <iframe src="~/pdfs/product-lines/replace-BGA-process.pdf" title="Replace BGA process" allowfullscreen></iframe>
+                    </div>
+                    <p class="text-muted small mt-3 mb-0">Nếu tài liệu không hiển thị, hãy <a href="~/pdfs/product-lines/replace-BGA-process.pdf" target="_blank">mở trong tab mới</a>.</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Luồng trạng thái Replace BGA</h5>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-striped align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Stt</th>
+                                    <th scope="col">Bước</th>
+                                    <th scope="col">ApplyScrapStatus</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr><td>1</td><td>Waiting approve replace BGA</td><td>4</td></tr>
+                                <tr><td>2</td><td>Check in barking</td><td>10</td></tr>
+                                <tr><td>3</td><td>Check out barking</td><td>11</td></tr>
+                                <tr><td>4</td><td>VI after barking</td><td>12</td></tr>
+                                <tr><td>5</td><td>Remove BGA, clean pad</td><td>13</td></tr>
+                                <tr><td>6</td><td>Check VI BGA pad</td><td>14</td></tr>
+                                <tr><td>7</td><td>Replace BGA</td><td>15</td></tr>
+                                <tr><td>8</td><td>Xray</td><td>16</td></tr>
+                                <tr><td>9</td><td>ICT, FT</td><td>17</td></tr>
+                                <tr><td>10</td><td>Replaced BGA ok</td><td>3</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="text-muted mt-3 mb-0">Ở trạng thái 16 (Xray), nếu kết quả OK hệ thống chuyển sang trạng thái 17, nếu NG quay lại trạng thái 13. Mỗi lần xác nhận, người dùng nhập remark lưu vào <strong>FindBoardStatus</strong>.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/PESystem/Areas/BGA/Views/Home/Search.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Search.cshtml
@@ -1,0 +1,53 @@
+@{
+    ViewData["Title"] = "Tra cứu SN";
+    Layout = "~/Areas/BGA/Views/Shared/layout_bga.cshtml";
+}
+
+<section class="container-fluid py-4">
+    <div class="row mb-4">
+        <div class="col-12">
+            <h1 class="fw-bold text-primary mb-1">Tra cứu trạng thái theo SN</h1>
+            <p class="text-muted mb-0">Nhập danh sách SN để xem trạng thái hiện tại hoặc lịch sử.</p>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-12 col-lg-5 col-xxl-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-gradient text-white">
+                    <h5 class="mb-0">Danh sách SN</h5>
+                </div>
+                <div class="card-body">
+                    <div class="mb-3">
+                        <label for="lookup-sn-input" class="form-label fw-semibold">SN (mỗi dòng một mã hoặc tách bằng dấu phẩy)</label>
+                        <textarea id="lookup-sn-input" class="form-control" rows="10" placeholder="Ví dụ:\nSN001\nSN002\nSN003"></textarea>
+                    </div>
+                    <div class="d-grid gap-2">
+                        <button id="search-current-btn" class="btn btn-primary">Tra cứu trạng thái hiện tại</button>
+                        <button id="search-history-btn" class="btn btn-outline-primary">Tra cứu lịch sử</button>
+                        <button id="clear-lookup-btn" class="btn btn-outline-secondary">Xóa danh sách</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-7 col-xxl-8">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-light d-flex align-items-center justify-content-between">
+                    <div>
+                        <h5 id="lookup-title" class="mb-0">Kết quả tra cứu</h5>
+                        <small id="lookup-subtitle" class="text-muted">Chưa có dữ liệu.</small>
+                    </div>
+                    <button id="download-result-btn" class="btn btn-sm btn-outline-success" disabled><i class="fas fa-file-excel me-1"></i>Tải Excel</button>
+                </div>
+                <div class="card-body">
+                    <div id="lookup-feedback" class="alert d-none" role="alert"></div>
+                    <div id="lookup-result" class="table-responsive" style="max-height: 480px; overflow-y: auto;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+@section Scripts {
+    <script src="~/assets/Areas/BGA/js/search.js"></script>
+}

--- a/PESystem/Areas/BGA/Views/Shared/layout_bga.cshtml
+++ b/PESystem/Areas/BGA/Views/Shared/layout_bga.cshtml
@@ -1,0 +1,145 @@
+@using PESystem.Helpers
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Replace BGA control</title>
+    <link rel="icon" href="~/assets/img/bga.png" type="image/png">
+    <link rel="stylesheet" href="~/css/site.css?v=@DateTime.Now.Ticks" asp-append-version="true" />
+    <link href="~/lib/all-fa-icon/css/all.min.css" rel="stylesheet" />
+    <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="~/lib/datatable/style.css" rel="stylesheet" />
+    <link href="~/lib/datatable/jquery.datatables.min.css" rel="stylesheet" />
+    <script src="~/lib/gsap-particles/particles.min.js"></script>
+    <script src="~/lib/gsap-particles/gsap.min.js"></script>
+</head>
+<body>
+    <script>
+        (function () {
+            const isSidebarFixed = localStorage.getItem('isSidebarFixed') === 'true';
+            if (isSidebarFixed) {
+                document.documentElement.classList.add('sidebar-expanded');
+                document.write(`
+                    <style>
+                        #sidebar { width: 260px; }
+                        #sidebar .nav-link span, #sidebar .dashboard-container span { opacity: 1; }
+                        #mainContent { margin-left: 260px; }
+                        .header { left: 260px; width: calc(100% - 260px); }
+                    </style>
+                `);
+            } else {
+                document.documentElement.classList.remove('sidebar-expanded');
+                document.write(`
+                    <style>
+                        #sidebar { width: 70px; }
+                        #sidebar .nav-link span, #sidebar .dashboard-container span { opacity: 0; }
+                        #mainContent { margin-left: 70px; }
+                        .header { left: 70px; width: calc(100% - 70px); }
+                    </style>
+                `);
+            }
+        })();
+    </script>
+    <header class="header d-flex justify-content-between align-items-center" id="header">
+        <div class="d-flex align-items-center">
+            <span class="input-group-text bg-transparent border-0" onclick="toggleSearch()">
+                <i class="fas" style="cursor: pointer;"></i>
+            </span>
+            <div class="search-container" id="searchContainer">
+                <input type="text" class="form-control" placeholder="Search...">
+            </div>
+        </div>
+        <ul class="d-flex align-items-center">
+            @if (User.Identity?.IsAuthenticated ?? false)
+            {
+                <li class="nav-item dropdown">
+                    <a class="nav-link d-flex align-items-center avatar-link" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <img src="~/assets/img/avatar.png" class="user-avatar" alt="User" style="width: 40px; height: 40px;">
+                        <span class="d-none d-md-block ps-2">@User.Identity?.Name</span>
+                    </a>
+                </li>
+            }
+        </ul>
+    </header>
+
+    <div id="sidebar" class="sidebar">
+        <div class="dashboard-container">
+            <a href="@Url.Action("Home", "Home", new { area = "" })">
+                <img src="~/assets/img/bga.png" style="width:48px; height:48px;" class="logo" />
+            </a>
+            <span class="spanTitle" style="font-size: 1rem; font-weight: bold;">Replace BGA</span>
+            <span><input type="checkbox" id="toggleSidebarFixed" title="Giữ cố định" /></span>
+        </div>
+        <nav class="nav flex-column">
+            <!-- Menu Items -->
+            <a href="@Url.Action("Home", "Home", new { area = "" })" class="nav-link"><i class="fas fa-home"></i> <span>Trang chủ</span></a>
+            <div class="mt-3">
+                <span class="text-uppercase small fw-bold text-muted px-3">Phần 1</span>
+                <a href="@Url.Action("Process", "Home", new { area = "BGA" })" class="nav-link"><i class="fas fa-diagram-project"></i> <span>Replace BGA process</span></a>
+            </div>
+            <div class="mt-3">
+                <span class="text-uppercase small fw-bold text-muted px-3">Phần 2</span>
+                <a href="@Url.Action("Dashboard", "Home", new { area = "BGA" })" class="nav-link"><i class="fas fa-chart-pie"></i> <span>Dashboard</span></a>
+            </div>
+            <div class="mt-3">
+                <span class="text-uppercase small fw-bold text-muted px-3">Phần 3</span>
+                <a href="@Url.Action("Actions", "Home", new { area = "BGA" })" class="nav-link"><i class="fas fa-tasks"></i> <span>Thao tác trạng thái</span></a>
+            </div>
+            <div class="mt-3">
+                <span class="text-uppercase small fw-bold text-muted px-3">Phần 4</span>
+                <a href="@Url.Action("Search", "Home", new { area = "BGA" })" class="nav-link"><i class="fas fa-search"></i> <span>Tra cứu theo SN</span></a>
+            </div>
+        </nav>
+    </div>
+
+    <script>
+        const sidebar = document.getElementById("sidebar");
+        sidebar?.addEventListener("click", () => {
+            sidebar.classList.toggle("open");
+        });
+
+        document.addEventListener("DOMContentLoaded", function () {
+            let toggleSidebarFixed = document.getElementById("toggleSidebarFixed");
+
+            if (localStorage.getItem("sidebarState") === "expanded") {
+                sidebar?.classList.add("open");
+                if (toggleSidebarFixed) {
+                    toggleSidebarFixed.checked = true;
+                }
+            } else {
+                sidebar?.classList.remove("open");
+                if (toggleSidebarFixed) {
+                    toggleSidebarFixed.checked = false;
+                }
+            }
+
+            toggleSidebarFixed?.addEventListener("change", function () {
+                if (this.checked) {
+                    sidebar?.classList.add("open");
+                    localStorage.setItem("sidebarState", "expanded");
+                } else {
+                    sidebar?.classList.remove("open");
+                    localStorage.setItem("sidebarState", "collapsed");
+                }
+            });
+        });
+    </script>
+
+    <main id="mainContent">
+        <div id="spinner-overlay">
+            <span class="loader"></span>
+        </div>
+        @RenderBody()
+    </main>
+
+    <script src="~/lib/jquery/dist/jquery.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/lib/sweetalert2/dist/sweetalert2.all.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="~/lib/jquery.datatables.min.js"></script>
+    <script src="~/lib/excel/xlsx.full.min.js"></script>
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/PESystem/Views/Home/Home.cshtml
+++ b/PESystem/Views/Home/Home.cshtml
@@ -137,8 +137,9 @@
                 </div>
             </a>
         </div>
+        <!-- Replace BGA control -->
         <div class="col-6 col-md-4 col-lg-2">
-            <a href="@Url.Action("Index", "Home", new { area = "BGA" })" class="text-decoration-none">
+            <a href="@Url.Action("Process", "Home", new { area = "BGA" })" class="text-decoration-none">
                 <div class="card shadow-sm text-center custom-card">
                     <div class="d-flex flex-column justify-content-center align-items-center h-100">
                         <img src="~/assets/img/bga.png" class="logo mb-2" />

--- a/PESystem/wwwroot/assets/Areas/BGA/js/actions.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/actions.js
@@ -1,0 +1,216 @@
+const API_BASE_URL = "/api/bga-replace";
+const STATUS_MAP = {
+    3: "Replaced BGA ok",
+    4: "Waiting approve replace BGA",
+    10: "Check in barking",
+    11: "Check out barking",
+    12: "VI after barking",
+    13: "Remove BGA, clean pad",
+    14: "Check VI BGA pad",
+    15: "Replace BGA",
+    16: "Xray",
+    17: "ICT, FT"
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+    const currentStatusSelect = document.getElementById("current-status");
+    const snInput = document.getElementById("sn-input");
+    const remarkInput = document.getElementById("remark-input");
+    const updateButton = document.getElementById("update-status-btn");
+    const updateFeedback = document.getElementById("update-status-feedback");
+    const xrayGroup = document.getElementById("xray-result-group");
+    const previewBody = document.getElementById("status-preview-body");
+    const previewFeedback = document.getElementById("status-preview-feedback");
+    const previewTotal = document.getElementById("preview-total");
+
+    if (!currentStatusSelect || !snInput || !updateButton) {
+        return;
+    }
+
+    let debounceTimer = null;
+
+    const setButtonLoading = (button, isLoading, loadingText) => {
+        if (!button) {
+            return;
+        }
+        if (isLoading) {
+            button.disabled = true;
+            button.dataset.originalText = button.dataset.originalText || button.innerHTML;
+            button.innerHTML = loadingText || '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Đang xử lý...';
+        } else {
+            button.disabled = false;
+            const original = button.dataset.originalText;
+            if (original) {
+                button.innerHTML = original;
+            }
+        }
+    };
+
+    const toggleXrayGroup = () => {
+        if (parseInt(currentStatusSelect.value, 10) === 16) {
+            xrayGroup?.classList.remove("d-none");
+        } else {
+            xrayGroup?.classList.add("d-none");
+            document.querySelectorAll('input[name="xray-result"]').forEach(radio => radio.checked = false);
+        }
+    };
+
+    const parseSNs = (raw) => {
+        return raw
+            .split(/[\s,;]+/)
+            .map(item => item.trim())
+            .filter(item => item.length);
+    };
+
+    const showUpdateFeedback = (message, isSuccess) => {
+        updateFeedback.textContent = message;
+        updateFeedback.classList.remove("d-none");
+        updateFeedback.classList.toggle("alert-success", isSuccess);
+        updateFeedback.classList.toggle("alert-danger", !isSuccess);
+    };
+
+    const resetPreview = (message) => {
+        previewFeedback?.classList.add("d-none");
+        previewFeedback?.classList.remove("alert-danger", "alert-warning", "alert-info");
+        previewBody.innerHTML = `<tr class="text-muted"><td colspan="4" class="text-center">${message}</td></tr>`;
+        if (previewTotal) {
+            previewTotal.textContent = "0 SN";
+        }
+    };
+
+    const renderPreview = (items) => {
+        if (!Array.isArray(items) || !items.length) {
+            resetPreview("Không có SN hợp lệ.");
+            return;
+        }
+
+        const rows = items.map((item, index) => {
+            const statusName = item.statusName ?? STATUS_MAP[item.applyTaskStatus] ?? item.applyTaskStatus ?? "N/A";
+            const remark = item.findBoardStatus ?? "";
+            const statusClass = item.isValid === false ? "text-danger" : "";
+            return `
+                <tr class="${statusClass}">
+                    <td>${index + 1}</td>
+                    <td>${item.sn ?? ""}</td>
+                    <td>${statusName}</td>
+                    <td>${remark}</td>
+                </tr>
+            `;
+        }).join("");
+
+        previewBody.innerHTML = rows;
+        if (previewTotal) {
+            previewTotal.textContent = `${items.length} SN`;
+        }
+    };
+
+    const fetchPreview = async () => {
+        const sns = parseSNs(snInput.value);
+        if (!sns.length) {
+            resetPreview("Nhập SN để xem trạng thái hiện tại.");
+            return;
+        }
+
+        previewBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted">Đang tải...</td></tr>`;
+        previewFeedback?.classList.add("d-none");
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/status/bulk`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ sns })
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || "Không thể tra cứu trạng thái.");
+            }
+            renderPreview(data);
+        } catch (error) {
+            previewBody.innerHTML = `<tr><td colspan="4" class="text-center text-danger">${error.message}</td></tr>`;
+            if (previewFeedback) {
+                previewFeedback.textContent = error.message;
+                previewFeedback.classList.remove("d-none");
+                previewFeedback.classList.add("alert-danger");
+            }
+        }
+    };
+
+    const debouncePreview = () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(fetchPreview, 500);
+    };
+
+    snInput.addEventListener("input", debouncePreview);
+    toggleXrayGroup();
+    currentStatusSelect.addEventListener("change", toggleXrayGroup);
+
+    updateButton.addEventListener("click", async () => {
+        const snRaw = snInput.value;
+        const remark = (remarkInput?.value || "").trim();
+        const currentStatus = parseInt(currentStatusSelect.value, 10);
+
+        updateFeedback.classList.add("d-none");
+        updateFeedback.textContent = "";
+        updateFeedback.classList.remove("alert-success", "alert-danger");
+
+        const sns = parseSNs(snRaw);
+        if (!sns.length) {
+            showUpdateFeedback("Vui lòng nhập ít nhất một SN.", false);
+            return;
+        }
+
+        if (!remark) {
+            showUpdateFeedback("Remark không được để trống.", false);
+            return;
+        }
+
+        if (remark.length > 50) {
+            showUpdateFeedback("Remark tối đa 50 ký tự.", false);
+            return;
+        }
+
+        const payload = {
+            sns,
+            currentStatus,
+            remark
+        };
+
+        if (currentStatus === 16) {
+            const xraySelection = document.querySelector('input[name="xray-result"]:checked');
+            if (!xraySelection) {
+                showUpdateFeedback("Vui lòng chọn kết quả Xray.", false);
+                return;
+            }
+            payload.xrayResult = xraySelection.value;
+        }
+
+        try {
+            setButtonLoading(updateButton, true);
+            const response = await fetch(`${API_BASE_URL}/update-status`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload)
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                const message = data.message || "Cập nhật trạng thái thất bại.";
+                if (Array.isArray(data.details) && data.details.length) {
+                    showUpdateFeedback(`${message} ${data.details.join("; ")}`, false);
+                } else {
+                    showUpdateFeedback(message, false);
+                }
+                return;
+            }
+
+            showUpdateFeedback(data.message || "Cập nhật thành công.", true);
+            remarkInput.value = "";
+            snInput.value = "";
+            document.querySelectorAll('input[name="xray-result"]').forEach(radio => radio.checked = false);
+            resetPreview("Nhập SN để xem trạng thái hiện tại.");
+        } catch (error) {
+            showUpdateFeedback(error.message || "Đã xảy ra lỗi khi cập nhật.", false);
+        } finally {
+            setButtonLoading(updateButton, false);
+        }
+    });
+});

--- a/PESystem/wwwroot/assets/Areas/BGA/js/dashboard.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/dashboard.js
@@ -1,0 +1,313 @@
+const API_BASE_URL = "/api/bga-replace";
+const STATUS_TEXT = {
+    3: "Replaced BGA ok",
+    4: "Waiting approve replace BGA",
+    10: "Check in barking",
+    11: "Check out barking",
+    12: "VI after barking",
+    13: "Remove BGA, clean pad",
+    14: "Check VI BGA pad",
+    15: "Replace BGA",
+    16: "Xray",
+    17: "ICT, FT"
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+    const statusChartCanvas = document.getElementById("status-chart");
+    const statusChartEmpty = document.getElementById("status-chart-empty");
+    const barkingChartCanvas = document.getElementById("barking-age-chart");
+    const barkingChartEmpty = document.getElementById("barking-age-empty");
+    const dashboardLastUpdated = document.getElementById("dashboard-last-updated");
+    const refreshDashboardButton = document.getElementById("refresh-dashboard-btn");
+
+    if (!statusChartCanvas || !statusChartEmpty || !barkingChartCanvas || !barkingChartEmpty) {
+        return;
+    }
+
+    let statusChartInstance = null;
+    let barkingChartInstance = null;
+
+    const setButtonLoading = (button, isLoading, loadingText) => {
+        if (!button) {
+            return;
+        }
+        if (isLoading) {
+            button.disabled = true;
+            button.dataset.originalText = button.dataset.originalText || button.innerHTML;
+            button.innerHTML = loadingText || '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Đang tải...';
+        } else {
+            button.disabled = false;
+            const original = button.dataset.originalText;
+            if (original) {
+                button.innerHTML = original;
+            }
+        }
+    };
+
+    const showStatusLoading = () => {
+        statusChartEmpty.textContent = "Đang tải dữ liệu...";
+        statusChartEmpty.classList.remove("d-none", "alert-danger");
+        statusChartEmpty.classList.add("alert-info");
+        statusChartCanvas.classList.add("d-none");
+    };
+
+    const showBarkingLoading = () => {
+        barkingChartEmpty.textContent = "Đang tải dữ liệu...";
+        barkingChartEmpty.classList.remove("d-none", "alert-danger");
+        barkingChartEmpty.classList.add("alert-info");
+        barkingChartCanvas.classList.add("d-none");
+    };
+
+    const renderStatusChart = (data, errorMessage) => {
+        if (errorMessage) {
+            statusChartEmpty.textContent = errorMessage;
+            statusChartEmpty.classList.remove("alert-info");
+            statusChartEmpty.classList.add("alert-danger");
+            statusChartEmpty.classList.remove("d-none");
+            statusChartCanvas.classList.add("d-none");
+            if (statusChartInstance) {
+                statusChartInstance.destroy();
+                statusChartInstance = null;
+            }
+            return;
+        }
+
+        if (!data.length) {
+            statusChartEmpty.textContent = "Không có dữ liệu để hiển thị.";
+            statusChartEmpty.classList.remove("alert-danger");
+            statusChartEmpty.classList.add("alert-info");
+            statusChartEmpty.classList.remove("d-none");
+            statusChartCanvas.classList.add("d-none");
+            if (statusChartInstance) {
+                statusChartInstance.destroy();
+                statusChartInstance = null;
+            }
+            return;
+        }
+
+        const labels = data.map(item => `${item.status} - ${item.statusName ?? STATUS_TEXT[item.status] ?? item.status}`);
+        const values = data.map(item => item.count ?? 0);
+
+        if (statusChartInstance) {
+            statusChartInstance.destroy();
+        }
+
+        statusChartInstance = new Chart(statusChartCanvas, {
+            type: "bar",
+            data: {
+                labels,
+                datasets: [{
+                    label: "Số lượng SN",
+                    data: values,
+                    backgroundColor: "rgba(54, 162, 235, 0.6)",
+                    borderColor: "rgba(54, 162, 235, 1)",
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: context => `${context.parsed.y ?? context.parsed} SN`
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        ticks: {
+                            autoSkip: false,
+                            maxRotation: 45,
+                            minRotation: 0
+                        }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: "Số lượng"
+                        }
+                    }
+                }
+            }
+        });
+
+        statusChartCanvas.classList.remove("d-none");
+        statusChartEmpty.classList.add("d-none");
+    };
+
+    const renderBarkingChart = (data, errorMessage) => {
+        if (errorMessage) {
+            barkingChartEmpty.textContent = errorMessage;
+            barkingChartEmpty.classList.remove("alert-info");
+            barkingChartEmpty.classList.add("alert-danger");
+            barkingChartEmpty.classList.remove("d-none");
+            barkingChartCanvas.classList.add("d-none");
+            if (barkingChartInstance) {
+                barkingChartInstance.destroy();
+                barkingChartInstance = null;
+            }
+            return;
+        }
+
+        if (!data.length) {
+            barkingChartEmpty.textContent = "Không có SN nào ở trạng thái 11.";
+            barkingChartEmpty.classList.remove("alert-danger");
+            barkingChartEmpty.classList.add("alert-info");
+            barkingChartEmpty.classList.remove("d-none");
+            barkingChartCanvas.classList.add("d-none");
+            if (barkingChartInstance) {
+                barkingChartInstance.destroy();
+                barkingChartInstance = null;
+            }
+            return;
+        }
+
+        const validData = data.filter(item => typeof item.hours === "number" && !Number.isNaN(item.hours));
+        const missingCount = data.length - validData.length;
+
+        if (!validData.length) {
+            barkingChartEmpty.textContent = missingCount > 0
+                ? "Không có dữ liệu giờ hợp lệ cho trạng thái 11. (Một số bản ghi thiếu Apply Time)"
+                : "Không có dữ liệu giờ hợp lệ cho trạng thái 11.";
+            barkingChartEmpty.classList.remove("alert-danger");
+            barkingChartEmpty.classList.add("alert-info");
+            barkingChartEmpty.classList.remove("d-none");
+            barkingChartCanvas.classList.add("d-none");
+            if (barkingChartInstance) {
+                barkingChartInstance.destroy();
+                barkingChartInstance = null;
+            }
+            return;
+        }
+
+        const labels = validData.map(item => item.sn ?? "");
+        const values = validData.map(item => item.hours ?? 0);
+        const tooltips = validData.map(item => {
+            const applyTime = item.applyTime ? new Date(item.applyTime).toLocaleString() : "Không xác định";
+            const hours = item.hours ?? 0;
+            return `SN: ${item.sn}\nApply time: ${applyTime}\nSố giờ: ${Math.round(hours * 10) / 10}`;
+        });
+
+        if (missingCount > 0) {
+            barkingChartEmpty.textContent = `${missingCount} SN không có Apply Time hợp lệ.`;
+            barkingChartEmpty.classList.remove("d-none", "alert-danger", "alert-info");
+            barkingChartEmpty.classList.add("alert-warning");
+        } else {
+            barkingChartEmpty.classList.add("d-none");
+            barkingChartEmpty.classList.remove("alert-warning", "alert-danger");
+            if (!barkingChartEmpty.classList.contains("alert-info")) {
+                barkingChartEmpty.classList.add("alert-info");
+            }
+        }
+
+        if (barkingChartInstance) {
+            barkingChartInstance.destroy();
+        }
+
+        barkingChartInstance = new Chart(barkingChartCanvas, {
+            type: "bar",
+            data: {
+                labels,
+                datasets: [{
+                    label: "Số giờ kể từ khi Barking",
+                    data: values,
+                    backgroundColor: "rgba(255, 159, 64, 0.6)",
+                    borderColor: "rgba(255, 159, 64, 1)",
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                indexAxis: "y",
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: "Số giờ"
+                        }
+                    },
+                    y: {
+                        ticks: { autoSkip: false }
+                    }
+                },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: context => tooltips[context.dataIndex]
+                        }
+                    }
+                }
+            }
+        });
+
+        barkingChartCanvas.classList.remove("d-none");
+        if (!barkingChartEmpty.classList.contains("alert-warning")) {
+            barkingChartEmpty.classList.add("d-none");
+        }
+    };
+
+    const loadStatusSummary = async () => {
+        try {
+            const response = await fetch(`${API_BASE_URL}/dashboard/status-summary`);
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || "Không thể tải biểu đồ trạng thái.");
+            }
+            if (!Array.isArray(data)) {
+                throw new Error("Dữ liệu trả về không hợp lệ.");
+            }
+            renderStatusChart(data);
+            return true;
+        } catch (error) {
+            renderStatusChart([], error.message);
+            return false;
+        }
+    };
+
+    const loadBarkingAging = async () => {
+        try {
+            const response = await fetch(`${API_BASE_URL}/dashboard/barking-aging`);
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || "Không thể tải dữ liệu Barking.");
+            }
+            if (!Array.isArray(data)) {
+                throw new Error("Dữ liệu trả về không hợp lệ.");
+            }
+            renderBarkingChart(data);
+            return true;
+        } catch (error) {
+            renderBarkingChart([], error.message);
+            return false;
+        }
+    };
+
+    const refreshDashboard = async () => {
+        showStatusLoading();
+        showBarkingLoading();
+
+        const [statusSuccess, barkingSuccess] = await Promise.all([
+            loadStatusSummary(),
+            loadBarkingAging()
+        ]);
+
+        if (dashboardLastUpdated) {
+            const suffix = (!statusSuccess || !barkingSuccess) ? " (có lỗi)" : "";
+            dashboardLastUpdated.textContent = `${new Date().toLocaleString()}${suffix}`;
+        }
+    };
+
+    refreshDashboardButton?.addEventListener("click", async () => {
+        setButtonLoading(refreshDashboardButton, true, "Đang tải...");
+        await refreshDashboard();
+        setButtonLoading(refreshDashboardButton, false);
+    });
+
+    refreshDashboard();
+});

--- a/PESystem/wwwroot/assets/Areas/BGA/js/search.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/search.js
@@ -1,0 +1,310 @@
+const API_BASE_URL = "/api/bga-replace";
+const STATUS_LABELS = {
+    3: "Replaced BGA ok",
+    4: "Waiting approve replace BGA",
+    10: "Check in barking",
+    11: "Check out barking",
+    12: "VI after barking",
+    13: "Remove BGA, clean pad",
+    14: "Check VI BGA pad",
+    15: "Replace BGA",
+    16: "Xray",
+    17: "ICT, FT"
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+    const snInput = document.getElementById("lookup-sn-input");
+    const searchCurrentBtn = document.getElementById("search-current-btn");
+    const searchHistoryBtn = document.getElementById("search-history-btn");
+    const clearBtn = document.getElementById("clear-lookup-btn");
+    const feedback = document.getElementById("lookup-feedback");
+    const resultContainer = document.getElementById("lookup-result");
+    const downloadBtn = document.getElementById("download-result-btn");
+    const title = document.getElementById("lookup-title");
+    const subtitle = document.getElementById("lookup-subtitle");
+
+    if (!snInput || !searchCurrentBtn || !searchHistoryBtn || !resultContainer) {
+        return;
+    }
+
+    let lastExportData = [];
+    let lastExportSheet = "TraCuu";
+
+    const parseSNs = (raw) => raw
+        .split(/[\s,;]+/)
+        .map(item => item.trim())
+        .filter(item => item.length);
+
+    const setFeedback = (message, type) => {
+        if (!feedback) {
+            return;
+        }
+        if (!message) {
+            feedback.classList.add("d-none");
+            feedback.textContent = "";
+            feedback.classList.remove("alert-danger", "alert-success", "alert-warning", "alert-info");
+            return;
+        }
+        feedback.textContent = message;
+        feedback.classList.remove("d-none", "alert-danger", "alert-success", "alert-warning", "alert-info");
+        feedback.classList.add(`alert-${type}`);
+    };
+
+    const setSubtitle = (text) => {
+        if (subtitle) {
+            subtitle.textContent = text;
+        }
+    };
+
+    const setTitle = (text) => {
+        if (title) {
+            title.textContent = text;
+        }
+    };
+
+    const disableDownload = () => {
+        if (downloadBtn) {
+            downloadBtn.disabled = true;
+        }
+        lastExportData = [];
+    };
+
+    const renderCurrentTable = (items) => {
+        if (!Array.isArray(items) || !items.length) {
+            resultContainer.innerHTML = "<p class=\"text-muted\">Không có dữ liệu.</p>";
+            setSubtitle("Không có dữ liệu.");
+            disableDownload();
+            return;
+        }
+
+        const rows = items.map((item, index) => {
+            if (item.isValid === false) {
+                return `
+                    <tr class="table-danger">
+                        <td>${index + 1}</td>
+                        <td>${item.sn ?? ""}</td>
+                        <td colspan="6">${item.message || "Không tìm thấy dữ liệu."}</td>
+                    </tr>
+                `;
+            }
+
+            const statusName = item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "";
+            const applyTime = item.applyTime ? new Date(item.applyTime).toLocaleString() : "";
+            return `
+                <tr>
+                    <td>${index + 1}</td>
+                    <td>${item.sn ?? ""}</td>
+                    <td>${statusName}</td>
+                    <td>${item.findBoardStatus ?? ""}</td>
+                    <td>${item.approveScrapperson ?? ""}</td>
+                    <td>${applyTime}</td>
+                    <td>${item.taskNumber ?? ""}</td>
+                    <td>${item.internalTask ?? ""}</td>
+                    <td>${item.desc ?? ""}</td>
+                </tr>
+            `;
+        }).join("");
+
+        resultContainer.innerHTML = `
+            <table class="table table-bordered table-hover align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th>#</th>
+                        <th>SN</th>
+                        <th>Trạng thái</th>
+                        <th>Remark</th>
+                        <th>Approve</th>
+                        <th>Apply Time</th>
+                        <th>Task Number</th>
+                        <th>Internal Task</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+
+        setSubtitle(`${items.length} dòng dữ liệu.`);
+
+        lastExportData = items.map((item, index) => ({
+            STT: index + 1,
+            SN: item.sn ?? "",
+            TrangThai: item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "",
+            Remark: item.findBoardStatus ?? "",
+            Approve: item.approveScrapperson ?? "",
+            ApplyTime: item.applyTime ? new Date(item.applyTime).toLocaleString() : "",
+            TaskNumber: item.taskNumber ?? "",
+            InternalTask: item.internalTask ?? "",
+            Description: item.desc ?? "",
+            GhiChu: item.message ?? ""
+        }));
+
+        lastExportSheet = "TrangThaiHienTai";
+        if (downloadBtn) {
+            downloadBtn.disabled = false;
+        }
+    };
+
+    const renderHistoryTable = (items) => {
+        if (!Array.isArray(items) || !items.length) {
+            resultContainer.innerHTML = "<p class=\"text-muted\">Không có lịch sử cho các SN đã nhập.</p>";
+            setSubtitle("Không có dữ liệu lịch sử.");
+            disableDownload();
+            return;
+        }
+
+        const rows = items.map((item, index) => {
+            const statusName = item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "";
+            const applyTime = item.applyTime ? new Date(item.applyTime).toLocaleString() : "";
+            const createTime = item.createTime ? new Date(item.createTime).toLocaleString() : "";
+            return `
+                <tr>
+                    <td>${index + 1}</td>
+                    <td>${item.sn ?? ""}</td>
+                    <td>${statusName}</td>
+                    <td>${item.findBoardStatus ?? ""}</td>
+                    <td>${item.approveScrapperson ?? ""}</td>
+                    <td>${applyTime}</td>
+                    <td>${createTime}</td>
+                    <td>${item.taskNumber ?? ""}</td>
+                    <td>${item.internalTask ?? ""}</td>
+                    <td>${item.desc ?? ""}</td>
+                </tr>
+            `;
+        }).join("");
+
+        resultContainer.innerHTML = `
+            <table class="table table-bordered table-hover align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th>#</th>
+                        <th>SN</th>
+                        <th>Trạng thái</th>
+                        <th>Remark</th>
+                        <th>Approve</th>
+                        <th>Apply Time</th>
+                        <th>Create Time</th>
+                        <th>Task Number</th>
+                        <th>Internal Task</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+
+        setSubtitle(`${items.length} dòng dữ liệu lịch sử.`);
+        lastExportData = items.map((item, index) => ({
+            STT: index + 1,
+            SN: item.sn ?? "",
+            TrangThai: item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "",
+            Remark: item.findBoardStatus ?? "",
+            Approve: item.approveScrapperson ?? "",
+            ApplyTime: item.applyTime ? new Date(item.applyTime).toLocaleString() : "",
+            CreateTime: item.createTime ? new Date(item.createTime).toLocaleString() : "",
+            TaskNumber: item.taskNumber ?? "",
+            InternalTask: item.internalTask ?? "",
+            Description: item.desc ?? ""
+        }));
+        lastExportSheet = "LichSu";
+        if (downloadBtn) {
+            downloadBtn.disabled = false;
+        }
+    };
+
+    const fetchCurrent = async (sns) => {
+        setTitle("Kết quả tra cứu trạng thái hiện tại");
+        resultContainer.innerHTML = "<p class=\"text-muted\">Đang tải dữ liệu...</p>";
+        setSubtitle("Đang tải...");
+        disableDownload();
+        setFeedback("", "info");
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/status/bulk`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ sns })
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || "Không thể tra cứu trạng thái.");
+            }
+            renderCurrentTable(data);
+        } catch (error) {
+            resultContainer.innerHTML = "";
+            setSubtitle("Có lỗi xảy ra.");
+            disableDownload();
+            setFeedback(error.message, "danger");
+        }
+    };
+
+    const fetchHistory = async (sns) => {
+        setTitle("Kết quả tra cứu lịch sử");
+        resultContainer.innerHTML = "<p class=\"text-muted\">Đang tải lịch sử...</p>";
+        setSubtitle("Đang tải...");
+        disableDownload();
+        setFeedback("", "info");
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/history`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ sns })
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || "Không thể tra cứu lịch sử.");
+            }
+            renderHistoryTable(data);
+        } catch (error) {
+            resultContainer.innerHTML = "";
+            setSubtitle("Có lỗi xảy ra.");
+            disableDownload();
+            setFeedback(error.message, "danger");
+        }
+    };
+
+    const handleSearch = (mode) => {
+        const sns = parseSNs(snInput.value);
+        if (!sns.length) {
+            setFeedback("Vui lòng nhập ít nhất một SN.", "warning");
+            resultContainer.innerHTML = "";
+            setSubtitle("Không có dữ liệu.");
+            disableDownload();
+            return;
+        }
+
+        setFeedback("", "info");
+        if (mode === "current") {
+            fetchCurrent(sns);
+        } else {
+            fetchHistory(sns);
+        }
+    };
+
+    searchCurrentBtn.addEventListener("click", () => handleSearch("current"));
+    searchHistoryBtn.addEventListener("click", () => handleSearch("history"));
+    clearBtn?.addEventListener("click", () => {
+        snInput.value = "";
+        resultContainer.innerHTML = "";
+        setFeedback("", "info");
+        setSubtitle("Chưa có dữ liệu.");
+        disableDownload();
+    });
+
+    downloadBtn?.addEventListener("click", () => {
+        if (!window.XLSX) {
+            setFeedback("Không thể tải Excel vì thiếu thư viện XLSX.", "warning");
+            return;
+        }
+        if (!lastExportData.length) {
+            setFeedback("Không có dữ liệu để tải xuống.", "warning");
+            return;
+        }
+
+        const worksheet = XLSX.utils.json_to_sheet(lastExportData);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, lastExportSheet);
+        XLSX.writeFile(workbook, `${lastExportSheet}-${new Date().toISOString().replace(/[:T]/g, "-").split(".")[0]}.xlsx`);
+    });
+});

--- a/PESystem/wwwroot/pdfs/product-lines/replace-BGA-process.pdf
+++ b/PESystem/wwwroot/pdfs/product-lines/replace-BGA-process.pdf
@@ -1,0 +1,39 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 83 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Replace BGA process flow) Tj
+/F1 14 Tf
+0 -40 Td
+(Tai lieu se duoc cap nhat.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000108 00000 n 
+0000000245 00000 n 
+0000000364 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+431
+%%EOF


### PR DESCRIPTION
## Summary
- move status name mapping out of EF Core projections in ReplaceBgaController
- add a shared helper for translating status codes to names before returning responses

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68e6611841b8832681eef2886928d24b