### PR TITLE
Revamp scrap area UI and update scrap status API

### DIFF
--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -439,34 +439,65 @@ namespace API_WEB.Controllers.Scrap
             }
         }
 
-        // API: Lấy dữ liệu từ ScrapList với ApplyTaskStatus = 0 hoặc 10
+        // API: Lấy dữ liệu từ ScrapList trong 3 tháng gần nhất có InternalTask hợp lệ
         [HttpGet("get-scrap-status-zero")]
         public async Task<IActionResult> GetScrapStatusZero()
         {
             try
             {
-                // Lấy dữ liệu từ bảng ScrapList với ApplyTaskStatus = 0 hoặc 10
-                var scrapData = await _sqlContext.ScrapLists
-                    .Where(s => s.ApplyTaskStatus == 0 || s.ApplyTaskStatus == 10) // Lọc theo ApplyTaskStatus = 0 hoặc 10
-                    .GroupBy(s => s.InternalTask) // Nhóm theo InternalTask
+                var threeMonthsAgo = DateTime.Now.AddMonths(-3);
+
+                var groupedData = await _sqlContext.ScrapLists
+                    .Where(s => !string.IsNullOrWhiteSpace(s.InternalTask))
+                    .Where(s => s.InternalTask != "N/A")
+                    .Where(s => s.CreateTime >= threeMonthsAgo)
+                    .GroupBy(s => s.InternalTask)
                     .Select(g => new
                     {
                         InternalTask = g.Key,
-                        Description = g.First().Desc, // Lấy giá trị đầu tiên của Description
-                        ApproveScrapPerson = g.First().ApproveScrapperson, // Lấy giá trị đầu tiên
-                        KanBanStatus = g.First().KanBanStatus, // Lấy giá trị đầu tiên
-                        Category = g.First().Category,
-                        Remark = g.First().Remark,
-                        CreateTime = g.First().CreateTime.ToString("yyyy-MM-dd"), // Chỉ lấy ngày tháng năm
-                        CreateBy = g.First().CreatedBy, // Lấy giá trị đầu tiên
-                        ApplyTaskStatus = g.First().ApplyTaskStatus, // Lấy giá trị đầu tiên
-                        TotalQty = g.Count() // Đếm số lượng SN trong mỗi InternalTask
+                        Latest = g
+                            .OrderByDescending(x => x.CreateTime)
+                            .FirstOrDefault(),
+                        TotalQty = g.Count()
                     })
                     .ToListAsync();
 
+                var scrapData = groupedData
+                    .Where(x => x.Latest != null)
+                    .Select(x => new
+                    {
+                        x.InternalTask,
+                        x.Latest!.Desc,
+                        ApproveScrapPerson = x.Latest.ApproveScrapperson,
+                        x.Latest.KanBanStatus,
+                        x.Latest.Category,
+                        x.Latest.Purpose,
+                        x.Latest.Remark,
+                        x.Latest.CreateTime,
+                        CreateBy = x.Latest.CreatedBy,
+                        x.Latest.ApplyTaskStatus,
+                        x.TotalQty
+                    })
+                    .OrderByDescending(x => x.CreateTime)
+                    .Select(x => new
+                    {
+                        x.InternalTask,
+                        Description = x.Desc,
+                        x.ApproveScrapPerson,
+                        x.KanBanStatus,
+                        x.Category,
+                        x.Purpose,
+                        x.Remark,
+                        CreateTime = x.CreateTime.ToString("yyyy-MM-dd"),
+                        x.CreateBy,
+                        x.ApplyTaskStatus,
+                        x.TotalQty
+                    })
+                    .ToList();
+
                 if (!scrapData.Any())
                 {
-                    return NotFound(new { message = "Không tìm thấy dữ liệu với ApplyTaskStatus = 0 hoặc 3." });
+                    return NotFound(new { message = "Không tìm thấy dữ liệu phù hợp trong 3 tháng gần nhất." });
                 }
 
                 return Ok(scrapData);

--- a/PESystem/Areas/Scrap/Views/Function/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function/Index.cshtml
@@ -5,218 +5,203 @@
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
 
-<div class="row">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
+<div class="scrap-page">
+    <div class="scrap-card scrap-card--selector">
+        <div class="scrap-card-header">
+            <h2 class="scrap-card-title">Scrap task toolkit</h2>
+            <p class="scrap-card-subtitle">Quản lý toàn bộ tiến trình xin task, cập nhật dữ liệu và xử lý phế được SPE phê duyệt.</p>
+        </div>
+        <form id="search-form" class="scrap-selector">
+            <label for="search-options">Select function</label>
             <select id="search-options" class="form-select">
                 <option selected disabled>SELECT FUNCTION</option>
                 <option value="INPUT_SN">INPUT SN</option>
                 <option value="CREATE_TASK_FORM">CREATE TASK FORM</option>
                 <option value="CREATE_TASK_FORM_SN">CREATE TASK FORM BY SN</option>
                 <option value="UPDATE_DATA">UPDATE DATA</option>
-                <option value="HISTORY_APPLY">HISTORY APPLY</option>
             </select>
         </form>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row align-items-end">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-input" class="form-control" rows="10" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <form id="input-sn-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="INPUT_SN">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Nhập danh sách SN</h3>
+            <p class="scrap-card-subtitle">Tải lên danh sách board đã được SPE duyệt để tạo request xin task.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">Serial numbers</label>
+                <textarea name="serialNumbers" id="sn-input" class="form-control" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+            </div>
+            <div class="scrap-form-grid">
+                <div>
+                    <label class="form-label fw-semibold text-uppercase text-muted">Tiêu đề mail</label>
+                    <input type="text" id="description-input" name="description" class="form-control" placeholder="Tiêu đề mail khách hàng approved">
                 </div>
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <input type="text" id="description-input" name="description" class="form-control" placeholder="Tiêu đề mail khách hàng approved">
-                    </div>
-                    <div class="mb-2">
-                        <input type="text" id="NVmember-input" name="po" class="form-control" placeholder="Nhập tên khách hàng approved">
-                    </div>
-                    <div class="mb-2">
-                        <select id="Scrap-options" class="form-select">
-                            <option selected disabled>Select type scrap</option>
-                            <option value="0">SPE approve to scrap</option>
-                            <option value="1">Scrap to quarterly</option>
-                            <option value="2">Approved to engineer sample</option>
-                            <option value="3">Approved to master board</option>
-                            <option value="4">Approved to BGA</option>
-                        </select>
-                    </div>
-                    <div class="mb-2">
-                        <label for="speApproveTime-input" class="form-label">Thời gian khách hàng approve</label>
-                        <input type="date" id="speApproveTime-input" name="speApproveTime" class="form-control" />
-                    </div>
-                    <div class="mb-2">
-                        <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                    </div>
+                <div>
+                    <label class="form-label fw-semibold text-uppercase text-muted">Người phê duyệt</label>
+                    <input type="text" id="NVmember-input" name="po" class="form-control" placeholder="Nhập tên khách hàng approved">
+                </div>
+                <div>
+                    <label class="form-label fw-semibold text-uppercase text-muted">Loại xử lý</label>
+                    <select id="Scrap-options" class="form-select">
+                        <option selected disabled>Select type scrap</option>
+                        <option value="0">SPE approve to scrap</option>
+                        <option value="1">Scrap to quarterly</option>
+                        <option value="2">Approved to engineer sample</option>
+                        <option value="3">Approved to master board</option>
+                        <option value="4">Approved to BGA</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="speApproveTime-input" class="form-label fw-semibold text-uppercase text-muted">Thời gian khách hàng approve</label>
+                    <input type="date" id="speApproveTime-input" name="speApproveTime" class="form-control" />
+                </div>
+                <div class="scrap-button-group">
+                    <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
                 </div>
             </div>
-        </form>
+        </div>
+        <p class="scrap-card-note">* Hệ thống sẽ kiểm tra trùng lặp và cập nhật trạng thái tự động sau khi danh sách hợp lệ.</p>
+    </form>
 
-        <!-- Form create task -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="CREATE_TASK_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="create-task-btn" class="btn btn-ne" type="button">Create task</button>
+    <form id="custom-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="CREATE_TASK_FORM">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Tạo task theo Internal Task</h3>
+            <p class="scrap-card-subtitle">Tải dữ liệu đã sẵn sàng xin task và xuất ra file template gửi khách hàng.</p>
+        </div>
+        <div class="scrap-button-group">
+            <button id="create-task-btn" class="btn btn-ne" type="button">Create task</button>
+        </div>
+    </form>
+
+    <form id="custom-form-sn" method="post" class="scrap-card scrap-card--form hidden" data-search-type="CREATE_TASK_FORM_SN">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Tạo task theo SN</h3>
+            <p class="scrap-card-subtitle">Nhập nhanh danh sách SN để hệ thống gom theo Internal Task tương ứng.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">Serial numbers</label>
+                <textarea name="SN box" id="create-task-btn-sn-box" class="form-control" rows="5" placeholder="Nhập SN"></textarea>
+            </div>
+            <div class="scrap-button-group align-self-end">
+                <button id="create-task-btn-sn" class="btn btn-ne" type="button">Create task</button>
+            </div>
+        </div>
+    </form>
+
+    <form id="update-data-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="UPDATE_DATA">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Cập nhật dữ liệu sau khi xin task</h3>
+            <p class="scrap-card-subtitle">Thêm thông tin Task/PO và chi phí phế để đồng bộ với hệ thống quản lý.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">Serial numbers</label>
+                <textarea name="serialNumbers" id="sn-input-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+            </div>
+            <div class="scrap-form-grid">
+                <div>
+                    <label for="task-input" class="form-label fw-semibold text-uppercase text-muted">Task</label>
+                    <input type="text" id="task-input" name="task" class="form-control" placeholder="Nhập Task">
+                </div>
+                <div>
+                    <label for="po-input" class="form-label fw-semibold text-uppercase text-muted">PO</label>
+                    <input type="text" id="po-input" name="po" class="form-control" placeholder="Nhập PO">
+                </div>
+                <div class="scrap-button-group">
+                    <button id="update-task-btn" class="btn btn-ne" type="button">Update</button>
                 </div>
             </div>
-        </form>
-
-        <!-- Form create task by SN -->
-        <form id="custom-form-sn" method="post" class="hidden" data-search-type="CREATE_TASK_FORM_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-4">
-                    <textarea name="SN box" id="create-task-btn-sn-box" class="form-control" rows="5" placeholder="Nhập SN"></textarea>
+            <div class="scrap-form-grid">
+                <div>
+                    <label for="cost-input" class="form-label fw-semibold text-uppercase text-muted">Cost</label>
+                    <input type="text" id="cost-input" name="cost" class="form-control" placeholder="Nhập Cost">
                 </div>
-                <div class="col-md-2">
-                    <button id="create-task-btn-sn" class="btn btn-ne" type="button">Create task</button>
+                <div>
+                    <label for="file-input" class="form-label fw-semibold text-uppercase text-muted">Upload Excel File (Board SN &amp; Cost)</label>
+                    <input type="file" id="file-input" name="file" class="form-control" accept=".xlsx, .xls">
                 </div>
-            </div>
-        </form>
-
-        <!-- Form update data -->
-        <form id="update-data-form" method="post" class="hidden" data-search-type="UPDATE_DATA">
-            <div class="row">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-input-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
-                </div>
-
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="task-input" class="form-label">Task</label>
-                        <input type="text" id="task-input" name="task" class="form-control" placeholder="Nhập Task">
-                    </div>
-                    <div class="mb-2">
-                        <label for="po-input" class="form-label">PO</label>
-                        <input type="text" id="po-input" name="po" class="form-control" placeholder="Nhập PO">
-                    </div>
-                    <button id="update-task-btn" class="btn btn-ne mt-1" type="button">Update</button>
-                </div>
-
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="cost-input" class="form-label">Cost</label>
-                        <input type="text" id="cost-input" name="cost" class="form-control" placeholder="Nhập Cost">
-                    </div>
-                    <div class="mb-2">
-                        <label for="file-input" class="form-label">Upload Excel File (Board SN & Cost)</label>
-                        <input type="file" id="file-input" name="file" class="form-control" accept=".xlsx, .xls">
-                    </div>
-                    <button id="update-cost-btn" class="btn btn-ne mt-1" type="button">Update Cost</button>
+                <div class="scrap-button-group">
+                    <button id="update-cost-btn" class="btn btn-ne" type="button">Update Cost</button>
                 </div>
             </div>
-        </form>
+        </div>
+    </form>
 
-        <!-- Form history apply -->
-        <form id="history-apply-form" method="post" class="hidden" data-search-type="HISTORY_APPLY_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="create-history-task-btn" class="btn btn-ne" type="button">Data</button>
-                </div>
-            </div>
-        </form>
+    <form id="history-apply-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="HISTORY_APPLY_FORM">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Lịch sử xin task</h3>
+            <p class="scrap-card-subtitle">Chức năng đã được lưu trữ. Liên hệ MIS nếu cần truy cập lại.</p>
+        </div>
+        <div class="scrap-button-group">
+            <button id="create-history-task-btn" class="btn btn-ne" type="button">Data</button>
+        </div>
+    </form>
+
+    <div id="input-sn-result" class="scrap-card scrap-card--form hidden"></div>
+
+    <div id="create-task-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">Danh sách Internal Task</h4>
+            <span class="scrap-card-subtitle">Các yêu cầu đã có Internal Task và trong vòng 3 tháng gần nhất.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <table id="task-checkbox-table" class="table table-hover align-middle scrap-table datatable-table">
+                <thead>
+                    <tr>
+                        <th class="checkbox-column"><input type="checkbox" id="select-all"></th>
+                        <th>INTERNAL_TASK</th>
+                        <th>DESCRIPTION</th>
+                        <th>NV_APPROVE</th>
+                        <th>KANBAN_STATUS</th>
+                        <th>CATEGORY</th>
+                        <th>PURPOSE</th>
+                        <th>TYPE_BP</th>
+                        <th>CREATE_TIME</th>
+                        <th>CREATE_BY</th>
+                        <th>APPLY_TASK_STATUS</th>
+                        <th>TOTAL_Q'TY</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+
+    <div id="create-task-result-sn" class="scrap-card scrap-card--form hidden"></div>
+    <div id="update-data-result" class="scrap-card scrap-card--form hidden"></div>
+
+    <div id="history-apply-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">History apply</h4>
+            <span class="scrap-card-subtitle">Dữ liệu lưu trữ dành cho mục đích tham khảo.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <table id="history-task-checkbox-table" class="table table-hover align-middle scrap-table datatable-table">
+                <thead>
+                    <tr>
+                        <th class="checkbox-column"><input type="checkbox" id="select-all-history"></th>
+                        <th>INTERNAL_TASK</th>
+                        <th>DESCRIPTION</th>
+                        <th>NV_APPROVE</th>
+                        <th>KANBAN_STATUS</th>
+                        <th>CATEGORY</th>
+                        <th>TYPE_BP</th>
+                        <th>CREATE_TIME</th>
+                        <th>CREATE_BY</th>
+                        <th>APPLY_TIME</th>
+                        <th>APPLY_TASK_STATUS</th>
+                        <th>TOTAL_Q'TY</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
     </div>
 </div>
 
-<!--hiển thị của chức năng input sn-->
-<div id="input-sn-result" class="hidden"></div>
-
-<!--hiển thị của chức năng create task-->
-<div id="create-task-result" class="hidden">
-    <table id="task-checkbox-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-        <thead>
-            <tr>
-                <th class="checkbox-column"><input type="checkbox" id="select-all"></th>
-                <th>INTERNAL_TASK</th>
-                <th>DESCRIPTION</th>
-                <th>NV_APPROVE</th>
-                <th>KANBAN_STATUS</th>
-                <th>CATEGORY</th>
-                <th>TYPE_BP</th>
-                <th>CREATE_TIME</th>
-                <th>CREATE_BY</th>
-                <th>APPLY_TASK_STATUS</th>
-                <th>TOTAL_Q'TY</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
-
-<!--hiển thị của chức năng create task by sn-->
-<div id="create-task-result-sn" class="hidden"></div>
-
-<!--hiển thị của chức năng update data-->
-<div id="update-data-result" class="hidden"></div>
-
-<!--hiển thị của chức năng update data-->
-<div id="history-apply-result" class="hidden">
-    <table id="history-task-checkbox-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-        <thead>
-            <tr>
-                <th class="checkbox-column"><input type="checkbox" id="select-all-history"></th>
-                <th>INTERNAL_TASK</th>
-                <th>DESCRIPTION</th>
-                <th>NV_APPROVE</th>
-                <th>KANBAN_STATUS</th>
-                <th>CATEGORY</th>
-                <th>TYPE_BP</th>
-                <th>CREATE_TIME</th>
-                <th>CREATE_BY</th>
-                <th>APPLY_TIME</th>
-                <th>APPLY_TASK_STATUS</th>
-                <th>TOTAL_Q'TY</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
-
-
-
 @section Scripts {
-    <!-- Script tùy chỉnh -->
-    <script src="~/assets/areas/scrap/js/function.js?v=@DateTime.Now.Ticks"></script>
-    <style>
-        .hidden {
-            display: none !important;
-        }
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 20px!important; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center !important;
-        }
-        /* Giới hạn độ rộng cột */
-        #task-checkbox-table th, #task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            /*max-width: 80px!important;  Giới hạn độ rộng cột */
-        }
-
-        /* Giới hạn độ rộng cột */
-        #history-task-checkbox-table th, #history-task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            /*max-width: 80px!important;  Giới hạn độ rộng cột */
-        }
-        #history-task-checkbox-table td, #task-checkbox-table td{
-            background-color:#fff;
-        }
-
-         /* Thêm hiệu ứng hover cho hàng */
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76b900 !important;
-            /*transition: background-color 0.2s ease;*/
-        }
-
-
-    </style>
+    <script src="~/assets/Areas/Scrap/js/function.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
@@ -1,184 +1,71 @@
-﻿﻿﻿@{
+﻿﻿@{
     ViewData["Title"] = "process can't repair";
 }
 @{
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
+
+<div class="scrap-page">
+    <div class="scrap-card scrap-card--selector">
+        <div class="scrap-card-header">
+            <h2 class="scrap-card-title">Process can't repair</h2>
+            <p class="scrap-card-subtitle">Quản lý danh sách board bị lỗi process không thể sửa chữa và các thao tác cập nhật liên quan.</p>
+        </div>
+        <form id="search-form" class="scrap-selector">
+            <label for="search-options">Select function</label>
             <select id="search-options" class="form-select">
                 <option selected disabled>SELECT FUNCTION</option>
                 <option value="INPUT_SN_1">INPUT SN</option>
-                <option value="SN_PROCESS_CANT_REPAIR">SN process can't repair'</option>
+                <option value="SN_PROCESS_CANT_REPAIR">SN process can't repair</option>
             </select>
         </form>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-1-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <form id="input-sn-1-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="INPUT_SN">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Nhập danh sách SN lỗi process</h3>
+            <p class="scrap-card-subtitle">Tải SN vào hệ thống để theo dõi và xin phê duyệt SPE.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">Serial numbers</label>
+                <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+            </div>
+            <div class="scrap-form-grid">
+                <div>
+                    <label for="description-input-1" class="form-label fw-semibold text-uppercase text-muted">Description</label>
+                    <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="description-input" class="form-label">Description</label>
-                        <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
-                    </div>
-                    <!--<div class="mb-2">
-                        <label for="tpye-bp-input" class="form-label">Type Bonepile</label>
-                        <select id="bp-options" class="form-select">
-                            <option selected disabled>SELECT TYPE BONEPILE</option>
-                            <option value="BP-10">BONEPILE 1.0</option>
-                            <option value="BP-20">BONEPILE 2.0</option>
-                            <option value="B36R">AFFTER KANBAN</option>
-                        </select>
-                    </div>-->
+                <div class="scrap-button-group">
                     <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
                 </div>
-                <!--<div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="tpye-approve-input" class="form-label">Type approve input</label>
-                        <select id="approve-options" class="form-select">
-                            <option selected disabled>SELECT TYPE APPROVE</option>
-                            <option value="2">Waiting SPE Approve Scrap</option>
-                            <option value="4">Waiting SPE Approve BGA</option>
-                        </select>
-                    </div>
-                </div>-->
             </div>
-        </form>
-
-        <!-- Form sn wait approve result -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="SN_WAIT_LIST_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
-                </div>
-            </div>
-        </form>
-    </div>
-</div>
-
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng input sn 1-->
-    <div id="input-sn-1-result" class="hidden"></div>
-    <!--hiển thị của chức năng sn đợi SPE approve-->
-    <div id="sn-wait-approve-result" class="hidden">
-        <div class="table-container">
-            <table id="table-sn-wait-approve" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>SERIAL_NUMBER</th>
-                        <th>DESCRIPTION</th>
-                        <th>CREATE_TIME</th>
-                        <th>APPLY_TASK_STATUS</th>
-                        <th>CREATE_BY</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </div>
+    </form>
 
+    <form id="custom-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="SN_WAIT_LIST_FORM">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Tải danh sách lỗi process</h3>
+            <p class="scrap-card-subtitle">Xuất báo cáo các SN lỗi process không thể sửa chữa.</p>
+        </div>
+        <div class="scrap-button-group">
+            <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
+        </div>
+    </form>
+
+    <div id="input-sn-1-result" class="scrap-card scrap-card--form hidden"></div>
+
+    <div id="sn-wait-approve-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">SN process can't repair</h4>
+            <span class="scrap-card-subtitle">Danh sách sẽ hiển thị sau khi tải dữ liệu từ API.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <div class="table-container"></div>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(3), td:nth-child(3), /* Cột Create Time */
-            th:nth-child(4), td:nth-child(4) { /* Cột Apply Task Status */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description) */
-            th:nth-child(2), td:nth-child(2) { /* Cột Description */
-                white-space: normal; /* Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
-    <script src="~/assets/areas/scrap/js/function0.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/function0.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
@@ -1,13 +1,18 @@
-﻿﻿﻿@{
+﻿﻿@{
     ViewData["Title"] = "Scrap Area";
 }
 @{
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
+
+<div class="scrap-page">
+    <div class="scrap-card scrap-card--selector">
+        <div class="scrap-card-header">
+            <h2 class="scrap-card-title">SN wait SPE approve</h2>
+            <p class="scrap-card-subtitle">Theo dõi danh sách board chờ phê duyệt SPE và tải báo cáo cần thiết.</p>
+        </div>
+        <form id="search-form" class="scrap-selector">
+            <label for="search-options">Select function</label>
             <select id="search-options" class="form-select">
                 <option selected disabled>SELECT FUNCTION</option>
                 <option value="INPUT_SN_1">INPUT SN</option>
@@ -16,170 +21,68 @@
         </form>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-1-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <form id="input-sn-1-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="INPUT_SN">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Nhập SN chờ SPE approve</h3>
+            <p class="scrap-card-subtitle">Chuẩn bị dữ liệu để hệ thống tự động kiểm tra và xin phê duyệt.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">Serial numbers</label>
+                <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+            </div>
+            <div class="scrap-form-grid">
+                <div>
+                    <label for="description-input-1" class="form-label fw-semibold text-uppercase text-muted">Description</label>
+                    <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="description-input" class="form-label">Description</label>
-                        <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
-                    </div>
-                    <div class="mb-2">
-                        <label for="tpye-bp-input" class="form-label">Type Bonepile</label>
-                        <select id="bp-options" class="form-select">
-                            <option selected disabled>SELECT TYPE BONEPILE</option>
-                            <option value="BP-10">BONEPILE 1.0</option>
-                            <option value="BP-20">BONEPILE 2.0</option>
-                            <option value="B36R">AFFTER KANBAN</option>
-                        </select>
-                    </div>
+                <div>
+                    <label for="bp-options" class="form-label fw-semibold text-uppercase text-muted">Type Bonepile</label>
+                    <select id="bp-options" class="form-select">
+                        <option selected disabled>SELECT TYPE BONEPILE</option>
+                        <option value="BP-10">BONEPILE 1.0</option>
+                        <option value="BP-20">BONEPILE 2.0</option>
+                        <option value="B36R">AFTER KANBAN</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="approve-options" class="form-label fw-semibold text-uppercase text-muted">Type approve input</label>
+                    <select id="approve-options" class="form-select">
+                        <option selected disabled>SELECT TYPE APPROVE</option>
+                        <option value="2">Waiting SPE Approve Scrap</option>
+                        <option value="4">Waiting SPE Approve BGA</option>
+                    </select>
+                </div>
+                <div class="scrap-button-group">
                     <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="tpye-approve-input" class="form-label">Type approve input</label>
-                        <select id="approve-options" class="form-select">
-                            <option selected disabled>SELECT TYPE APPROVE</option>
-                            <option value="2">Waiting SPE Approve Scrap</option>
-                            <option value="4">Waiting SPE Approve BGA</option>
-                        </select>
-                    </div>
-                </div>
             </div>
-        </form>
-
-        <!-- Form sn wait approve result -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="SN_WAIT_LIST_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
-                </div>
-            </div>
-        </form>
-    </div>
-</div>
-
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng input sn 1-->
-    <div id="input-sn-1-result" class="hidden"></div>
-    <!--hiển thị của chức năng sn đợi SPE approve-->
-    <div id="sn-wait-approve-result" class="hidden">
-        <div class="table-container">
-            <table id="table-sn-wait-approve" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>SERIAL_NUMBER</th>
-                        <th>DESCRIPTION</th>
-                        <th>CREATE_TIME</th>
-                        <th>APPLY_TASK_STATUS</th>
-                        <th>BONEPILE_TYPE</th>
-                        <th>CREATE_BY</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </div>
+    </form>
 
+    <form id="custom-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="SN_WAIT_LIST_FORM">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Tải danh sách chờ SPE</h3>
+            <p class="scrap-card-subtitle">Xuất file tổng hợp các SN đang chờ phê duyệt.</p>
+        </div>
+        <div class="scrap-button-group">
+            <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
+        </div>
+    </form>
+
+    <div id="input-sn-1-result" class="scrap-card scrap-card--form hidden"></div>
+
+    <div id="sn-wait-approve-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">Danh sách SN chờ SPE approve</h4>
+            <span class="scrap-card-subtitle">Dữ liệu sẽ hiển thị ngay khi tải từ hệ thống.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <div class="table-container"></div>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(3), td:nth-child(3), /* Cột Create Time */
-            th:nth-child(4), td:nth-child(4) { /* Cột Apply Task Status */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description) */
-            th:nth-child(2), td:nth-child(2) { /* Cột Description */
-                white-space: normal; /* Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
-    <script src="~/assets/areas/scrap/js/function1.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/function1.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Home/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Home/Index.cshtml
@@ -1,197 +1,68 @@
-﻿@* File: Index.cshtml *@
-@{
+﻿﻿@{
     ViewData["Title"] = "Scrap Area";
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
 
-<!-- Nội dung trang dashboard -->
-<div class="container">
-    <h1 class="flowchart-title">Apply Task Scrap System Flow</h1>
-    <div class="flowchart-container">
-        <!-- Biểu đồ khối -->
-        <div class="flowchart">
-            <!-- Khối 1: List SN board which NV approved scrap -->
-            <div class="flowchart-box blue-box" data-url="/Scrap/ListSNBoard" style="top: 50px; left: 50px;">
-                List SN board which NV approved scrap
+<div class="scrap-page">
+    <div class="scrap-card scrap-flowchart-card">
+        <div class="scrap-card-header">
+            <h2 class="scrap-card-title">Apply Task Scrap System Flow</h2>
+            <p class="scrap-card-subtitle">Hành trình tự động hoá quy trình xin task phế từ khi NV phê duyệt đến khi chuyển kho MRB.</p>
+        </div>
+        <div class="scrap-table-wrapper">
+            <div class="flowchart-container">
+                <div class="flowchart">
+                    <div class="flowchart-box blue-box" data-url="/Scrap/ListSNBoard" style="top: 50px; left: 50px;">
+                        List SN board which NV approved scrap
+                    </div>
+                    <div class="flowchart-box orange-box" data-url="/Scrap/Function" style="top: 50px; left: 250px;">
+                        Load SN list into system
+                    </div>
+                    <div class="arrow" style="top: 90px; left: 170px; width: 80px;"></div>
+                    <div class="flowchart-box orange-box" data-url="/Scrap/SystemAutoCheck" style="top: 50px; left: 450px; width: 200px;">
+                        System auto check SN list compare with database. Have any SN duplicate or not
+                    </div>
+                    <div class="arrow" style="top: 90px; left: 370px; width: 80px;"></div>
+                    <div class="flowchart-box orange-box" data-url="/Scrap/RejectList" style="top: 50px; left: 800px;">
+                        Reject all list to recheck. Notice which SN duplicate
+                    </div>
+                    <div class="arrow" style="top: 90px; left: 650px; width: 150px;"></div>
+                    <div class="arrow-label" style="top: 60px; left: 670px;">Yes, have SN duplicate</div>
+                    <div class="flowchart-box orange-box" data-url="/Scrap/Function" style="top: 200px; left: 450px; width: 200px;">
+                        System save SN list to database and auto create apply task form (internal task)
+                    </div>
+                    <div class="vertical-arrow" style="top: 130px; left: 550px; height: 70px;"></div>
+                    <div class="arrow-label" style="top: 160px; left: 570px;">No, don’t have SN duplicate</div>
+                    <div class="flowchart-box blue-box" data-url="/Scrap/PMGiveCost" style="top: 200px; left: 200px;">
+                        PM give cost
+                    </div>
+                    <div class="arrow" style="top: 240px; left: 320px; width: 130px; transform: rotate(180deg);"></div>
+                    <div class="arrow-label" style="top: 220px; left: 340px;">SN before kanban</div>
+                    <div class="flowchart-box blue-box" data-url="/Scrap/SubmitTask" style="top: 350px; left: 450px; width: 200px;">
+                        Submit task form to NV to get task no/PO. The system records the SN sent to customers.
+                    </div>
+                    <div class="vertical-arrow" style="top: 280px; left: 550px; height: 70px;"></div>
+                    <div class="arrow-label" style="top: 310px; left: 570px;">SN after kanban</div>
+                    <div class="arrow" style="top: 390px; left: 260px; width: 190px;"></div>
+                    <div class="vertical-arrow" style="top: 280px; left: 260px; height: 105px;"></div>
+                    <div class="flowchart-box orange-box" data-url="/Scrap/Function" style="top: 500px; left: 450px; width: 200px;">
+                        After get task/PO from NV, load task/PO to system record
+                    </div>
+                    <div class="vertical-arrow" style="top: 430px; left: 550px; height: 70px;"></div>
+                    <div class="flowchart-box orange-box" data-url="/Scrap/MoveTaskPOScrapSystem" style="top: 500px; left: 700px;">
+                        Move task/PO to scrap system (FXVQ-FXVZ)
+                    </div>
+                    <div class="arrow" style="top: 540px; left: 650px; width: 50px;"></div>
+                    <div class="flowchart-box blue-box" data-url="/Scrap/MoveScrapStock" style="top: 500px; left: 850px;">
+                        Move to Scrap stock
+                    </div>
+                    <div class="arrow" style="top: 540px; left: 820px; width: 30px;"></div>
+                </div>
             </div>
-
-            <!-- Khối 2: Load SN list into system -->
-            <div class="flowchart-box orange-box" data-url="/Scrap/Function" style="top: 50px; left: 250px;">
-                Load SN list into system
-            </div>
-
-            <!-- Mũi tên từ Khối 1 đến Khối 2 -->
-            <div class="arrow" style="top: 90px; left: 170px; width: 80px;"></div>
-
-            <!-- Khối 3: System auto check SN list -->
-            <div class="flowchart-box orange-box" data-url="/Scrap/SystemAutoCheck" style="top: 50px; left: 450px; width: 200px;">
-                System auto check SN list compare with data base. Have any SN duplicate or not
-            </div>
-
-            <!-- Mũi tên từ Khối 2 đến Khối 3 -->
-            <div class="arrow" style="top: 90px; left: 370px; width: 80px;"></div>
-
-            <!-- Khối 4: Reject all list to recheck -->
-            <div class="flowchart-box orange-box" data-url="/Scrap/RejectList" style="top: 50px; left: 800px;">
-                Reject all list to recheck. Notice which SN duplicate
-            </div>
-
-            <!-- Mũi tên từ Khối 3 đến Khối 4 (Yes, have SN duplicate) -->
-            <div class="arrow" style="top: 90px; left: 650px; width: 150px;"></div>
-            <div class="arrow-label" style="top: 60px; left: 670px;">Yes, have SN duplicate</div>
-
-            <!-- Khối 5: System save SN list to database -->
-            <div class="flowchart-box orange-box" data-url="/Scrap/Function" style="top: 200px; left: 450px; width: 200px;">
-                System save SN list to database and auto create apply task form (internal task)
-            </div>
-
-            <!-- Mũi tên từ Khối 3 đến Khối 5 (No, don’t have SN duplicate) -->
-            <div class="vertical-arrow" style="top: 130px; left: 550px; height: 70px;"></div>
-            <div class="arrow-label" style="top: 160px; left: 570px;">No, don’t have SN duplicate</div>
-
-            <!-- Khối 6: PM give cost -->
-            <div class="flowchart-box blue-box" data-url="/Scrap/PMGiveCost" style="top: 200px; left: 200px;">
-                PM give cost
-            </div>
-
-            <!-- Mũi tên từ Khối 5 đến Khối 6 (SN before kanban) -->
-            <div class="arrow" style="top: 240px; left: 320px; width: 130px; transform: rotate(180deg);"></div>
-            <div class="arrow-label" style="top: 220px; left: 340px;">SN before kanban</div>
-
-            <!-- Khối 7: Submit task form to NV -->
-            <div class="flowchart-box blue-box" data-url="/Scrap/SubmitTask" style="top: 350px; left: 450px; width: 200px;">
-                Submit task form to NV to get task no/PO. The system record the SN sent to customers.
-            </div>
-
-            <!-- Mũi tên từ Khối 5 đến Khối 7 (SN after kanban) -->
-            <div class="vertical-arrow" style="top: 280px; left: 550px; height: 70px;"></div>
-            <div class="arrow-label" style="top: 310px; left: 570px;">SN after kanban</div>
-
-            <!-- Mũi tên từ Khối 6 đến Khối 7 -->
-            <div class="arrow" style="top: 390px; left: 260px; width: 190px;"></div>
-            <div class="vertical-arrow" style="top: 280px; left: 260px; height: 105px;"></div>
-            <!-- Khối 8: After get task/PO from NV -->
-            <div class="flowchart-box orange-box" data-url="/Scrap/Function" style="top: 500px; left: 450px; width: 200px;">
-                After get task/PO from NV, load task/PO to system record
-            </div>
-
-            <!-- Mũi tên từ Khối 7 đến Khối 8 -->
-            <div class="vertical-arrow" style="top: 430px; left: 550px; height: 70px;"></div>
-
-            <!-- Khối 9: Move task/PO to scrap system -->
-            <div class="flowchart-box orange-box" data-url="/Scrap/MoveTaskPOScrapSystem" style="top: 500px; left: 700px;">
-                Move task/PO to scrap system (FXVQ-FXVZ)
-            </div>
-
-            <!-- Mũi tên từ Khối 8 đến Khối 9 -->
-            <div class="arrow" style="top: 540px; left: 650px; width: 50px;"></div>
-
-            <!-- Khối 10: Move to Scrap stock -->
-            <div class="flowchart-box blue-box" data-url="/Scrap/MoveScrapStock" style="top: 500px; left: 850px;">
-                Move to Scrap stock
-            </div>
-
-            <!-- Mũi tên từ Khối 9 đến Khối 10 -->
-            <div class="arrow" style="top: 540px; left: 820px; width: 30px;"></div>
         </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .flowchart-title {
-            text-align: center;
-            font-size: 24px;
-            font-weight: bold;
-            margin-bottom: 20px;
-            color: #003087;
-        }
-
-        .flowchart-container {
-            position: relative;
-            width: 100%;
-            height: 700px;
-            border: 1px solid #ccc;
-            background-color: #f9f9f9;
-            overflow: auto;
-        }
-
-        .flowchart {
-            position: relative;
-            width: 1000px;
-            height: 600px;
-        }
-
-        .flowchart-box {
-            position: absolute;
-            width: 120px;
-            height: 80px;
-            padding: 10px;
-            text-align: center;
-            font-size: 12px;
-            font-family: Arial, sans-serif;
-            border: 1px solid;
-            border-radius: 5px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            box-sizing: border-box;
-        }
-
-            .flowchart-box:hover {
-                filter: drop-shadow(0 0 15px rgba(0, 255, 255, 0.8)) drop-shadow(0 0 30px rgba(0, 255, 255, 0.5));
-                transform: scale(1.05);
-            }
-
-        .blue-box {
-            background-color: #1ba1e2;
-            color: #ffffff;
-            border-color: #006EAF;
-        }
-
-        .orange-box {
-            background-color: #fa6800;
-            color: #000000;
-            border-color: #C73500;
-        }
-
-        .arrow {
-            position: absolute;
-            height: 2px;
-            background-color: #000;
-        }
-
-            .arrow::after {
-                content: '';
-                position: absolute;
-                right: -10px;
-                top: -5px;
-                border: 5px solid transparent;
-                border-left-color: #000;
-            }
-
-        .vertical-arrow {
-            position: absolute;
-            width: 2px;
-            background-color: #000;
-        }
-
-            .vertical-arrow::after {
-                content: '';
-                position: absolute;
-                bottom: -10px;
-                left: -4px;
-                border: 5px solid transparent;
-                border-top-color: #000;
-            }
-
-        .arrow-label {
-            position: absolute;
-            font-size: 11px;
-            color: #000;
-        }
-    </style>
-    <script src="~/assets/areas/scrap/js/dashboard.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/dashboard.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/MRB/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/MRB/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+﻿﻿@{
     ViewData["Title"] = "Chuyển kho MRB";
 }
 @{
@@ -8,10 +8,14 @@
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
 
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
+<div class="scrap-page">
+    <div class="scrap-card scrap-card--selector">
+        <div class="scrap-card-header">
+            <h2 class="scrap-card-title">MRB transfer control</h2>
+            <p class="scrap-card-subtitle">Theo dõi và điều phối các bước chuyển kho phế sang MRB.</p>
+        </div>
+        <form id="search-form" class="scrap-selector">
+            <label for="search-mrb-options">Select function</label>
             <select id="search-mrb-options" class="form-select">
                 <option selected disabled>SELECT FUNCTION</option>
                 <option value="5">Chờ RE chuyển MRB</option>
@@ -21,144 +25,107 @@
         </form>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form Chờ RE chuyển MRB -->
-        <form id="wait-re-move-mrb" method="post" class="hidden" data-search-type="wait-re-move-mrb">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    @{
-                        var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
-                        .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-                        var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
-                    }
-                    @if (Scrap)
-                    {
-                        <button id="move-mrb-btn" class="btn btn-ne" type="button">Move MRB</button>
-                    }else
-                    {
-                        <button id="move-mrb-btn" class="btn btn-ne hidden" type="button">Move MRB</button>
-                    }
-                </div>
-            </div>
-        </form>
+    <form id="wait-re-move-mrb" method="post" class="scrap-card scrap-card--form hidden" data-search-type="wait-re-move-mrb">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Chờ RE chuyển MRB</h3>
+            <p class="scrap-card-subtitle">Danh sách task đã có số nhưng đang chờ chuyển kho phế.</p>
+        </div>
+        <div class="scrap-button-group">
+            @{
+                var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
+                    .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
+            }
+            <button id="move-mrb-btn" class="btn btn-ne @(Scrap ? string.Empty : "hidden")" type="button">Move MRB</button>
+        </div>
+    </form>
 
-        <!-- Form Chờ kho MRB xác nhận -->
-        <form id="wait-mrb-confirm" method="post" class="hidden" data-search-type="wait-mrb-confirm">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    
-                    @{
-                        var allowedAreas1 = HttpContextAccessor.HttpContext.User.Claims
-                        .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-                        var Mrb = allowedAreas1 != null && allowedAreas1.Any(area => area.Trim() == "Mrb");
-                    }
-                    @if (Mrb)
-                    {
-                        <button id="confirm-mrb-btn" class="btn btn-ne" type="button">Confirm</button>
-                    }else
-                    {
-                        <button id="confirm-mrb-btn" class="btn btn-ne hidden" type="button">Confirm</button>
-                    }
-                </div>
-            </div>
-        </form>
+    <form id="wait-mrb-confirm" method="post" class="scrap-card scrap-card--form hidden" data-search-type="wait-mrb-confirm">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Chờ kho MRB xác nhận</h3>
+            <p class="scrap-card-subtitle">Danh sách task đã chuyển kho phế và chờ MRB xác nhận.</p>
+        </div>
+        <div class="scrap-button-group">
+            @{
+                var allowedAreas1 = HttpContextAccessor.HttpContext.User.Claims
+                    .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                var Mrb = allowedAreas1 != null && allowedAreas1.Any(area => area.Trim() == "Mrb");
+            }
+            <button id="confirm-mrb-btn" class="btn btn-ne @(Mrb ? string.Empty : "hidden")" type="button">Confirm</button>
+        </div>
+    </form>
 
-        <!-- Form Đã vào kho MRB -->
-        <form id="moved-mrb-form" method="post" class="hidden" data-search-type="moved-mrb">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <button id="moved-mrb-btn" class="btn btn-ne" type="button">Load data</button>
-                </div>
-            </div>
-        </form>
-    </div>
-</div>
+    <form id="moved-mrb-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="moved-mrb">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Đã vào kho MRB</h3>
+            <p class="scrap-card-subtitle">Danh sách task đã hoàn tất chuyển kho phế.</p>
+        </div>
+        <div class="scrap-button-group">
+            <button id="moved-mrb-btn" class="btn btn-ne" type="button">Load data</button>
+        </div>
+    </form>
 
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng Chờ RE chuyển MRB-->
-    <div id="wait-re-move-mrb-result" class="hidden">
-        <table id="wait-re-move-mrb-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-5"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+    <div id="wait-re-move-mrb-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">Chờ RE chuyển MRB</h4>
+            <span class="scrap-card-subtitle">Kiểm tra task trước khi chuyển kho phế.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <table id="wait-re-move-mrb-table" class="table table-hover align-middle scrap-table datatable-table">
+                <thead>
+                    <tr>
+                        <th class="checkbox-column"><input type="checkbox" id="select-all-5"></th>
+                        <th>Task Number</th>
+                        <th>Apply Time</th>
+                        <th>Total Qty</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
     </div>
-    <!--hiển thị của chức năng Chờ kho MRB xác nhận-->
-    <div id="wait-mrb-confirm-result" class="hidden">
-        <table id="wait-mrb-confirm-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-6"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+
+    <div id="wait-mrb-confirm-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">Chờ kho MRB xác nhận</h4>
+            <span class="scrap-card-subtitle">Theo dõi trạng thái chuyển kho phế đã gửi tới MRB.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <table id="wait-mrb-confirm-table" class="table table-hover align-middle scrap-table datatable-table">
+                <thead>
+                    <tr>
+                        <th class="checkbox-column"><input type="checkbox" id="select-all-6"></th>
+                        <th>Task Number</th>
+                        <th>Apply Time</th>
+                        <th>Total Qty</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
     </div>
-    <!--hiển thị của chức năng Đã vào kho MRB-->
-    <div id="moved-mrb-form-result" class="hidden">
-        <table id="moved-mrb-form-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-7"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+
+    <div id="moved-mrb-form-result" class="scrap-card scrap-table-card hidden">
+        <div class="scrap-table-header">
+            <h4 class="scrap-card-title mb-0">Đã vào kho MRB</h4>
+            <span class="scrap-card-subtitle">Danh sách task đã được MRB xác nhận.</span>
+        </div>
+        <div class="scrap-table-wrapper">
+            <table id="moved-mrb-form-table" class="table table-hover align-middle scrap-table datatable-table">
+                <thead>
+                    <tr>
+                        <th class="checkbox-column"><input type="checkbox" id="select-all-7"></th>
+                        <th>Task Number</th>
+                        <th>Apply Time</th>
+                        <th>Total Qty</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important; /* Đảm bảo ẩn hoàn toàn */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 20px!important; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center !important;
-        }
-        /* Giới hạn độ rộng cột */
-        #task-checkbox-table th, #task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            max-width: 80px!important; /* Giới hạn độ rộng cột */
-        }
-
-        /* Giới hạn độ rộng cột */
-        #history-task-checkbox-table th, #history-task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            max-width: 80px!important; /* Giới hạn độ rộng cột */
-        }
-        #history-task-checkbox-table td, #task-checkbox-table td{
-            background-color:#fff;
-        }
-
-         /* Thêm hiệu ứng hover cho hàng */
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76b900 !important;
-            /*transition: background-color 0.2s ease;*/
-        }
-    </style>
-    <script src="~/assets/areas/scrap/js/mrb.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/mrb.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
@@ -8,232 +8,97 @@
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
 
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-2">
-        <form id="search-form" class="form-inline">
+<div class="scrap-page">
+    <div class="scrap-card scrap-card--selector">
+        <div class="scrap-card-header">
+            <h2 class="scrap-card-title">Scrap progress center</h2>
+            <p class="scrap-card-subtitle">Theo dõi tiến độ xin task, kiểm tra tồn kho phế hàng quý và tra cứu lịch sử xử lý.</p>
+        </div>
+        <form id="search-form" class="scrap-selector">
+            <label for="search-options">Select function</label>
             <select id="search-options" class="form-select">
                 <option selected disabled>SELECT FUNCTION</option>
