### PR TITLE
Enhance BGA dashboard and search with additional validations

### DIFF
--- a/API_WEB/Controllers/BGA/ReplaceBgaController.cs
+++ b/API_WEB/Controllers/BGA/ReplaceBgaController.cs
@@ -221,44 +221,46 @@ namespace API_WEB.Controllers.BGA
                 return BadRequest(new { message = "Danh sách SN không hợp lệ." });
             }
 
-            var scrapRecords = await _sqlContext.ScrapLists
-                .AsNoTracking()
-                .Where(s => normalizedSNs.Contains(s.SN))
-                .Select(s => new
-                {
-                    s.SN,
-                    s.TaskNumber,
-                    s.InternalTask,
-                    s.Desc,
-                    s.ApplyTaskStatus,
-                    s.FindBoardStatus,
-                    s.ApproveScrapperson,
-                    s.ApplyTime,
-                    s.CreateTime,
-                    s.Category
-                })
-                .ToListAsync();
+                var scrapRecords = await _sqlContext.ScrapLists
+                    .AsNoTracking()
+                    .Where(s => normalizedSNs.Contains(s.SN))
+                    .Select(s => new
+                    {
+                        s.SN,
+                        s.TaskNumber,
+                        s.InternalTask,
+                        s.Desc,
+                        s.ApplyTaskStatus,
+                        s.FindBoardStatus,
+                        s.ApproveScrapperson,
+                        s.ApplyTime,
+                        s.CreateTime,
+                        s.Category,
+                        s.Remark
+                    })
+                    .ToListAsync();
 
             var scrapLookup = scrapRecords
                 .GroupBy(s => s.SN, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
-            var historyRecords = await QueryBgaHistory()
-                .Where(h => normalizedSNs.Contains(h.SN))
-                .Select(h => new
-                {
-                    h.SN,
-                    h.TaskNumber,
-                    h.InternalTask,
-                    h.Desc,
-                    h.ApplyTaskStatus,
-                    h.FindBoardStatus,
-                    h.ApproveScrapperson,
-                    h.ApplyTime,
-                    h.CreateTime,
-                    h.Category
-                })
-                .ToListAsync();
+                var historyRecords = await QueryBgaHistory()
+                    .Where(h => normalizedSNs.Contains(h.SN))
+                    .Select(h => new
+                    {
+                        h.SN,
+                        h.TaskNumber,
+                        h.InternalTask,
+                        h.Desc,
+                        h.ApplyTaskStatus,
+                        h.FindBoardStatus,
+                        h.ApproveScrapperson,
+                        h.ApplyTime,
+                        h.CreateTime,
+                        h.Category,
+                        h.Remark
+                    })
+                    .ToListAsync();
 
             var historyLookup = historyRecords
                 .GroupBy(h => h.SN, StringComparer.OrdinalIgnoreCase)
@@ -304,6 +306,8 @@ namespace API_WEB.Controllers.BGA
                         record.ApproveScrapperson,
                         record.ApplyTime,
                         record.CreateTime,
+                        record.Category,
+                        record.Remark,
                         isValid,
                         message,
                         source = "Current"
@@ -329,6 +333,8 @@ namespace API_WEB.Controllers.BGA
                         history.ApproveScrapperson,
                         history.ApplyTime,
                         history.CreateTime,
+                        history.Category,
+                        history.Remark,
                         isValid = inBgaCategory,
                         message,
                         source = "History"
@@ -349,8 +355,11 @@ namespace API_WEB.Controllers.BGA
                     ApproveScrapperson = (string?)null,
                     ApplyTime = (DateTime?)null,
                     CreateTime = (DateTime?)null,
+                    Category = (string?)null,
+                    Remark = (string?)null,
                     isValid = false,
-                    message = "Không tìm thấy SN trong Replace BGA."
+                    message = "Không tìm thấy SN trong Replace BGA.",
+                    source = (string?)null
                 });
             }
 
