### PR TITLE
Refine BGA workflow and remove external repair scrap sync

### DIFF
--- a/API_WEB/Controllers/BGA/ReplaceBgaController.cs
+++ b/API_WEB/Controllers/BGA/ReplaceBgaController.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Threading.Tasks;
 using API_WEB.ModelsDB;
 using Microsoft.AspNetCore.Mvc;
@@ -16,16 +13,17 @@ namespace API_WEB.Controllers.BGA
     public class ReplaceBgaController : ControllerBase
     {
         private readonly CSDL_NE _sqlContext;
-        private readonly HttpClient _repairScrapClient;
 
         private static readonly Dictionary<int, int> _linearNextStatusMap = new()
         {
+            { 4, 10 },
             { 10, 11 },
             { 11, 12 },
             { 12, 13 },
             { 13, 14 },
             { 14, 15 },
-            { 15, 16 }
+            { 15, 16 },
+            { 18, 19 }
         };
 
         private static readonly Dictionary<int, string> _statusDescriptions = new()
@@ -39,7 +37,8 @@ namespace API_WEB.Controllers.BGA
             { 15, "Replace BGA" },
             { 16, "Xray" },
             { 17, "ICT, FT" },
-            { 18, "Replaced BGA ok" },
+            { 18, "Waiting return PD line" },
+            { 19, "Return PD line ok" },
             { 3, "Replaced BGA ok" }
         };
 
