### PR TITLE
Refactor SPE scrap approval endpoint to use EF queries

### DIFF
--- a/API_WEB/ModelsOracle/NvidiaBonepileSnLog.cs
+++ b/API_WEB/ModelsOracle/NvidiaBonepileSnLog.cs
@@ -1,0 +1,7 @@
+namespace API_WEB.ModelsOracle
+{
+    public class NvidiaBonepileSnLog
+    {
+        public string SERIAL_NUMBER { get; set; }
+    }
+}

--- a/API_WEB/ModelsOracle/OracleDbContext.cs
+++ b/API_WEB/ModelsOracle/OracleDbContext.cs
@@ -20,6 +20,7 @@ namespace API_WEB.ModelsOracle
         public DbSet<SYSTEM_AUTO_BLOCK> OracleSystemBlock { get; set; } = null!;
         public DbSet<SYSTEM_HOLD> OracleSystemHold { get; set; } = null!;
         public DbSet<SFISM4_Z_KANBAN_TRACKING_T> OracleDataZKanbanTracking { get; set; } = null!;
+        public DbSet<NvidiaBonepileSnLog> NvidiaBonepileSnLogs { get; set; } = null!;
         public DbSet<FailedSerialNumber> FailedSerialNumbers { get; set; } // lấy dữ liệu fail hass-bi
         public DbSet<GetAteSn> GetAteSnRecords { get; set; } // DbSet cho bảng
         public DbSet<ErrorCode> ErrorCodes { get; set; } // DbSet cho bảng
@@ -133,7 +134,8 @@ namespace API_WEB.ModelsOracle
                 entity.Property(e => e.GROUP_NAME).HasColumnName("GROUP_NAME");
                 entity.Property(e => e.ERROR_FLAG).HasColumnName("ERROR_FLAG");
                 entity.Property(e => e.WIP_GROUP).HasColumnName("WIP_GROUP");
-            });            
+                entity.Property(e => e.MO_NUMBER).HasColumnName("MO_NUMBER");
+            });
             modelBuilder.Entity<SFISM4_r108>(entity =>
             {
                 entity.ToTable("R108", schema: "SFISM4");
@@ -147,6 +149,12 @@ namespace API_WEB.ModelsOracle
                 entity.HasKey(e => e.SERIAL_NUMBER);
                 entity.Property(e => e.SERIAL_NUMBER).HasColumnName("SERIAL_NUMBER");
                 entity.Property(e => e.WIP_GROUP).HasColumnName("WIP_GROUP");
+            });
+            modelBuilder.Entity<NvidiaBonepileSnLog>(entity =>
+            {
+                entity.HasNoKey();
+                entity.ToTable("NVIDIA_BONPILE_SN_LOG", schema: "SFISM4");
+                entity.Property(e => e.SERIAL_NUMBER).HasColumnName("SERIAL_NUMBER");
             });
             modelBuilder.Entity<SYSTEM_HOLD>(entity =>
             {

--- a/API_WEB/ModelsOracle/SFISM4_r117.cs
+++ b/API_WEB/ModelsOracle/SFISM4_r117.cs
@@ -6,5 +6,6 @@
         public string GROUP_NAME { get; set; }
         public string ERROR_FLAG { get; set; }
         public string WIP_GROUP { get; set; }
+        public string MO_NUMBER { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- replace the SPE approval endpoint's OracleCommand usage with Entity Framework Core queries that reuse the existing Oracle context
- add Oracle mappings for MO_NUMBER and the bonepile log table so the endpoint can query bonepile and kanban data without manual connections

## Testing
- dotnet build PESystem.sln *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68ea426eb47483269745380adb63b28e