@@ -380,7 +389,9 @@ namespace API_WEB.Controllers.BGA
                     h.FindBoardStatus,
                     h.ApproveScrapperson,
                     h.ApplyTime,
-                    h.CreateTime
+                    h.CreateTime,
+                    h.Category,
+                    h.Remark
                 })
                 .ToListAsync();
 
@@ -396,7 +407,9 @@ namespace API_WEB.Controllers.BGA
                     s.FindBoardStatus,
                     s.ApproveScrapperson,
                     s.ApplyTime,
-                    s.CreateTime
+                    s.CreateTime,
+                    s.Category,
+                    s.Remark
                 })
                 .ToListAsync();
 
@@ -413,6 +426,8 @@ namespace API_WEB.Controllers.BGA
                     history.ApproveScrapperson,
                     history.ApplyTime,
                     history.CreateTime,
+                    history.Category,
+                    history.Remark,
                     Source = "History"
                 })
                 .Concat(currentRecords.Select(record => new
@@ -427,6 +442,8 @@ namespace API_WEB.Controllers.BGA
                     record.ApproveScrapperson,
                     record.ApplyTime,
                     record.CreateTime,
+                    record.Category,
+                    record.Remark,
                     Source = "Current"
                 }))
                 .OrderBy(item => item.SN)

--- a/PESystem/Areas/BGA/Views/Home/Actions.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Actions.cshtml
@@ -79,7 +79,7 @@
                                     <th>#</th>
                                     <th>SN</th>
                                     <th>Trạng thái</th>
-                                    <th>Remark</th>
+                                    <th>Category</th>
                                 </tr>
                             </thead>
                             <tbody id="status-preview-body">

--- a/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
@@ -24,8 +24,9 @@
                 </div>
                 <div class="card-body">
                     <div id="status-chart-empty" class="alert alert-info d-none" role="alert"></div>
-                    <canvas id="status-chart" height="220" class="d-none"></canvas>
-                    <div id="status-chart-info" class="mt-3 d-none"></div>
+                    <div class="position-relative" style="height: 360px;">
+                        <canvas id="status-chart" class="d-none w-100 h-100"></canvas>
+                    </div>
                 </div>
             </div>
         </div>
@@ -36,7 +37,9 @@
                 </div>
                 <div class="card-body">
                     <div id="barking-age-empty" class="alert alert-info d-none" role="alert"></div>
-                    <canvas id="barking-age-chart" height="220" class="d-none"></canvas>
+                    <div class="position-relative" style="height: 360px;">
+                        <canvas id="barking-age-chart" class="d-none w-100 h-100"></canvas>
+                    </div>
                 </div>
             </div>
         </div>

--- a/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
@@ -25,6 +25,7 @@
                 <div class="card-body">
                     <div id="status-chart-empty" class="alert alert-info d-none" role="alert"></div>
                     <canvas id="status-chart" height="220" class="d-none"></canvas>
+                    <div id="status-chart-info" class="mt-3 d-none"></div>
                 </div>
             </div>
         </div>

--- a/PESystem/wwwroot/assets/Areas/BGA/js/actions.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/actions.js
@@ -100,14 +100,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const rows = items.map((item, index) => {
             const statusName = item.statusName ?? STATUS_MAP[item.applyTaskStatus] ?? item.applyTaskStatus ?? "N/A";
-            const remark = item.findBoardStatus ?? "";
+            const category = item.isValid === false && item.message
+                ? item.message
+                : item.category ?? "";
             const statusClass = item.isValid === false ? "text-danger" : "";
             return `
                 <tr class="${statusClass}">
                     <td>${index + 1}</td>
                     <td>${item.sn ?? ""}</td>
                     <td>${statusName}</td>
-                    <td>${remark}</td>
+                    <td>${category}</td>
                 </tr>
             `;
         }).join("");

--- a/PESystem/wwwroot/assets/Areas/BGA/js/search.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/search.js
@@ -84,7 +84,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     <tr class="table-danger">
                         <td>${index + 1}</td>
                         <td>${item.sn ?? ""}</td>