-                <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
-                <!--<option value="UPDATE_STATUS">UPDATE STATUS</option>-->
+                <option value="TASK_STOCK_STATUS">Checking scrap quarterly</option>
                 <option value="SEARCH_STATUS">Tìm kiếm</option>
                 <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
             </select>
         </form>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-10">
+    <form id="task-stock-status-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="TASK_STOCK_STATUS_FORM">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Kiểm tra tồn kho phế hàng quý</h3>
+            <p class="scrap-card-subtitle">Lấy danh sách Internal Task chưa hoàn tất chuyển kho phế và xuất báo cáo tổng hợp.</p>
+        </div>
+        <div class="scrap-button-group">
+            <button id="task-stock-status-btn" class="btn btn-ne" type="button">Detail</button>
+        </div>
+    </form>
 
-        <!-- Form Checking scrap quaterly -->
-        <form id="task-stock-status-form" method="post" class="hidden" data-search-type="TASK_STOCK_STATUS_FORM">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-2">
-                    <button id="task-stock-status-btn" class="btn btn-ne" type="button">Detail</button>
+    <form id="search-status-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="SEARCH_STATUS">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Tra cứu trạng thái theo SN / Task</h3>
+            <p class="scrap-card-subtitle">Nhập danh sách SN, Internal Task hoặc Task NV để xem tiến trình xử lý.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">SN / Internal task</label>
+                <textarea name="SN/TASK" id="search-status-update" class="form-control" rows="8" placeholder="Nhập SN hoặc Internal Task"></textarea>
+            </div>
+            <div class="scrap-form-grid">
+                <div>
+                    <label for="search-status-options" class="form-label fw-semibold text-uppercase text-muted">Hình thức tìm kiếm</label>
+                    <select id="search-status-options" class="form-select">
+                        <option selected disabled>SELECT STATUS</option>
+                        <option value="1">Tìm kiếm theo SN</option>
+                        <option value="2">Tìm kiếm theo Internal Task</option>
+                        <option value="3">Tìm kiếm theo Task NV</option>
+                    </select>
+                </div>
+                <div class="scrap-button-group">
+                    <button id="search-status-btn" class="btn btn-ne" type="button">Search</button>
+                    <button id="load-status-btn" class="btn btn-ne" type="button">Load List</button>
                 </div>
             </div>
