### PR TITLE
Fix lookup table wrapping and mark helper as non-action

### DIFF
--- a/API_WEB/Controllers/Repositories/ProductController.cs
+++ b/API_WEB/Controllers/Repositories/ProductController.cs
@@ -1033,6 +1033,7 @@ namespace API_WEB.Controllers
         }
 
 
+        [NonAction]
         public async Task SendReceivingStatusAsync(IEnumerable<string> serialNumbers, string owner, string? location, string tag)
         {
             if (serialNumbers == null || !serialNumbers.Any())

--- a/PESystem/Areas/BGA/Views/Home/Search.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Search.cshtml
@@ -3,6 +3,16 @@
     Layout = "~/Areas/BGA/Views/Shared/layout_bga.cshtml";
 }
 
+@section Styles {
+    <style>
+        #lookup-result table,
+        #lookup-result table th,
+        #lookup-result table td {
+            white-space: nowrap;
+        }
+    </style>
+}
+
 <section class="container-fluid py-4">
     <div class="row mb-4">
         <div class="col-12">


### PR DESCRIPTION
## Summary
- prevent lookup results table from wrapping cell text by adding a local stylesheet
- mark ProductController.SendReceivingStatusAsync as a non-action so Swagger no longer treats it as an ambiguous endpoint

## Testing
- dotnet build PESystem.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e90e45973483268b286e61116ff18b