-                        <td colspan="9">${item.message || "Không tìm thấy dữ liệu."}</td>
+                        <td colspan="10">${item.message || "Không tìm thấy dữ liệu."}</td>
                     </tr>
                 `;
             }
@@ -96,6 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 : item.source === "Current"
                     ? "Hiện tại"
                     : "";
+            const note = item.findBoardStatus ?? "";
             const remark = item.remark ?? "";
             const category = item.category ?? "";
             return `
@@ -103,6 +104,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     <td>${index + 1}</td>
                     <td>${item.sn ?? ""}</td>
                     <td>${statusName}</td>
+                    <td>${note}</td>
                     <td>${sourceLabel}</td>
                     <td>${category}</td>
                     <td>${remark}</td>
@@ -116,12 +118,13 @@ document.addEventListener("DOMContentLoaded", () => {
         }).join("");
 
         resultContainer.innerHTML = `
-            <table class="table table-bordered table-hover align-middle">
+            <table class="table table-striped table-hover table-sm align-middle">
                 <thead class="table-light">
                     <tr>
                         <th>#</th>
                         <th>SN</th>
                         <th>Trạng thái</th>
+                        <th>Note</th>
                         <th>Nguồn</th>
                         <th>Category</th>
                         <th>Remark</th>
@@ -142,6 +145,7 @@ document.addEventListener("DOMContentLoaded", () => {
             STT: index + 1,
             SN: item.sn ?? "",
             TrangThai: item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "",
+            Note: item.findBoardStatus ?? "",
             Nguon: item.source === "History" ? "History" : item.source === "Current" ? "Current" : "",
             Category: item.category ?? "",
             Remark: item.remark ?? "",
@@ -172,11 +176,13 @@ document.addEventListener("DOMContentLoaded", () => {
             const applyTime = item.applyTime ? new Date(item.applyTime).toLocaleString() : "";
             const createTime = item.createTime ? new Date(item.createTime).toLocaleString() : "";
             const sourceLabel = item.source === "Current" ? "Hiện tại" : "Lịch sử";
+            const note = item.findBoardStatus ?? "";
             return `
                 <tr>
                     <td>${index + 1}</td>
                     <td>${item.sn ?? ""}</td>
                     <td>${statusName}</td>
+                    <td>${note}</td>
                     <td>${sourceLabel}</td>
                     <td>${item.category ?? ""}</td>
                     <td>${item.remark ?? ""}</td>
@@ -191,12 +197,13 @@ document.addEventListener("DOMContentLoaded", () => {
         }).join("");
 
         resultContainer.innerHTML = `
-            <table class="table table-bordered table-hover align-middle">
+            <table class="table table-striped table-hover table-sm align-middle">
                 <thead class="table-light">
                     <tr>
                         <th>#</th>
                         <th>SN</th>
                         <th>Trạng thái</th>
+                        <th>Note</th>
                         <th>Nguồn</th>
                         <th>Category</th>
                         <th>Remark</th>
@@ -217,6 +224,7 @@ document.addEventListener("DOMContentLoaded", () => {
             STT: index + 1,
             SN: item.sn ?? "",
             TrangThai: item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "",
+            Note: item.findBoardStatus ?? "",
             Nguon: item.source === "Current" ? "Current" : "History",
             Category: item.category ?? "",
             Remark: item.remark ?? "",

--- a/PESystem/wwwroot/assets/Areas/BGA/js/search.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/search.js
@@ -84,19 +84,28 @@ document.addEventListener("DOMContentLoaded", () => {
                     <tr class="table-danger">
                         <td>${index + 1}</td>
                         <td>${item.sn ?? ""}</td>
-                        <td colspan="6">${item.message || "Không tìm thấy dữ liệu."}</td>
+                        <td colspan="9">${item.message || "Không tìm thấy dữ liệu."}</td>
                     </tr>
                 `;
             }
 
             const statusName = item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "";
             const applyTime = item.applyTime ? new Date(item.applyTime).toLocaleString() : "";