-        </form>
-
-        <!-- Form UPDATE STATUS 
-        <form id="update-status-form" method="post" class="hidden" data-search-type="UPDATE_STATUS">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-status-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
-                </div>
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="status-input" class="form-label">Update trạng thái</label>
-                        <select id="status-options" class="form-select">
-                            <option selected disabled>SELECT STATUS</option>
-                            <option value="1">Đã tìm thấy bản</option>
-                            <option value="2">Đã chuyển kho phế</option>
-                        </select>
-                    </div>
-                    
-
-                    <div>
-                        @{
-                            var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
-                            .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-
-                            var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
-                            
-                        }
-                        @if (Scrap)
-                        {
-                            <button id="update-status-btn" class="md-2 btn btn-ne" type="button">Update</button>
-                        }else
-                        {
-                            <button id="update-status-btn" class="md-2 btn btn-ne hidden" type="button">Update</button>
-                        }
-                    </div>
+            <div class="scrap-card-subtitle">
+                <strong class="d-block mb-2">Quy ước trạng thái</strong>
+                <div class="scrap-pill-list">
+                    <span>0. Phế, chưa gửi xin task</span>
+                    <span>1. Phế, đã gửi xin task nhưng chưa có</span>
+                    <span>2. Chờ SPE approved phế</span>
+                    <span>3. Đã approved thay BGA</span>
+                    <span>4. Chờ approved thay BGA</span>
+                    <span>5. Đã có task, chờ chuyển kho phế</span>
+                    <span>6. Đã chuyển kho phế, chờ MRB xác nhận</span>
+                    <span>7. MRB đã nhận bản phế</span>
+                    <span>8. Lỗi process, không thể sửa chữa</span>
                 </div>
             </div>
