### PR TITLE
Render optional Styles section in BGA layout

### DIFF
--- a/PESystem/Areas/BGA/Views/Shared/layout_bga.cshtml
+++ b/PESystem/Areas/BGA/Views/Shared/layout_bga.cshtml
@@ -13,6 +13,7 @@
     <link href="~/lib/datatable/jquery.datatables.min.css" rel="stylesheet" />
     <script src="~/lib/gsap-particles/particles.min.js"></script>
     <script src="~/lib/gsap-particles/gsap.min.js"></script>
+    @await RenderSectionAsync("Styles", required: false)
 </head>
 <body>
     <script>


### PR DESCRIPTION
## Summary
- render the optional Styles section in the BGA layout so views can inject page-specific CSS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e910320d048326b2d2542e3ff6616c