@@ -53,14 +52,6 @@ namespace API_WEB.Controllers.BGA
         public ReplaceBgaController(CSDL_NE sqlContext)
         {
             _sqlContext = sqlContext;
-
-            var handler = new HttpClientHandler
-            {
-                ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
-            };
-
-            _repairScrapClient = new HttpClient(handler);
-            _repairScrapClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
         private IQueryable<ScrapList> QueryBgaScrapLists()
@@ -143,7 +134,6 @@ namespace API_WEB.Controllers.BGA
         public async Task<IActionResult> GetStatusSummary()
         {
             var summary = await QueryBgaScrapLists()
-                .Where(s => s.ApplyTaskStatus != 4)
                 .GroupBy(s => s.ApplyTaskStatus)
                 .Select(g => new
                 {
@@ -583,32 +573,6 @@ namespace API_WEB.Controllers.BGA
 
             await AddHistoryEntriesAsync(scrapRecords);
             await _sqlContext.SaveChangesAsync();
-
-            var repairScrapPayload = new
-            {
-                type = "update",
-                sn_list = string.Join(",", scrapRecords.Select(record => record.SN)),
-                type_bp = (string?)null,
-                status = nextStatus.ToString(),
-                task = (string?)null
-            };
-
-            try
-            {
-                var response = await _repairScrapClient.PostAsJsonAsync(
-                    "https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap",
-                    repairScrapPayload);
-
-                response.EnsureSuccessStatusCode();
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, new
-                {
-                    message = "Cập nhật ScrapList thành công nhưng đồng bộ repair_scrap thất bại.",
-                    error = ex.Message
-                });
-            }
 
             var nextStatusName = _statusDescriptions.ContainsKey(nextStatus)
                 ? _statusDescriptions[nextStatus]

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -1785,25 +1785,6 @@ namespace API_WEB.Controllers.Scrap
                 await AddHistoryEntriesAsync(updatedRecords);
                 await _sqlContext.SaveChangesAsync();
 
-                // Chuẩn bị dữ liệu để gọi API bên thứ ba
-                var snListString = string.Join(",", matchedSNs);
-                var status = updatedRecords[0].ApplyTaskStatus.ToString(); // Lấy trạng thái cuối cùng sau khi cập nhật
-
-                var externalRequest = new
-                {
-                    type = "update",
-                    sn_list = snListString,
-                    type_bp = (string)null,
-                    status = status,
-                    task = (string)null
-                };
-
-                // Gọi API bên thứ ba
-                var externalResponse = await _httpClient.PostAsJsonAsync("https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap", externalRequest);
-                externalResponse.EnsureSuccessStatusCode();
-                var externalResult = await externalResponse.Content.ReadAsStringAsync();
-                Console.WriteLine($"External API response: {externalResult}");
-
                 string message = "Cập nhật trạng thái ApplyTaskStatus thành công.";
                 return Ok(new { message });
             }
@@ -1899,115 +1880,9 @@ namespace API_WEB.Controllers.Scrap
 
         // API: Đồng bộ dữ liệu từ ScrapList với SFISM4.R_REPAIR_SCRAP
         [HttpPost("sync-scrap")]
-        public async Task<IActionResult> SyncScrap()
+        public IActionResult SyncScrap()
         {
-            try
-            {
-                // Lấy tất cả dữ liệu từ bảng ScrapList với cột InternalTask chứa ký tự "Task"
-                var scrapLists = await _sqlContext.ScrapLists
-                    .Where(s => s.InternalTask != null && s.InternalTask.Contains("Task"))
-                    .ToListAsync();
-
-                if (!scrapLists.Any())
-                {
-                    return Ok(new { message = "Không có dữ liệu nào trong ScrapList cần đồng bộ." });
-                }
-
-                // Tạo HttpClient riêng cho URL này (vì BaseAddress khác với _httpClient hiện tại)
-                var syncHttpClient = new HttpClient(new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true // Bỏ qua kiểm tra chứng chỉ (test)
-                });
-                syncHttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-                var baseUrl = "https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap";
-
-                int successCount = 0;
-                int failureCount = 0;
-                var failureDetails = new List<string>();
-
-                foreach (var entry in scrapLists)
-                {
-
-                    // Tạo request cho insert
-                    var insertRequest = new
-                    {
-                        type = "insert",
-                        sn_list = entry.SN,
-                        type_bp = entry.Remark,
-                        status = entry.ApplyTaskStatus.ToString(),
-                        task = entry.TaskNumber
-                    };
-
-                    HttpResponseMessage response;
-                    string content;
-
-                    try
-                    {
-                        // Gọi API với type "insert"
-                        response = await syncHttpClient.PostAsJsonAsync(baseUrl, insertRequest);
-                        content = await response.Content.ReadAsStringAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        failureDetails.Add($"SN {entry.SN}: Lỗi khi gọi API insert - {ex.Message}");
-                        failureCount++;
-                        continue;
-                    }
-
-                    if (response.IsSuccessStatusCode && content.Trim() == "\"OK\"")
-                    {
-                        successCount++;
-                        continue; // Thành công, tiếp tục SN tiếp theo
-                    }
-
-                    // Nếu không thành công, thử update
-                    var updateRequest = new
-                    {
-                        type = "update",
-                        sn_list = entry.SN,
-                        type_bp = entry.Remark,
-                        status = entry.ApplyTaskStatus.ToString(),
-                        task = entry.TaskNumber
-                    };
-
-                    try
-                    {
-                        // Gọi API với type "update"
-                        response = await syncHttpClient.PostAsJsonAsync(baseUrl, updateRequest);
-                        content = await response.Content.ReadAsStringAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        failureDetails.Add($"SN {entry.SN}: Lỗi khi gọi API update - {ex.Message}");
-                        failureCount++;
-                        continue;
-                    }
-
-                    if (response.IsSuccessStatusCode && content.Trim() == "\"OK\"")
-                    {
-                        successCount++;
-                    }
-                    else
-                    {
-                        failureDetails.Add($"SN {entry.SN}: Đồng bộ thất bại - Response: {content}, StatusCode: {response.StatusCode}");
-                        failureCount++;
-                    }
-                }
-
-                // Trả về kết quả đồng bộ
-                return Ok(new
-                {
-                    message = "Quá trình đồng bộ hoàn tất.",
-                    successCount,
-                    failureCount,
-                    failureDetails
-                });
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, new { message = "Đã xảy ra lỗi khi đồng bộ dữ liệu.", error = ex.Message });
-            }
+            return Ok(new { message = "Chức năng đồng bộ repair_scrap đã được vô hiệu hóa." });
         }
 
         // API: Process can not repair - Insert vào bảng ScrapList

--- a/PESystem/Areas/BGA/Views/Home/Actions.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Actions.cshtml
@@ -21,6 +21,7 @@
                     <div class="mb-3">
                         <label for="current-status" class="form-label fw-semibold">Trạng thái hiện tại</label>
                         <select id="current-status" class="form-select">
+                            <option value="4">4 - Waiting approve replace BGA</option>
                             <option value="10">10 - Check in barking</option>
                             <option value="11">11 - Check out barking</option>
                             <option value="12">12 - VI after barking</option>
@@ -29,6 +30,8 @@
                             <option value="15">15 - Replace BGA</option>
                             <option value="16">16 - Xray</option>
                             <option value="17">17 - ICT, FT</option>
+                            <option value="18">18 - Waiting return PD line</option>
+                            <option value="19">19 - Return PD line ok</option>
                         </select>
                     </div>
 