-        </form>-->
+        </div>
+    </form>
 
-        <!-- Form SEARCH STATUS -->
-        <form id="search-status-form" method="post" class="hidden" data-search-type="SEARCH_STATUS">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="SN/TASK" id="search-status-update" class="form-control" rows="8" placeholder="Nhập SN/Internal Task"></textarea>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="SNTASK-input" class="form-label">Tìm kiếm trạng thái</label>
-                        <select id="search-status-options" class="form-select">
-                            <option selected disabled>SELECT STATUS</option>
-                            <option value="1">Tìm kiếm theo SN</option>
-                            <option value="2">Tìm kiếm theo Internal Task</option>
-                            <option value="3">Tìm kiếm theo Task NV</option>
-                        </select>
-                    </div>
-                    <button id="search-status-btn" class="md-2 btn btn-ne" type="button">Search</button>
-                    <button id="load-status-btn" class="md-2 btn btn-ne" type="button">Load List</button>
-                </div>
-                <div class="col-md-2">
-                    <div>ApplyTaskStatus</div>
-                    <div>0. Phế, chưa gửi xin task</div>
-                    <div>1. Phế, đã gửi xin task nhưng chưa có</div>
-                    <div>2. Chờ SPE approved phế</div>
-                    <div>3. Đã approved thay BGA</div>
-                    
-                </div>
-                <div class="col-md-2">
-                    <div>4. Chờ approved thay BGA</div>
-                    <div>5. Đã có task, chờ chuyển kho phế</div>
-                    <div>6. Đã chuyển kho phế chờ MRB xác nhận</div>
-                    <div>7. MRB đã nhận bản phế</div>
-                    <div>8. Lỗi process, không thể sửa chữa</div>
-                </div>
+    <form id="search-history-form" method="post" class="scrap-card scrap-card--form hidden" data-search-type="SEARCH_HISTORY">
+        <div class="scrap-card-header">
+            <h3 class="scrap-card-title">Tra cứu lịch sử xử lý SN</h3>
+            <p class="scrap-card-subtitle">Xem lại toàn bộ hành trình thay đổi trạng thái từ bảng HistoryScrapList.</p>
+        </div>
+        <div class="scrap-form-grid two-column">
+            <div>
+                <label class="form-label fw-semibold text-uppercase text-muted">Danh sách SN</label>
+                <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
             </div>