+            const sourceLabel = item.source === "History"
+                ? "Lịch sử"
+                : item.source === "Current"
+                    ? "Hiện tại"
+                    : "";
+            const remark = item.remark ?? "";
+            const category = item.category ?? "";
             return `
                 <tr>
                     <td>${index + 1}</td>
                     <td>${item.sn ?? ""}</td>
                     <td>${statusName}</td>
-                    <td>${item.findBoardStatus ?? ""}</td>
+                    <td>${sourceLabel}</td>
+                    <td>${category}</td>
+                    <td>${remark}</td>
                     <td>${item.approveScrapperson ?? ""}</td>
                     <td>${applyTime}</td>
                     <td>${item.taskNumber ?? ""}</td>
@@ -113,6 +122,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         <th>#</th>
                         <th>SN</th>
                         <th>Trạng thái</th>
+                        <th>Nguồn</th>
+                        <th>Category</th>
                         <th>Remark</th>
                         <th>Approve</th>
                         <th>Apply Time</th>
@@ -131,7 +142,9 @@ document.addEventListener("DOMContentLoaded", () => {
             STT: index + 1,
             SN: item.sn ?? "",
             TrangThai: item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "",
-            Remark: item.findBoardStatus ?? "",
+            Nguon: item.source === "History" ? "History" : item.source === "Current" ? "Current" : "",
+            Category: item.category ?? "",
+            Remark: item.remark ?? "",
             Approve: item.approveScrapperson ?? "",
             ApplyTime: item.applyTime ? new Date(item.applyTime).toLocaleString() : "",
             TaskNumber: item.taskNumber ?? "",
@@ -158,12 +171,15 @@ document.addEventListener("DOMContentLoaded", () => {
             const statusName = item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "";
             const applyTime = item.applyTime ? new Date(item.applyTime).toLocaleString() : "";
             const createTime = item.createTime ? new Date(item.createTime).toLocaleString() : "";
+            const sourceLabel = item.source === "Current" ? "Hiện tại" : "Lịch sử";
             return `
                 <tr>
                     <td>${index + 1}</td>
                     <td>${item.sn ?? ""}</td>
                     <td>${statusName}</td>
-                    <td>${item.findBoardStatus ?? ""}</td>
+                    <td>${sourceLabel}</td>
+                    <td>${item.category ?? ""}</td>
+                    <td>${item.remark ?? ""}</td>
                     <td>${item.approveScrapperson ?? ""}</td>
                     <td>${applyTime}</td>
                     <td>${createTime}</td>
@@ -181,6 +197,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         <th>#</th>
                         <th>SN</th>
                         <th>Trạng thái</th>
+                        <th>Nguồn</th>
+                        <th>Category</th>
                         <th>Remark</th>
                         <th>Approve</th>
                         <th>Apply Time</th>
@@ -199,7 +217,9 @@ document.addEventListener("DOMContentLoaded", () => {
             STT: index + 1,
             SN: item.sn ?? "",
             TrangThai: item.statusName ?? STATUS_LABELS[item.applyTaskStatus] ?? item.applyTaskStatus ?? "",
-            Remark: item.findBoardStatus ?? "",
+            Nguon: item.source === "Current" ? "Current" : "History",
+            Category: item.category ?? "",
+            Remark: item.remark ?? "",
             Approve: item.approveScrapperson ?? "",
             ApplyTime: item.applyTime ? new Date(item.applyTime).toLocaleString() : "",
             CreateTime: item.createTime ? new Date(item.createTime).toLocaleString() : "",


### PR DESCRIPTION
## Summary
- block BP-10/BP-20 serials from being processed when they still exist in SFISM4.Z_KANBAN_TRACKING_T during scrap intake
- enrich BGA replace search APIs and UI tables with category, remark, and source details for both current and historical lookups
- add chart labels and a detailed summary table to the dashboard status chart and surface category information in the actions preview table

## Testing
- `dotnet build PESystem.sln` *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e8d3c4383c8326b37df6158d320135