--- a/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Dashboard.cshtml
@@ -20,26 +20,43 @@
         <div class="col-12">
             <div class="card shadow-sm border-0 bg-white text-dark h-100">
                 <div class="card-header bg-white border-0">
-                    <h5 class="mb-0 text-primary">Số lượng theo ApplyScrapStatus</h5>
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                        <h5 class="mb-0 text-primary">Số lượng theo ApplyScrapStatus</h5>
+                        <div class="d-flex flex-wrap align-items-center gap-2">
+                            <select id="status-download-select" class="form-select form-select-sm w-auto">
+                                <option value="" selected disabled>Chọn trạng thái</option>
+                            </select>
+                            <button id="status-download-btn" class="btn btn-outline-primary btn-sm" type="button">
+                                <i class="fas fa-download me-1"></i>Tải danh sách SN
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 <div class="card-body">
                     <div id="status-chart-empty" class="alert alert-info d-none" role="alert"></div>
                     <div class="position-relative" style="height: 360px;">
                         <canvas id="status-chart" class="d-none w-100 h-100"></canvas>
                     </div>
+                    <div id="status-summary-info" class="mt-3"></div>
                 </div>
             </div>
         </div>
         <div class="col-12">
             <div class="card shadow-sm border-0 bg-white text-dark h-100">
                 <div class="card-header bg-white border-0">
-                    <h5 class="mb-0 text-primary">Thời gian Barking (ApplyScrapStatus = 11)</h5>
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                        <h5 class="mb-0 text-primary">Thời gian Barking (ApplyScrapStatus = 11)</h5>
+                        <button id="barking-download-btn" class="btn btn-outline-secondary btn-sm" type="button">
+                            <i class="fas fa-file-download me-1"></i>Tải danh sách SN
+                        </button>
+                    </div>
                 </div>
                 <div class="card-body">
                     <div id="barking-age-empty" class="alert alert-info d-none" role="alert"></div>
                     <div class="position-relative" style="height: 360px;">
                         <canvas id="barking-age-chart" class="d-none w-100 h-100"></canvas>
                     </div>
+                    <div id="barking-summary" class="mt-3"></div>
                 </div>
             </div>
         </div>

--- a/PESystem/Areas/BGA/Views/Home/Process.cshtml
+++ b/PESystem/Areas/BGA/Views/Home/Process.cshtml
@@ -50,12 +50,12 @@
                                 <tr><td>7</td><td>Replace BGA</td><td>15</td></tr>
                                 <tr><td>8</td><td>Xray</td><td>16</td></tr>
                                 <tr><td>9</td><td>ICT, FT</td><td>17</td></tr>
-                                <tr><td>10</td><td>Replaced BGA ok</td><td>18</td></tr>
-                                <tr><td>11</td><td>Hoàn tất Replace BGA</td><td>3</td></tr>
+                                <tr><td>10</td><td>Waiting return PD line</td><td>18</td></tr>
+                                <tr><td>11</td><td>Return PD line ok</td><td>19</td></tr>
                             </tbody>
                         </table>
                     </div>
-                    <p class="text-muted mt-3 mb-0">Ở trạng thái 16 (Xray) và 17 (ICT/FT), nếu kết quả OK hệ thống chuyển sang bước tiếp theo, nếu NG quay lại trạng thái 13. Mỗi lần xác nhận, người dùng nhập remark lưu vào <strong>FindBoardStatus</strong>.</p>
+                    <p class="text-muted mt-3 mb-0">Ở trạng thái 16 (Xray) và 17 (ICT/FT), nếu kết quả OK hệ thống chuyển sang bước tiếp theo, nếu NG quay lại trạng thái 13. Trạng thái 18 phản ánh việc chờ trả về PD line trước khi hoàn tất ở trạng thái 19. Mỗi lần xác nhận, người dùng nhập remark lưu vào <strong>FindBoardStatus</strong>.</p>
                 </div>
             </div>
         </div>