-        </form>
-
-        <!-- Form SEARCH HISTORY -->
-        <form id="search-history-form" method="post" class="hidden" data-search-type="SEARCH_HISTORY">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label class="form-label">Tra cứu lịch sử SN</label>
-                        <p class="form-text">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</p>
-                    </div>
-                    <button id="history-search-btn" class="md-2 btn btn-ne" type="button">Search history</button>
-                    <button id="history-download-btn" class="md-2 btn btn-ne" type="button">Download Excel</button>
-                </div>
+            <div class="scrap-button-group align-self-end">
+                <button id="history-search-btn" class="btn btn-ne" type="button">Search history</button>
+                <button id="history-download-btn" class="btn btn-ne" type="button">Download Excel</button>
             </div>
-        </form>
-    </div>
-</div>
+        </div>
+    </form>
 
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng create task-->
-    <div id="task-stock-status-result" class="hidden"></div>
-    <!--hiển thị của chức năng update data
-    <div id="update-status-result" class="hidden"></div>-->
-    <!--hiển thị của chức năng search data-->
-    <div id="search-status-result" class="hidden"></div>
-    <!--hiển thị của chức năng history search-->
-    <div id="history-search-result" class="hidden"></div>
+    <div id="task-stock-status-result" class="scrap-card scrap-table-card hidden"></div>
+    <div id="search-status-result" class="scrap-card scrap-table-card hidden"></div>
+    <div id="history-search-result" class="scrap-card scrap-table-card hidden"></div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(9), td:nth-child(9), /* Cột Cost */
-            th:nth-child(13), td:nth-child(13), /* Cột Create Time */
-            th:nth-child(14), td:nth-child(14) { /* Cột Apply Time */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description, Remark) */
-            th:nth-child(1), td:nth-child(1), /* Cột internal task */
-            th:nth-child(2), td:nth-child(2), /* Cột internal task */
-            th:nth-child(3), td:nth-child(3), /* Cột Description */
-            th:nth-child(10), td:nth-child(10) { /* Cột Remark */
-                /*white-space: normal; * Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
-    <script src="~/assets/areas/scrap/js/progress.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/progress.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Shared/Layout_scrap.cshtml
+++ b/PESystem/Areas/Scrap/Views/Shared/Layout_scrap.cshtml
@@ -11,10 +11,11 @@
     <link href="~/lib/datatable/style.css" rel="stylesheet" />
     <link href="~/lib/datatable/jquery.datatables.min.css" rel="stylesheet" />
     <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="~/assets/Areas/Scrap/css/scrap-theme.css" rel="stylesheet" asp-append-version="true" />
     <script src="~/lib/gsap-particles/particles.min.js"></script>
     <script src="~/lib/gsap-particles/gsap.min.js"></script>
 </head>
-<body>
+<body class="scrap-layout">
     <script>
         (function () {
             const isSidebarFixed = localStorage.getItem('isSidebarFixed') === 'true';
@@ -41,16 +42,20 @@
             }
         })();
     </script>
-    <header class="header d-flex justify-content-between align-items-center" id="header">
-        <div class="d-flex align-items-center">
-            <span class="input-group-text bg-transparent border-0" onclick="toggleSearch()">
-                <i class="fas" style="cursor: pointer;"></i>
+    <header class="header scrap-header d-flex justify-content-between align-items-center" id="header">
+        <div class="d-flex align-items-center gap-3">
+            <span class="input-group-text bg-transparent border-0 shadow-none" onclick="toggleSearch()">
+                <i class="fas fa-magnifying-glass" style="cursor: pointer;"></i>
             </span>
             <div class="search-container" id="searchContainer">
                 <input type="text" class="form-control" placeholder="Search...">
             </div>
+            <div class="d-none d-md-flex flex-column">
+                <span class="fw-semibold text-uppercase text-muted" style="letter-spacing:0.08em; font-size:0.75rem;">Scrap workspace</span>
+                <span class="fw-bold" style="font-size:1rem; color:#1d4ed8;">Operations Control Center</span>
+            </div>
         </div>
-        <ul class="d-flex align-items-center">
+        <ul class="d-flex align-items-center mb-0">
             @if (User.Identity.IsAuthenticated)
             {
                 <li class="nav-item dropdown">
@@ -63,7 +68,7 @@
         </ul>
     </header>
     <!-- Sidebar dọc -->
-    <div id="sidebar" class="sidebar">
+    <div id="sidebar" class="sidebar scrap-sidebar">
         <!-- Logo and Dashboard with fixed checkbox -->
         <div class="dashboard-container">
             <a href="@Url.Action("Home", "Home", new { area = "" })">
@@ -117,7 +122,7 @@
 
 
 
-    <main id="mainContent">
+    <main id="mainContent" class="scrap-main">
         <!--SPINER-->
         <div id="spinner-overlay">
             <span class="loader"></span>

--- a/PESystem/wwwroot/assets/Areas/Scrap/css/scrap-theme.css
+++ b/PESystem/wwwroot/assets/Areas/Scrap/css/scrap-theme.css
@@ -1,0 +1,499 @@
+:root {
+    --scrap-primary: #2563eb;
+    --scrap-primary-dark: #1d4ed8;
+    --scrap-secondary: #0ea5e9;
+    --scrap-accent: #f97316;
+    --scrap-surface: rgba(255, 255, 255, 0.86);
+    --scrap-surface-strong: rgba(255, 255, 255, 0.95);
+    --scrap-border: rgba(15, 23, 42, 0.08);
+    --scrap-text: #0f172a;
+    --scrap-muted: #64748b;
+    --scrap-success: #22c55e;
+    --scrap-shadow: 0 30px 80px rgba(15, 23, 42, 0.25);
+}
+
+.scrap-layout {
+    font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    background: radial-gradient(circle at top left, rgba(14, 165, 233, 0.25), transparent 45%),
+        radial-gradient(circle at bottom right, rgba(99, 102, 241, 0.25), transparent 40%),
+        #0f172a;
+    color: var(--scrap-text);
+    min-height: 100vh;
+    position: relative;
+}
+
+.scrap-layout::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.06), transparent 50%),
+        radial-gradient(circle at 80% 10%, rgba(14, 165, 233, 0.08), transparent 55%),
+        radial-gradient(circle at 50% 80%, rgba(99, 102, 241, 0.12), transparent 60%);
+    pointer-events: none;
+    z-index: -1;
+}
+
+.scrap-header {
+    background: var(--scrap-surface-strong);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--scrap-border);
+    padding: 0.85rem 2rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+    border-radius: 0 0 24px 24px;
+}
+
+.scrap-header .search-container input {
+    background: rgba(241, 245, 249, 0.9);
+    border: none;
+    border-radius: 999px;
+    padding: 0.55rem 1.5rem;
+    transition: all 0.3s ease;
+    min-width: 220px;
+}
+
+.scrap-header .search-container input:focus {
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.scrap-layout .avatar-link {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.08));
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    color: var(--scrap-text);
+    font-weight: 500;
+}
+
+.scrap-layout .avatar-link span {
+    color: var(--scrap-text);
+    font-weight: 600;
+}
+
+#sidebar.scrap-sidebar {
+    background: linear-gradient(200deg, rgba(15, 23, 42, 0.92), rgba(30, 64, 175, 0.88));
+    backdrop-filter: blur(18px);
+    border-right: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 20px 0 50px rgba(15, 23, 42, 0.35);
+}
+
+.scrap-sidebar .dashboard-container {
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    padding-bottom: 1rem;
+}
+
+.scrap-sidebar .nav-link {
+    color: rgba(226, 232, 240, 0.82);
+    font-weight: 500;
+    border-radius: 12px;
+    margin: 0.35rem 0.75rem;
+    padding: 0.65rem 0.9rem;
+    transition: all 0.25s ease;
+}
+
+.scrap-sidebar .nav-link i {
+    width: 22px;
+    text-align: center;
+}
+
+.scrap-sidebar .nav-link:hover,
+.scrap-sidebar .nav-link.active,
+.scrap-sidebar .nav-link:focus {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(14, 165, 233, 0.35));
+    color: #fff;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+#mainContent.scrap-main {
+    padding: 2.5rem;
+    min-height: 100vh;
+}
+
+.scrap-page {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.scrap-card {
+    background: var(--scrap-surface);
+    border-radius: 24px;
+    border: 1px solid var(--scrap-border);
+    box-shadow: var(--scrap-shadow);
+    padding: 1.5rem 1.75rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.scrap-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(140deg, rgba(37, 99, 235, 0.16), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+}
+
+.scrap-card:hover::before {
+    opacity: 1;
+}
+
+.scrap-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+}
+
+.scrap-card-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--scrap-text);
+    margin: 0;
+}
+
+.scrap-card-subtitle {
+    margin: 0;
+    color: var(--scrap-muted);
+    font-size: 0.95rem;
+}
+
+.scrap-card--selector {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.scrap-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.scrap-selector label {
+    font-weight: 600;
+    color: var(--scrap-text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+}
+
+.scrap-selector .form-select {
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 0.8rem 1rem;
+    font-weight: 600;
+    color: var(--scrap-text);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.scrap-form-grid {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.scrap-form-grid.two-column {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.scrap-form-grid textarea,
+.scrap-form-grid input,
+.scrap-form-grid select {
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 0.85rem 1rem;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+    transition: all 0.3s ease;
+}
+
+.scrap-form-grid textarea:focus,
+.scrap-form-grid input:focus,
+.scrap-form-grid select:focus {
+    border-color: rgba(37, 99, 235, 0.35);
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.scrap-form-grid textarea {
+    min-height: 210px;
+    resize: vertical;
+}
+
+.scrap-button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.scrap-card-note {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--scrap-muted);
+}
+
+.scrap-table-card {
+    padding: 0;
+}
+
+.scrap-table-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.75rem 0.75rem;
+    border-bottom: 1px solid var(--scrap-border);
+}
+
+.scrap-table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+    padding: 1.25rem 1.75rem 1.75rem;
+}
+
+.scrap-card .table-container {
+    width: 100%;
+    overflow-x: auto;
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+}
+
+.scrap-card .table-container table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 780px;
+}
+
+.scrap-card .table-container thead th {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(14, 165, 233, 0.85));
+    color: #fff;
+    padding: 0.65rem 0.85rem;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.scrap-card .table-container tbody td {
+    padding: 0.65rem 0.85rem;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+    color: var(--scrap-text);
+    white-space: nowrap;
+}
+
+.scrap-card .table-container tbody tr:hover td {
+    background: rgba(14, 165, 233, 0.12);
+}
+
+.scrap-card .pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.scrap-card .pagination button {
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(14, 165, 233, 0.85));
+    color: #fff;
+    padding: 0.45rem 1rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.25);
+}
+
+.scrap-card .pagination button:disabled {
+    background: rgba(148, 163, 184, 0.5);
+    box-shadow: none;
+}
+
+.scrap-table {
+    width: 100%;
+    min-width: 960px;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: transparent;
+}
+
+.scrap-table thead th {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(14, 165, 233, 0.85));
+    color: #fff;
+    border: none;
+    padding: 0.75rem 1rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.scrap-table tbody tr {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.scrap-table tbody td {
+    background: rgba(255, 255, 255, 0.92);
+    border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+    padding: 0.75rem 1rem;
+    color: var(--scrap-text);
+    vertical-align: middle;
+}
+
+.scrap-table tbody tr:hover td {
+    background: rgba(14, 165, 233, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.15);
+}
+
+.scrap-table .checkbox-column {
+    width: 48px;
+    text-align: center;
+}
+
+.scrap-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--scrap-primary-dark);
+}
+
+.scrap-pill-list {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+}
+
+.scrap-pill-list span {
+    color: var(--scrap-muted);
+    padding-left: 1.25rem;
+    position: relative;
+}
+
+.scrap-pill-list span::before {
+    content: '\2022';
+    position: absolute;
+    left: 0.35rem;
+    color: rgba(37, 99, 235, 0.65);
+}
+
+.scrap-flowchart-card {
+    padding: 0;
+}
+
+.scrap-flowchart-card .scrap-card-header {
+    padding: 1.75rem 1.75rem 0;
+}
+
+.scrap-flowchart-card .flowchart-container {
+    border: none;
+    background: rgba(15, 23, 42, 0.65);
+    border-radius: 24px;
+    padding: 1.5rem;
+    color: #e2e8f0;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+.scrap-flowchart-card .flowchart-box {
+    border-radius: 18px;
+    padding: 12px;
+    font-weight: 600;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+}
+
+.scrap-flowchart-card .blue-box {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(129, 140, 248, 0.85));
+    color: #fff;
+}
+
+.scrap-flowchart-card .orange-box {
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.9), rgba(244, 63, 94, 0.85));
+    color: #fff;
+}
+
+.scrap-flowchart-card .arrow,
+.scrap-flowchart-card .vertical-arrow {
+    background-color: rgba(226, 232, 240, 0.75);
+}
+
+.scrap-flowchart-card .arrow::after,
+.scrap-flowchart-card .vertical-arrow::after {
+    border-left-color: rgba(226, 232, 240, 0.9);
+    border-top-color: rgba(226, 232, 240, 0.9);
+}
+
+.scrap-flowchart-card .arrow-label {
+    color: rgba(241, 245, 249, 0.88);
+    font-weight: 500;
+}
+
+.btn-ne {
+    background: linear-gradient(135deg, var(--scrap-primary), var(--scrap-secondary));
+    border: none;
+    color: #fff !important;
+    font-weight: 600;
+    padding: 0.65rem 1.5rem;
+    border-radius: 14px;
+    box-shadow: 0 12px 30px rgba(37, 99, 235, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-ne:hover,
+.btn-ne:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 38px rgba(14, 165, 233, 0.35);
+    color: #fff;
+}
+
+.hidden {
+    display: none !important;
+}
+
+@media (max-width: 1200px) {
+    #mainContent.scrap-main {
+        padding: 2rem 1.5rem 2.5rem;
+    }
+
+    .scrap-card {
+        border-radius: 18px;
+        padding: 1.35rem 1.5rem;
+    }
+
+    .scrap-table {
+        min-width: 840px;
+    }
+}
+
+@media (max-width: 992px) {
+    .scrap-header {
+        padding: 0.75rem 1.25rem;
+    }
+
+    .scrap-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .scrap-form-grid.two-column {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 576px) {
+    #mainContent.scrap-main {
+        padding: 1.5rem 1rem 2rem;
+    }
+
+    .scrap-card {
+        padding: 1.15rem 1.25rem;
+    }
+
+    .scrap-table-wrapper {
+        padding: 1rem 1.25rem 1.25rem;
+    }
+}

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
@@ -205,6 +205,7 @@ function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
                 <td data-bs-toggle="tooltip" data-bs-title="${item.approveScrapPerson || 'N/A'}">${item.approveScrapPerson || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.kanBanStatus || 'N/A'}">${item.kanBanStatus || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.category || 'N/A'}">${item.category || "N/A"}</td>
+                ${checkboxName === "history-task-checkbox" ? "" : `<td data-bs-toggle=\"tooltip\" data-bs-title=\"${item.purpose || 'N/A'}\">${item.purpose || "N/A"}</td>`}
                 <td data-bs-toggle="tooltip" data-bs-title="${item.remark || 'N/A'}">${item.remark || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.createTime || 'N/A'}">${item.createTime || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.createBy || 'N/A'}">${item.createBy || "N/A"}</td>

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function0.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function0.js
@@ -32,6 +32,16 @@ function hideAllElements() {
 // Ẩn tất cả các form và khu vực kết quả ngay lập tức khi trang tải
 hideAllElements();
 
+function setResultContent(resultDiv, html) {
+    if (!resultDiv) return;
+    const container = resultDiv.querySelector('.table-container');
+    if (container) {
+        container.innerHTML = html;
+    } else {
+        resultDiv.innerHTML = html;
+    }
+}
+
 /** 🔥 Lấy currentUsername từ thẻ HTML */
 function getCurrentUsername() {
     const usernameElement = document.querySelector(".d-none.d-md-block.ps-2");
@@ -41,11 +51,11 @@ function getCurrentUsername() {
 // Hàm hiển thị bảng với phân trang
 function displayTableWithPagination(data, resultDiv, itemsPerPage = 10) {
     if (!data || data.length === 0) {
-        resultDiv.innerHTML = `
+        setResultContent(resultDiv, `
             <div class="alert alert-warning">
                 <strong>Cảnh báo:</strong> Không tìm thấy dữ liệu với ApplyTaskStatus = 8.
             </div>
-        `;
+        `);
         return;
     }
 
@@ -105,7 +115,7 @@ function displayTableWithPagination(data, resultDiv, itemsPerPage = 10) {
             `;
         }
 
-        resultDiv.innerHTML = tableHTML;
+        setResultContent(resultDiv, tableHTML);
 
         // Gắn sự kiện cho nút Previous và Next
         if (totalPages > 1) {
@@ -133,11 +143,11 @@ function displayTableWithPagination(data, resultDiv, itemsPerPage = 10) {
 
 // Hàm tải dữ liệu từ API và hiển thị
 async function loadScrapStatusTwo(resultDiv) {
-    resultDiv.innerHTML = `
+    setResultContent(resultDiv, `
         <div class="alert alert-info">
             <strong>Thông báo:</strong> Đang tải danh sách SN lỗi process không thể sửa chữa...
         </div>
-    `;
+    `);
 
     try {
         const response = await fetch("http://10.220.130.119:9090/api/Scrap/get-scrap-status-eight", {
@@ -152,18 +162,18 @@ async function loadScrapStatusTwo(resultDiv) {
         if (response.ok) {
             displayTableWithPagination(result, resultDiv);
         } else {
-            resultDiv.innerHTML = `
+            setResultContent(resultDiv, `
                 <div class="alert alert-danger">
                     <strong>Lỗi:</strong> ${result.message || 'Không thể tải dữ liệu.'}
                 </div>
-            `;
+            `);
         }
     } catch (error) {
-        resultDiv.innerHTML = `
+        setResultContent(resultDiv, `
             <div class="alert alert-danger">
                 <strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.
             </div>
-        `;
+        `);
         console.error("Error:", error);
     }
 }
@@ -235,29 +245,29 @@ document.addEventListener("DOMContentLoaded", function () {
 
             // Kiểm tra dữ liệu đầu vào
             if (!sNs.length) {
-                resultDiv.innerHTML = `
+                setResultContent(resultDiv, `
                     <div class="alert alert-warning">
                         <strong>Cảnh báo:</strong> Vui lòng nhập ít nhất một Serial Number hợp lệ!
                     </div>
-                `;
+                `);
                 return;
             }
 
             if (!createdBy) {
-                resultDiv.innerHTML = `
+                setResultContent(resultDiv, `
                     <div class="alert alert-warning">
                         <strong>Cảnh báo:</strong> Không thể lấy thông tin người dùng. Vui lòng đăng nhập lại.
                     </div>
-                `;
+                `);
                 return;
             }
 
             // Hiển thị thông báo "đang xử lý"
-            resultDiv.innerHTML = `
+            setResultContent(resultDiv, `
                 <div class="alert alert-info">
                     <strong>Thông báo:</strong> Đang lưu danh sách SN...
                 </div>
-            `;
+            `);
 
             try {
                 // Gọi API process-can-not-repair
@@ -295,40 +305,40 @@ document.addEventListener("DOMContentLoaded", function () {
 
                     if (updateResponse.ok) {
                         // Cả hai thành công
-                        resultDiv.innerHTML = `
+                        setResultContent(resultDiv, `
                             <div class="alert alert-success">
                                 <strong>Thành công:</strong> ${inputSnResult.message}
                             </div>
-                        `;
+                        `);
                     } else {
                         console.warn("UpdateScrap API failed:", updateResult);
-                        resultDiv.innerHTML = `
+                        setResultContent(resultDiv, `
                             <div class="alert alert-warning">
                                 <strong>Cảnh báo:</strong> Gọi API UpdateScrap thất bại: ${updateResult.message || 'Lỗi không xác định'}
                             </div>
-                        `;
+                        `);
                     }
 
                     // Chỉ process-can-not-repair thành công
-                    resultDiv.innerHTML = `
+                    setResultContent(resultDiv, `
                         <div class="alert alert-success">
                             <strong>Thành công:</strong> ${inputSnResult.message}
                         </div>
-                    `;
+                    `);
                 } else {
                     console.warn("process-can-not-repair API failed:", inputSnResult);
-                    resultDiv.innerHTML = `
+                    setResultContent(resultDiv, `
                         <div class="alert alert-warning">
                             <strong>Cảnh báo:</strong> Gọi API process-can-not-repair thất bại: ${inputSnResult.message || 'Lỗi không xác định'}
                         </div>
-                    `;
+                    `);
                 }
             } catch (error) {
-                resultDiv.innerHTML = `
+                setResultContent(resultDiv, `
                     <div class="alert alert-danger">
                         <strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.
                     </div>
-                `;
+                `);
                 console.error("Error:", error);
             }
         });
@@ -355,18 +365,18 @@ document.addEventListener("DOMContentLoaded", function () {
                     // Tải file Excel
                     downloadExcel(result);
                 } else {
-                    resultDiv.innerHTML = `
+                    setResultContent(resultDiv, `
                         <div class="alert alert-warning">
                             <strong>Cảnh báo:</strong> Không có dữ liệu để tải xuống.
                         </div>
-                    `;
+                    `);
                 }
             } catch (error) {
-                resultDiv.innerHTML = `
+                setResultContent(resultDiv, `
                     <div class="alert alert-danger">
                         <strong>Lỗi:</strong> Không thể tải dữ liệu để tạo file Excel.
                     </div>
-                `;
+                `);
                 console.error("Error:", error);
             }
         });

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function1.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function1.js
@@ -32,6 +32,16 @@ function hideAllElements() {
 // Ẩn tất cả các form và khu vực kết quả ngay lập tức khi trang tải
 hideAllElements();
 
+function setResultContent(resultDiv, html) {
+    if (!resultDiv) return;
+    const container = resultDiv.querySelector('.table-container');
+    if (container) {
+        container.innerHTML = html;
+    } else {
+        resultDiv.innerHTML = html;
+    }
+}
+
 /** 🔥 Lấy currentUsername từ thẻ HTML */
 function getCurrentUsername() {
     const usernameElement = document.querySelector(".d-none.d-md-block.ps-2");
@@ -41,11 +51,11 @@ function getCurrentUsername() {
 // Hàm hiển thị bảng với phân trang
 function displayTableWithPagination(data, resultDiv, itemsPerPage = 10) {
     if (!data || data.length === 0) {
-        resultDiv.innerHTML = `
+        setResultContent(resultDiv, `
             <div class="alert alert-warning">
-                <strong>Cảnh báo:</strong> Không tìm thấy dữ liệu với ApplyTaskStatus = 2.
+                <strong>Cảnh báo:</strong> Không tìm thấy dữ liệu chờ SPE approve.
             </div>
-        `;
+        `);
         return;
     }
 
@@ -107,7 +117,7 @@ function displayTableWithPagination(data, resultDiv, itemsPerPage = 10) {
             `;
         }
 
-        resultDiv.innerHTML = tableHTML;
+        setResultContent(resultDiv, tableHTML);
 
         // Gắn sự kiện cho nút Previous và Next
         if (totalPages > 1) {
@@ -133,11 +143,11 @@ function displayTableWithPagination(data, resultDiv, itemsPerPage = 10) {
 
 // Hàm tải dữ liệu từ API và hiển thị
 async function loadScrapStatusTwo(resultDiv) {
-    resultDiv.innerHTML = `
+    setResultContent(resultDiv, `
         <div class="alert alert-info">
             <strong>Thông báo:</strong> Đang tải danh sách SN chờ SPE approve...
         </div>
-    `;
+    `);
 
     try {
         const response = await fetch("http://10.220.130.119:9090/api/Scrap/get-scrap-status-two-and-four", {
@@ -152,18 +162,18 @@ async function loadScrapStatusTwo(resultDiv) {
         if (response.ok) {
             displayTableWithPagination(result, resultDiv);
         } else {
-            resultDiv.innerHTML = `
+            setResultContent(resultDiv, `
                 <div class="alert alert-danger">
                     <strong>Lỗi:</strong> ${result.message}
                 </div>
-            `;
+            `);
         }
     } catch (error) {
-        resultDiv.innerHTML = `
+        setResultContent(resultDiv, `
             <div class="alert alert-danger">
                 <strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.
             </div>
-        `;
+        `);
         console.error("Error:", error);
     }
 }
@@ -235,47 +245,47 @@ document.addEventListener("DOMContentLoaded", function () {
 
         // Kiểm tra dữ liệu đầu vào
         if (!sNs.length) {
-            resultDiv.innerHTML = `
-            <div class="alert alert-warning">
-                <strong>Cảnh báo:</strong> Vui lòng nhập ít nhất một Serial Number hợp lệ!
-            </div>
-        `;
+            setResultContent(resultDiv, `
+                <div class="alert alert-warning">
+                    <strong>Cảnh báo:</strong> Vui lòng nhập ít nhất một Serial Number hợp lệ!
+                </div>
+            `);
             return;
         }
 
         if (!description) {
-            resultDiv.innerHTML = `
-            <div class="alert alert-warning">
-                <strong>Cảnh báo:</strong> Vui lòng nhập mô tả!
-            </div>
-        `;
+            setResultContent(resultDiv, `
+                <div class="alert alert-warning">
+                    <strong>Cảnh báo:</strong> Vui lòng nhập mô tả!
+                </div>
+            `);
             return;
         }
 
         if (!["BP-10", "BP-20", "B36R"].includes(typeBonepile)) {
-            resultDiv.innerHTML = `
-            <div class="alert alert-warning">
-                <strong>Cảnh báo:</strong> Vui lòng chọn loại BonePile!
-            </div>
-        `;
+            setResultContent(resultDiv, `
+                <div class="alert alert-warning">
+                    <strong>Cảnh báo:</strong> Vui lòng chọn loại BonePile!
+                </div>
+            `);
             return;
         }
 
         if (!["2", "4"].includes(typeApprove)) {
-            resultDiv.innerHTML = `
-            <div class="alert alert-warning">
-                <strong>Cảnh báo:</strong> Vui lòng chọn loại Approve!
-            </div>
-        `;
+            setResultContent(resultDiv, `
+                <div class="alert alert-warning">
+                    <strong>Cảnh báo:</strong> Vui lòng chọn loại Approve!
+                </div>
+            `);
             return;
         }
 
         // Hiển thị thông báo "đang xử lý"
-        resultDiv.innerHTML = `
-        <div class="alert alert-info">
-            <strong>Thông báo:</strong> Đang lưu danh sách SN...
-        </div>
-    `;
+        setResultContent(resultDiv, `
+            <div class="alert alert-info">
+                <strong>Thông báo:</strong> Đang lưu danh sách SN...
+            </div>
+        `);
 
         // Định dạng sn_list thành chuỗi cách nhau bởi dấu phẩy
         const snListString = sNs.join(",");
@@ -349,40 +359,40 @@ document.addEventListener("DOMContentLoaded", function () {
 
                     if (updateResponse.ok) {
                         // Nếu cả hai bước đều thành công hoặc được bỏ qua theo yêu cầu
-                        resultDiv.innerHTML = `
-                        <div class="alert alert-success">
-                            <strong>Thành công:</strong> ${inputSnResult.message}${shouldCallRepairScrap ? "" : "<br><small class=\"text-muted\">" + repairScrapResult + "</small>"}
-                        </div>
-                    `;
+                        setResultContent(resultDiv, `
+                            <div class="alert alert-success">
+                                <strong>Thành công:</strong> ${inputSnResult.message}${shouldCallRepairScrap ? "" : "<br><small class=\"text-muted\">" + repairScrapResult + "</small>"}
+                            </div>
+                        `);
                     } else {
                         console.warn("UpdateProduct API failed:", updateResult.message);
-                        resultDiv.innerHTML = `
-                        <div class="alert alert-warning">
-                            <strong>Cảnh báo:</strong> Lưu SN thành công nhưng cập nhật sản phẩm trong kho thất bại: ${updateResult.message}
-                        </div>
-                    `;
+                        setResultContent(resultDiv, `
+                            <div class="alert alert-warning">
+                                <strong>Cảnh báo:</strong> Lưu SN thành công nhưng cập nhật sản phẩm trong kho thất bại: ${updateResult.message}
+                            </div>
+                        `);
                     }
                 } else {
-                    resultDiv.innerHTML = `
-                    <div class="alert alert-warning">
-                        <strong>Cảnh báo:</strong> Gọi API repair_scrap thất bại: ${repairScrapResult}
-                    </div>
-                `;
+                    setResultContent(resultDiv, `
+                        <div class="alert alert-warning">
+                            <strong>Cảnh báo:</strong> Gọi API repair_scrap thất bại: ${repairScrapResult}
+                        </div>
+                    `);
                 }
             } else {
                 console.warn("input-sn-wait-spe-approve API failed:", inputSnResult.message);
-                resultDiv.innerHTML = `
-                <div class="alert alert-warning">
-                    <strong>Cảnh báo:</strong> Gọi API input-sn-wait-spe-approve thất bại: ${inputSnResult.message}
-                </div>
-            `;
+                setResultContent(resultDiv, `
+                    <div class="alert alert-warning">
+                        <strong>Cảnh báo:</strong> Gọi API input-sn-wait-spe-approve thất bại: ${inputSnResult.message}
+                    </div>
+                `);
             }
         } catch (error) {
-            resultDiv.innerHTML = `
-            <div class="alert alert-danger">
-                <strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.
-            </div>
-        `;
+            setResultContent(resultDiv, `
+                <div class="alert alert-danger">
+                    <strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.
+                </div>
+            `);
             console.error("Error:", error);
         }
     });
@@ -401,23 +411,22 @@ document.addEventListener("DOMContentLoaded", function () {
             const result = await response.json();
 
             if (response.ok && result && result.length > 0) {
-                // Tải file Excel
                 downloadExcel(result);
             } else {
                 const resultDiv = document.getElementById("sn-wait-approve-result");
-                resultDiv.innerHTML = `
+                setResultContent(resultDiv, `
                     <div class="alert alert-warning">
                         <strong>Cảnh báo:</strong> Không có dữ liệu để tải xuống.
                     </div>
-                `;
+                `);
             }
         } catch (error) {
             const resultDiv = document.getElementById("sn-wait-approve-result");
-            resultDiv.innerHTML = `
+            setResultContent(resultDiv, `
                 <div class="alert alert-danger">
                     <strong>Lỗi:</strong> Không thể tải dữ liệu để tạo file Excel.
                 </div>
-            `;
+            `);
             console.error("Error:", error);
         }
     });


### PR DESCRIPTION
## Summary
- filter the `get-scrap-status-zero` endpoint to only return scrap items with a valid internal task created within the past three months and expose their purpose in the response
- restyle all Scrap area pages with the new card-based layout, updated copy, and remove the HISTORY APPLY option from the function selector
- add a dedicated Scrap theme stylesheet and adjust the front-end scripts to render tables inside the new layout and include the Purpose column

## Testing
- `dotnet build PESystem.sln` *(fails: dotnet CLI not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68ee0bdd3d088326afda287db235dc04