--- a/PESystem/wwwroot/assets/Areas/BGA/js/actions.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/actions.js
@@ -10,7 +10,8 @@ const STATUS_MAP = {
     15: "Replace BGA",
     16: "Xray",
     17: "ICT, FT",
-    18: "Replaced BGA ok"
+    18: "Waiting return PD line",
+    19: "Return PD line ok"
 };
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -168,6 +169,11 @@ document.addEventListener("DOMContentLoaded", () => {
         updateFeedback.classList.add("d-none");
         updateFeedback.textContent = "";
         updateFeedback.classList.remove("alert-success", "alert-danger");
+
+        if (currentStatus === 19) {
+            showUpdateFeedback("Trạng thái 19 - Return PD line ok là trạng thái cuối cùng và không cần xác nhận thêm.", false);
+            return;
+        }
 
         const sns = parseSNs(snRaw);
         if (!sns.length) {

--- a/PESystem/wwwroot/assets/Areas/BGA/js/dashboard.js
+++ b/PESystem/wwwroot/assets/Areas/BGA/js/dashboard.js
@@ -10,7 +10,8 @@ const STATUS_TEXT = {
     15: "Replace BGA",
     16: "Xray",
     17: "ICT, FT",
-    18: "Replaced BGA ok"
+    18: "Waiting return PD line",
+    19: "Return PD line ok"
 };
 
 const AXIS_TICK_COLOR = "#f8f9fa";
@@ -106,8 +107,13 @@ const statusValueLabelsPlugin = {
 document.addEventListener("DOMContentLoaded", () => {
     const statusChartCanvas = document.getElementById("status-chart");
     const statusChartEmpty = document.getElementById("status-chart-empty");
+    const statusSummaryInfo = document.getElementById("status-summary-info");
+    const statusDownloadSelect = document.getElementById("status-download-select");
+    const statusDownloadButton = document.getElementById("status-download-btn");
     const barkingChartCanvas = document.getElementById("barking-age-chart");
     const barkingChartEmpty = document.getElementById("barking-age-empty");
+    const barkingSummary = document.getElementById("barking-summary");
+    const barkingDownloadButton = document.getElementById("barking-download-btn");
     const dashboardLastUpdated = document.getElementById("dashboard-last-updated");
     const refreshDashboardButton = document.getElementById("refresh-dashboard-btn");
 
@@ -117,6 +123,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     let statusChartInstance = null;
     let barkingChartInstance = null;
+    let latestStatusData = [];
+    let latestBarkingData = [];
 
     const setButtonLoading = (button, isLoading, loadingText) => {
         if (!button) {
@@ -150,12 +158,23 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     const renderStatusChart = (data, errorMessage) => {
+        const resetStatusMeta = () => {
+            if (statusSummaryInfo) {
+                statusSummaryInfo.innerHTML = "";
+            }
+            if (statusDownloadSelect) {
+                statusDownloadSelect.innerHTML = '<option value="" disabled selected>Chọn trạng thái</option>';
+            }
+            latestStatusData = [];
+        };
+
         if (errorMessage) {
             statusChartEmpty.textContent = errorMessage;
             statusChartEmpty.classList.remove("alert-info");
             statusChartEmpty.classList.add("alert-danger");
             statusChartEmpty.classList.remove("d-none");
             statusChartCanvas.classList.add("d-none");
+            resetStatusMeta();
             if (statusChartInstance) {
                 statusChartInstance.destroy();
                 statusChartInstance = null;
@@ -169,6 +188,7 @@ document.addEventListener("DOMContentLoaded", () => {
             statusChartEmpty.classList.add("alert-info");
             statusChartEmpty.classList.remove("d-none");
             statusChartCanvas.classList.add("d-none");
+            resetStatusMeta();
             if (statusChartInstance) {
                 statusChartInstance.destroy();
                 statusChartInstance = null;
@@ -181,6 +201,41 @@ document.addEventListener("DOMContentLoaded", () => {
             count: item.count ?? 0,
             statusName: item.statusName ?? STATUS_TEXT[item.status] ?? item.status
         }));
+
+        latestStatusData = enrichedData;
+
+        if (statusDownloadSelect) {
+            const currentValue = statusDownloadSelect.value;
+            statusDownloadSelect.innerHTML = '<option value="" disabled selected>Chọn trạng thái</option>';
+            enrichedData.forEach(item => {
+                const option = document.createElement("option");
+                option.value = item.status;
+                option.textContent = `${item.status} - ${item.statusName}`;
+                statusDownloadSelect.appendChild(option);
+            });
+            if (currentValue && enrichedData.some(item => `${item.status}` === currentValue)) {
+                statusDownloadSelect.value = currentValue;
+            }
+        }
+
+        if (statusSummaryInfo) {
+            const total = enrichedData.reduce((sum, item) => sum + (item.count ?? 0), 0);
+            const top = enrichedData.reduce((prev, current) => {
+                if (!prev) {
+                    return current;
+                }
+                return (current.count ?? 0) > (prev.count ?? 0) ? current : prev;
+            }, null);
+            const topLabel = top ? `${top.status} - ${top.statusName}` : "Không xác định";
+            const topCount = top?.count ?? 0;
+            statusSummaryInfo.innerHTML = `
+                <div class="alert alert-secondary mb-0 small">
+                    <div><strong>Tổng số SN:</strong> ${total}</div>
+                    <div><strong>Trạng thái nhiều SN nhất:</strong> ${topLabel} (${topCount})</div>
+                </div>
+            `;
+        }
+
         const labels = enrichedData.map(item => `${item.status} - ${item.statusName}`);
         const values = enrichedData.map(item => item.count);
         const statusDetails = enrichedData.map(item => ({
@@ -278,12 +333,20 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     const renderBarkingChart = (data, errorMessage) => {
+        const resetBarkingMeta = () => {
+            if (barkingSummary) {
+                barkingSummary.innerHTML = "";
+            }
+            latestBarkingData = [];
+        };
+
         if (errorMessage) {
             barkingChartEmpty.textContent = errorMessage;
             barkingChartEmpty.classList.remove("alert-info");
             barkingChartEmpty.classList.add("alert-danger");
             barkingChartEmpty.classList.remove("d-none");
             barkingChartCanvas.classList.add("d-none");
+            resetBarkingMeta();
             if (barkingChartInstance) {
                 barkingChartInstance.destroy();
                 barkingChartInstance = null;
@@ -297,6 +360,7 @@ document.addEventListener("DOMContentLoaded", () => {
             barkingChartEmpty.classList.add("alert-info");
             barkingChartEmpty.classList.remove("d-none");
             barkingChartCanvas.classList.add("d-none");
+            resetBarkingMeta();
             if (barkingChartInstance) {
                 barkingChartInstance.destroy();
                 barkingChartInstance = null;
@@ -315,6 +379,7 @@ document.addEventListener("DOMContentLoaded", () => {
             barkingChartEmpty.classList.add("alert-info");
             barkingChartEmpty.classList.remove("d-none");
             barkingChartCanvas.classList.add("d-none");
+            resetBarkingMeta();
             if (barkingChartInstance) {
                 barkingChartInstance.destroy();
                 barkingChartInstance = null;
@@ -347,6 +412,35 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (barkingChartInstance) {
             barkingChartInstance.destroy();
+        }
+
+        latestBarkingData = validData;
+        if (barkingSummary) {
+            const total = validData.length;
+            const totalHours = validData.reduce((sum, item) => sum + (item.hours ?? 0), 0);
+            const averageHours = total ? Math.round((totalHours / total) * 10) / 10 : 0;
+            const longest = validData.reduce((prev, current) => (prev.hours ?? 0) > (current.hours ?? 0) ? prev : current, validData[0]);
+            const shortest = validData.reduce((prev, current) => (prev.hours ?? Infinity) < (current.hours ?? Infinity) ? prev : current, validData[0]);
+            const formatRecord = (record) => {
+                if (!record) {
+                    return "Không xác định";
+                }
+                const hours = record.hours ?? 0;
+                const minutes = typeof record.minutes === "number" && !Number.isNaN(record.minutes)
+                    ? record.minutes
+                    : Math.round(hours * 60);
+                return `${record.sn ?? "N/A"} (~${hours} giờ | ${minutes} phút)`;
+            };
+            const missingInfo = missingCount > 0 ? `<div><strong>Thiếu Apply Time:</strong> ${missingCount} SN</div>` : "";
+            barkingSummary.innerHTML = `
+                <div class="alert alert-secondary mb-0 small">
+                    <div><strong>Tổng số SN:</strong> ${total}</div>
+                    <div><strong>Thời gian trung bình:</strong> ${averageHours} giờ</div>
+                    <div><strong>Chờ lâu nhất:</strong> ${formatRecord(longest)}</div>
+                    <div><strong>Chờ ít nhất:</strong> ${formatRecord(shortest)}</div>
+                    ${missingInfo}
+                </div>
+            `;
         }
 
         barkingChartInstance = new Chart(barkingChartCanvas, {
@@ -447,6 +541,93 @@ document.addEventListener("DOMContentLoaded", () => {
             return false;
         }
     };
+
+    const downloadCsv = (rows, headers, filename) => {
+        if (!Array.isArray(rows) || !rows.length) {
+            return;
+        }
+
+        const csv = [headers.join(",")]
+            .concat(rows.map(row => headers.map(key => {
+                const value = row[key] ?? "";
+                const escaped = `${value}`.replace(/"/g, '""');
+                return /[",\n]/.test(escaped) ? `"${escaped}"` : escaped;
+            }).join(",")))
+            .join("\n");
+
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+        const link = document.createElement("a");
+        const url = URL.createObjectURL(blob);
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    };
+
+    statusDownloadButton?.addEventListener("click", async () => {
+        if (!statusDownloadSelect) {
+            return;
+        }
+
+        const selectedValue = statusDownloadSelect.value;
+        if (!selectedValue) {
+            alert("Vui lòng chọn trạng thái cần tải.");
+            return;
+        }
+
+        const statusNumber = parseInt(selectedValue, 10);
+        if (Number.isNaN(statusNumber)) {
+            alert("Trạng thái không hợp lệ.");
+            return;
+        }
+
+        try {
+            statusDownloadButton.disabled = true;
+            statusDownloadButton.dataset.originalText = statusDownloadButton.dataset.originalText || statusDownloadButton.innerHTML;
+            statusDownloadButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Đang tải...';
+
+            const response = await fetch(`${API_BASE_URL}/status?status=${statusNumber}`);
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.message || "Không thể tải danh sách SN.");
+            }
+
+            const rows = data.map(item => ({
+                SN: item.sn ?? item.SN ?? "",
+                Status: `${item.status ?? item.applyTaskStatus ?? statusNumber}`,
+                StatusName: item.statusName ?? STATUS_TEXT[item.status ?? item.applyTaskStatus] ?? "",
+                InternalTask: item.internalTask ?? "",
+                ApplyTime: item.applyTime ?? ""
+            }));
+
+            downloadCsv(rows, ["SN", "Status", "StatusName", "InternalTask", "ApplyTime"], `bga-status-${statusNumber}.csv`);
+        } catch (error) {
+            alert(error.message || "Không thể tải dữ liệu.");
+        } finally {
+            if (statusDownloadButton.dataset.originalText) {
+                statusDownloadButton.innerHTML = statusDownloadButton.dataset.originalText;
+            }
+            statusDownloadButton.disabled = false;
+        }
+    });
+
+    barkingDownloadButton?.addEventListener("click", () => {
+        if (!latestBarkingData.length) {
+            alert("Không có dữ liệu để tải.");
+            return;
+        }
+
+        const rows = latestBarkingData.map(item => ({
+            SN: item.sn ?? "",
+            ApplyTime: item.applyTime ?? "",
+            Hours: item.hours ?? "",
+            Minutes: item.minutes ?? ""
+        }));
+
+        downloadCsv(rows, ["SN", "ApplyTime", "Hours", "Minutes"], "bga-barking-status-11.csv");
+    });
 
     const refreshDashboard = async () => {
         showStatusLoading();

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
@@ -317,64 +317,42 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const ApproveStatus = purpose === "4" ? "3" : "0";
         const snListString = sNs.join(",");
-        const repairScrapData = {
-            type: "update",
-            sn_list: snListString,
-            type_bp: null,
-            status: ApproveStatus,
-            task: null
-        };
-
         const resultDiv = document.getElementById("input-sn-result");
         resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`;
 
         try {
-            // Gọi API repair_scrap trước
-            const repairScrapResponse = await fetch("https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap", {
+            const requestData = { sNs, createdBy: currentUsername, description, approveScrapPerson, purpose, speApproveTime };
+            const inputSnResponse = await fetch("http://10.220.130.119:9090/api/Scrap/input-sn", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(repairScrapData)
+                body: JSON.stringify(requestData)
             });
 
-            const repairScrapResult = await repairScrapResponse.text();
-            if (repairScrapResponse.ok && repairScrapResult === "\"OK\"") {
-                // Gọi API input-sn sau khi repair_scrap thành công
-                const requestData = { sNs, createdBy: currentUsername, description, approveScrapPerson, purpose, speApproveTime };
-                const inputSnResponse = await fetch("http://10.220.130.119:9090/api/Scrap/input-sn", {
-                    method: "POST",
+            const inputSnResult = await inputSnResponse.json();
+            if (inputSnResponse.ok) {
+                let scrapStatus;
+                switch (purpose) {
+                    case "0": scrapStatus = "SPE approve to scrap"; break;
+                    case "1": scrapStatus = "Scrap to quarterly"; break;
+                    case "2": scrapStatus = "Approved to engineer sample"; break;
+                    case "3": scrapStatus = "Approved to master board"; break;
+                    case "4": scrapStatus = "SPE approve to BGA"; break;
+                    default: scrapStatus = "Unknown"; break;
+                }
+
+                const updateProductRequest = { serialNumbers: sNs, scrapStatus };
+                const updateProductResponse = await fetch("http://10.220.130.119:9090/api/Product/UpdateScrap", {
+                    method: "PUT",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(requestData)
+                    body: JSON.stringify(updateProductRequest)
                 });
 
-                const inputSnResult = await inputSnResponse.json();
-                if (inputSnResponse.ok) {
-                    // Gọi API UpdateScrap nếu input-sn thành công
-                    let scrapStatus;
-                    switch (purpose) {
-                        case "0": scrapStatus = "SPE approve to scrap"; break;
-                        case "1": scrapStatus = "Scrap to quarterly"; break;
-                        case "2": scrapStatus = "Approved to engineer sample"; break;
-                        case "3": scrapStatus = "Approved to master board"; break;
-                        case "4": scrapStatus = "SPE approve to BGA"; break;
-                        default: scrapStatus = "Unknown"; break;
-                    }
-
-                    const updateProductRequest = { serialNumbers: sNs, scrapStatus };
-                    const updateProductResponse = await fetch("http://10.220.130.119:9090/api/Product/UpdateScrap", {
-                        method: "PUT",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify(updateProductRequest)
-                    });
-
-                    const updateProductResult = await updateProductResponse.json();
-                    resultDiv.innerHTML = updateProductResponse.ok && updateProductResult.success
-                        ? `<div class="alert alert-success"><strong>${inputSnResult.message}</strong><br>Internal Task: ${inputSnResult.internalTask}<br>Update Product: ${updateProductResult.message}</div>`
-                        : `<div class="alert alert-warning"><strong>${inputSnResult.message}</strong><br>Internal Task: ${inputSnResult.internalTask}<br><strong>Lỗi khi cập nhật Product:</strong> ${updateProductResult.message || "Không có thông tin lỗi"}</div>`;
-                } else {
-                    resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${inputSnResult.message}</div>`;
-                }
+                const updateProductResult = await updateProductResponse.json();
+                resultDiv.innerHTML = updateProductResponse.ok && updateProductResult.success
+                    ? `<div class="alert alert-success"><strong>${inputSnResult.message}</strong><br>Internal Task: ${inputSnResult.internalTask}<br>Update Product: ${updateProductResult.message}</div>`
+                    : `<div class="alert alert-warning"><strong>${inputSnResult.message}</strong><br>Internal Task: ${inputSnResult.internalTask}<br><strong>Lỗi khi cập nhật Product:</strong> ${updateProductResult.message || "Không có thông tin lỗi"}</div>`;
             } else {
-                resultDiv.innerHTML = `<div class="alert alert-warning"><strong>Cảnh báo:</strong> Gọi API repair_scrap thất bại: ${repairScrapResult}</div>`;
+                resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${inputSnResult.message}</div>`;
             }
         } catch (error) {
             resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
@@ -479,40 +457,19 @@ document.addEventListener("DOMContentLoaded", function () {
             return;
         }
 
-        const repairScrapData = {
-            type: "update",
-            sn_list: snList.join(","),
-            type_bp: null,
-            status: "5",
-            task: task
-        };
-
         try {
-            // Gọi API repair_scrap trước
-            const repairResponse = await fetch("https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap", {
+            const updateTaskRequest = { snList, task, po };
+            const updateResponse = await fetch("http://10.220.130.119:9090/api/Scrap/update-task-po", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(repairScrapData)
+                body: JSON.stringify(updateTaskRequest)
             });
 
-            const repairText = await repairResponse.text();
-            if (repairResponse.ok && repairText === "\"OK\"") {
-                // Gọi API update-task-po sau khi repair_scrap thành công
-                const updateTaskRequest = { snList, task, po };
-                const updateResponse = await fetch("http://10.220.130.119:9090/api/Scrap/update-task-po", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(updateTaskRequest)
-                });
-
-                const updateResult = await updateResponse.json();
-                if (updateResponse.ok) {
-                    resultDiv.innerHTML = `<div class="alert alert-success"><strong>Thành công:</strong> ${updateResult.message} <br>Repair Scrap cập nhật thành công.</div>`;
-                } else {
-                    resultDiv.innerHTML = `<div class="alert alert-warning"><strong>Lỗi khi cập nhật Task PO:</strong> ${updateResult.message}</div>`;
-                }
+            const updateResult = await updateResponse.json();
+            if (updateResponse.ok) {
+                resultDiv.innerHTML = `<div class="alert alert-success"><strong>Thành công:</strong> ${updateResult.message}</div>`;
             } else {
-                resultDiv.innerHTML = `<div class="alert alert-warning"><strong>Lỗi:</strong> Gọi API repair_scrap thất bại: ${repairText}</div>`;
+                resultDiv.innerHTML = `<div class="alert alert-warning"><strong>Lỗi khi cập nhật Task PO:</strong> ${updateResult.message}</div>`;
             }
         } catch (error) {
             resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function1.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function1.js
@@ -301,27 +301,40 @@ document.addEventListener("DOMContentLoaded", function () {
             const inputSnResult = await inputSnResponse.json();
 
             if (inputSnResponse.ok) {
-                // Gọi API repair_scrap sau khi input-sn-wait-spe-approve thành công
-                const repairScrapData = {
-                    type: "insert",
-                    sn_list: snListString,
-                    type_bp: typeBonepile,
-                    status: typeApprove,
-                    task: null
-                };
+                const shouldSkipRepairScrap = typeApprove === "4";
 
-                const repairScrapResponse = await fetch("https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
-                    body: JSON.stringify(repairScrapData)
-                });
+                let repairScrapSuccess = true;
+                if (!shouldSkipRepairScrap) {
+                    const repairScrapData = {
+                        type: "insert",
+                        sn_list: snListString,
+                        type_bp: typeBonepile,
+                        status: typeApprove,
+                        task: null
+                    };
 
-                const repairScrapResult = await repairScrapResponse.text();
+                    const repairScrapResponse = await fetch("https://sfc-portal.cns.myfiinet.com/SfcSmartRepair/api/repair_scrap", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify(repairScrapData)
+                    });
 
-                if (repairScrapResponse.ok && repairScrapResult === "\"OK\"") {
-                    // Gọi API UpdateScrap sau khi repair_scrap thành công
+                    const repairScrapResult = await repairScrapResponse.text();
+                    repairScrapSuccess = repairScrapResponse.ok && repairScrapResult === "\"OK\"";
+
+                    if (!repairScrapSuccess) {
+                        console.warn("repair_scrap API failed:", repairScrapResult);
+                        resultDiv.innerHTML = `
+                        <div class="alert alert-warning">
+                            <strong>Cảnh báo:</strong> Gọi API repair_scrap thất bại: ${repairScrapResult}
+                        </div>
+                    `;
+                    }
+                }
+
+                if (repairScrapSuccess) {
                     const updateResponse = await fetch("http://10.220.130.119:9090/api/Product/UpdateScrap", {
                         method: "PUT",
                         headers: {
@@ -336,27 +349,19 @@ document.addEventListener("DOMContentLoaded", function () {
                     const updateResult = await updateResponse.json();
 
                     if (updateResponse.ok) {
-                        // Nếu cả ba API đều thành công
                         resultDiv.innerHTML = `
                         <div class="alert alert-success">
-                            <strong>Thành công:</strong> ${inputSnResult.message}
+                            <strong>Thành công:</strong> ${inputSnResult.message}${shouldSkipRepairScrap ? " (Bỏ qua đồng bộ repair_scrap)" : ""}
                         </div>
                     `;
                     } else {
                         console.warn("UpdateProduct API failed:", updateResult.message);
                         resultDiv.innerHTML = `
                         <div class="alert alert-warning">
-                            <strong>Cảnh báo:</strong> Lưu SN và repair_scrap thành công nhưng cập nhật sản phẩm trong kho thất bại: ${updateResult.message}
+                            <strong>Cảnh báo:</strong> Lưu SN thành công nhưng cập nhật sản phẩm trong kho thất bại: ${updateResult.message}
                         </div>
                     `;
                     }
-                } else {
-                    console.warn("repair_scrap API failed:", repairScrapResult);
-                    resultDiv.innerHTML = `
-                    <div class="alert alert-warning">
-                        <strong>Cảnh báo:</strong> Gọi API repair_scrap thất bại: ${repairScrapResult}
-                    </div>
-                `;
                 }
             } else {
                 console.warn("input-sn-wait-spe-approve API failed:", inputSnResult.message);


### PR DESCRIPTION
## Summary
- remove calls to the external repair_scrap API from scrap input/update flows and related backend endpoints
- refresh the Replace BGA workflow, actions UI, and controller logic to support the new status progression through Return PD line ok
- enrich the Replace BGA dashboard with contextual summaries and CSV downloads for status and barking views

## Testing
- dotnet build *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ecc2440be88326b7f2df9b2fd7668f