### PR TITLE
Finalize scrap and allpart UI refresh

### DIFF
--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -439,34 +439,49 @@ namespace API_WEB.Controllers.Scrap
             }
         }
 
-        // API: Lấy dữ liệu từ ScrapList với ApplyTaskStatus = 0 hoặc 10
+        // API: Lấy dữ liệu ScrapList đã có InternalTask trong 3 tháng gần nhất
         [HttpGet("get-scrap-status-zero")]
         public async Task<IActionResult> GetScrapStatusZero()
         {
             try
             {
-                // Lấy dữ liệu từ bảng ScrapList với ApplyTaskStatus = 0 hoặc 10
-                var scrapData = await _sqlContext.ScrapLists
-                    .Where(s => s.ApplyTaskStatus == 0 || s.ApplyTaskStatus == 10) // Lọc theo ApplyTaskStatus = 0 hoặc 10
-                    .GroupBy(s => s.InternalTask) // Nhóm theo InternalTask
+                var threeMonthsAgo = DateTime.Now.AddMonths(-3);
+
+                var groupedData = await _sqlContext.ScrapLists
+                    .Where(s => !string.IsNullOrEmpty(s.InternalTask)
+                                && s.InternalTask != "N/A"
+                                && s.CreateTime >= threeMonthsAgo)
+                    .GroupBy(s => s.InternalTask)
                     .Select(g => new
                     {
                         InternalTask = g.Key,
-                        Description = g.First().Desc, // Lấy giá trị đầu tiên của Description
-                        ApproveScrapPerson = g.First().ApproveScrapperson, // Lấy giá trị đầu tiên
-                        KanBanStatus = g.First().KanBanStatus, // Lấy giá trị đầu tiên
-                        Category = g.First().Category,
-                        Remark = g.First().Remark,
-                        CreateTime = g.First().CreateTime.ToString("yyyy-MM-dd"), // Chỉ lấy ngày tháng năm
-                        CreateBy = g.First().CreatedBy, // Lấy giá trị đầu tiên
-                        ApplyTaskStatus = g.First().ApplyTaskStatus, // Lấy giá trị đầu tiên
-                        TotalQty = g.Count() // Đếm số lượng SN trong mỗi InternalTask
+                        LatestRecord = g.OrderByDescending(x => x.CreateTime).FirstOrDefault(),
+                        TotalQty = g.Count()
                     })
                     .ToListAsync();
 
+                var scrapData = groupedData
+                    .Where(x => x.LatestRecord != null)
+                    .OrderByDescending(x => x.LatestRecord!.CreateTime)
+                    .Select(x => new
+                    {
+                        InternalTask = x.InternalTask,
+                        Description = x.LatestRecord!.Desc,
+                        ApproveScrapPerson = x.LatestRecord!.ApproveScrapperson,
+                        KanBanStatus = x.LatestRecord!.KanBanStatus,
+                        Category = x.LatestRecord!.Category,
+                        Remark = x.LatestRecord!.Remark,
+                        Purpose = x.LatestRecord!.Purpose,
+                        CreateTime = x.LatestRecord!.CreateTime.ToString("yyyy-MM-dd"),
+                        CreateBy = x.LatestRecord!.CreatedBy,
+                        ApplyTaskStatus = x.LatestRecord!.ApplyTaskStatus,
+                        TotalQty = x.TotalQty
+                    })
+                    .ToList();
+
                 if (!scrapData.Any())
                 {
-                    return NotFound(new { message = "Không tìm thấy dữ liệu với ApplyTaskStatus = 0 hoặc 3." });
+                    return NotFound(new { message = "Không tìm thấy dữ liệu phù hợp trong 3 tháng gần nhất." });
                 }
 
                 return Ok(scrapData);

--- a/PESystem/Areas/Allpart/Views/DCLC/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/DCLC/Index.cshtml
@@ -1,58 +1,71 @@
-﻿@{
-    ViewData["Title"] = "Allpart DC-LC";
-}
 @{
+    ViewData["Title"] = "Allpart DC-LC";
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
+<link rel="stylesheet" href="~/assets/Areas/Allpart/css/theme.css" asp-append-version="true" />
 
-<link href="~/assets/css/dclc.css" rel="stylesheet" />
-
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">Tìm Kiếm Thông Tin Linh Kiện</h1>
-    </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)"></textarea>
+<section class="allpart-page py-4">
+    <div class="allpart-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>DC-LC Insight</h1>
+                <p>Tìm kiếm thông tin linh kiện theo Serial Number và vị trí, xuất dữ liệu trực quan chỉ với vài thao tác.</p>
             </div>
-            <div class="col-md-4">
-                <textarea id="refDes" class="form-control" rows="3" placeholder="Nhập vị trí (mỗi dòng một giá trị)..."></textarea>
-            </div>
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-            <div class="col-md-2">
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Tải xuống Excel</button>
-            </div>
-        </div>
-
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="dcLcTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>P_SN</th>
-                            <th>MODEL_NAME</th>
-                            <th>MÃ_LIỆU</th>
-                            <th>VENDOR_CODE</th>
-                            <th>VENDOR_NAME</th>
-                            <th>REF_DES</th>
-                            <th>DATE_CODE</th>
-                            <th>LOT_CODE</th>
-                            <th>PROCESS_FLAG</th>
-                            <th>STATION</th>
-                            <th>GROUP_NAME</th>
-                            <th>WORK_TIME</th>
-                            <th>WO</th>
-                        </tr>
-                    </thead>
-                    <tbody id="dcLcTableBody"></tbody>
-                </table>
+            <div class="allpart-badge-list">
+                <span class="badge"><i class="fas fa-microchip me-2"></i>Thông tin linh kiện</span>
+                <span class="badge"><i class="fas fa-download me-2"></i>Xuất Excel nhanh</span>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="allpart-card shadow-sm">
+        <div class="allpart-card-header">
+            <h2 class="allpart-card-title">Tìm Kiếm Thông Tin Linh Kiện</h2>
+            <p class="allpart-card-subtitle">Nhập danh sách Serial Number &amp; Reference Designator để truy vấn</p>
+        </div>
+        <div class="allpart-card-body">
+            <div class="row g-3 mb-4 align-items-center">
+                <div class="col-md-4">
+                    <label class="form-label" for="serialNumber">Serial Number</label>
+                    <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)..."></textarea>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="refDes">Reference Designator</label>
+                    <textarea id="refDes" class="form-control" rows="3" placeholder="Nhập vị trí (mỗi dòng một giá trị)..."></textarea>
+                </div>
+                <div class="col-md-2 d-grid gap-2">
+                    <button onclick="search()" class="btn btn-nv">Tìm kiếm</button>
+                    <button onclick="downloadExcel()" class="btn btn-nv">Tải xuống Excel</button>
+                </div>
+            </div>
+
+            <div class="allpart-table-wrapper">
+                <div class="table-responsive">
+                    <table id="dcLcTable" class="display table allpart-table table-hover align-middle w-100">
+                        <thead>
+                            <tr>
+                                <th>P_SN</th>
+                                <th>MODEL_NAME</th>
+                                <th>MÃ_LIỆU</th>
+                                <th>VENDOR_CODE</th>
+                                <th>VENDOR_NAME</th>
+                                <th>REF_DES</th>
+                                <th>DATE_CODE</th>
+                                <th>LOT_CODE</th>
+                                <th>PROCESS_FLAG</th>
+                                <th>STATION</th>
+                                <th>GROUP_NAME</th>
+                                <th>WORK_TIME</th>
+                                <th>WO</th>
+                            </tr>
+                        </thead>
+                        <tbody id="dcLcTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
     <script>
@@ -198,34 +211,28 @@
         function downloadExcel() {
             const allData = dcLcTable.rows().data().toArray();
 
-            const excelData = [
-                ['P_SN', 'MODEL_NAME', 'MÃ_LIỆU', 'VENDOR_CODE', 'VENDOR_NAME', 'REF_DES', 'DATE_CODE', 'LOT_CODE', 'PROCESS_FLAG', 'STATION', 'GROUP_NAME', 'WORK_TIME', 'WO']
+            if (allData.length === 0) {
+                alert('Không có dữ liệu để tải xuống. Vui lòng tìm kiếm trước.');
+                return;
+            }
+
+            const headers = [
+                'P_SN', 'MODEL_NAME', 'MÃ_LIỆU', 'VENDOR_CODE', 'VENDOR_NAME', 'REF_DES', 'DATE_CODE', 'LOT_CODE', 'PROCESS_FLAG', 'STATION', 'GROUP_NAME', 'WORK_TIME', 'WO'
             ];
 
-            allData.forEach(row => {
-                const rowData = Array.from(row).map(cell => {
-                    const div = document.createElement('div');
-                    div.innerHTML = cell;
-                    return div.textContent || '';
+            const worksheetData = allData.map(row => {
+                const rowData = {};
+                headers.forEach((header, index) => {
+                    const value = $(row[index]).text().trim();
+                    rowData[header] = value;
                 });
-                excelData.push(rowData);
+                return rowData;
             });
 
-            const ws = XLSX.utils.aoa_to_sheet(excelData);
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws, "Sheet1");
-
-            const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
-            const blob = new Blob([wbout], { type: 'application/octet-stream' });
-
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = 'data_dclc_' + new Date().toISOString().slice(0, 10) + '.xlsx';
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            window.URL.revokeObjectURL(url);
+            const worksheet = XLSX.utils.json_to_sheet(worksheetData);
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'DC_LC_DATA');
+            XLSX.writeFile(workbook, 'DC_LC_Data.xlsx');
         }
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/FailATE/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/FailATE/Index.cshtml
@@ -1,161 +1,155 @@
-﻿@{
-    ViewData["Title"] = "History Error";
-}
 @{
+    ViewData["Title"] = "Fail ATE";
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
+<link rel="stylesheet" href="~/assets/Areas/Allpart/css/theme.css" asp-append-version="true" />
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">FAIL ATE</h1>
-    </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="1" placeholder="Nhập SerialNumber..."></textarea>
+<section class="allpart-page py-4">
+    <div class="allpart-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>Fail ATE Analytics</h1>
+                <p>Phân tích lỗi kiểm tra ATE theo Serial Number, tra cứu nguyên nhân và xuất báo cáo nhanh.</p>
             </div>
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-        </div>
-
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="historyDataTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>SERIAL_NUMBER</th>
-                            <th>MODEL_NAME</th>
-                            <th>LINE_NAME</th>
-                            <th>SECTION_NAME</th>
-                            <th>GROUP_NAME</th>
-                            <th>STATION_NAME</th>
-                            <th>ERROR_CODE</th>
-                            <th>ERROR_DESC</th>
-                            <th>DATA6</th>
-                            <th>DATA12</th>
-                            <th>PASS_COUNT</th>
-                            <th>RETEST_COUNT</th>
-                            <th>TEST_VALUE</th>
-                            <th>IN_STATION_TIME</th>
-                            <th>RESULT</th>
-                            <th>DATA2</th>
-                            <th>TEST_MODE</th>
-                            <th>SCOF_MIN</th>
-                        </tr>
-                    </thead>
-                    <tbody id="historyDataTableBody"></tbody>
-                </table>
+            <div class="allpart-badge-list">
+                <span class="badge"><i class="fas fa-microchip me-2"></i>Thông tin kiểm tra</span>
+                <span class="badge"><i class="fas fa-chart-line me-2"></i>Phân tích xu hướng</span>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="allpart-card shadow-sm">
+        <div class="allpart-card-header">
+            <div>
+                <h2 class="allpart-card-title">Tra cứu lỗi Fail ATE</h2>
+                <p class="allpart-card-subtitle">Nhập Serial Number để xem chi tiết lỗi và trạng thái kiểm tra</p>
+            </div>
+        </div>
+        <div class="allpart-card-body">
+            <div class="row g-3 mb-4 align-items-end">
+                <div class="col-lg-5">
+                    <label class="form-label" for="serialNumber">Serial Number</label>
+                    <textarea id="serialNumber" class="form-control" rows="2" placeholder="Nhập SerialNumber..."></textarea>
+                    <p class="allpart-hint mt-2 mb-0">Có thể nhập nhiều Serial Number, mỗi dòng một giá trị.</p>
+                </div>
+                <div class="col-md-3 col-lg-2 d-grid">
+                    <button onclick="search()" class="btn btn-nv">Tìm kiếm</button>
+                </div>
+            </div>
+
+            <div class="allpart-table-wrapper">
+                <div class="table-responsive">
+                    <table id="historyDataTable" class="display table allpart-table table-hover align-middle w-100">
+                        <thead>
+                            <tr>
+                                <th>SERIAL_NUMBER</th>
+                                <th>MODEL_NAME</th>
+                                <th>LINE_NAME</th>
+                                <th>SECTION_NAME</th>
+                                <th>GROUP_NAME</th>
+                                <th>STATION_NAME</th>
+                                <th>ERROR_CODE</th>
+                                <th>ERROR_DESC</th>
+                                <th>DATA6</th>
+                                <th>DATA12</th>
+                                <th>PASS_COUNT</th>
+                                <th>RETEST_COUNT</th>
+                                <th>TEST_VALUE</th>
+                                <th>IN_STATION_TIME</th>
+                                <th>RESULT</th>
+                                <th>DATA2</th>
+                                <th>TEST_MODE</th>
+                                <th>SCOF_MIN</th>
+                            </tr>
+                        </thead>
+                        <tbody id="historyDataTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-    <style>
-        .bg-nvidia-green {
-            background-color: #76B900 !important;
-        }
-
-        .btn-nvidia-green {
-            background-color: #76B900 !important;
-            border-color: #76B900 !important;
-            color: #fff;
-            height: 100%;
-        }
-
-            .btn-nvidia-green:hover {
-                background-color: #639A00 !important;
-                border-color: #639A00 !important;
-            }
-
-        .custom-tooltip {
-            position: absolute;
-            background-color: #333;
-            color: #fff;
-            padding: 5px 10px;
-            border-radius: 3px;
-            font-size: 12px;
-            z-index: 1000;
-            display: none;
-            max-width: 200px;
-            word-wrap: break-word;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-        }
-
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76B900 !important;
-        }
-
-        .dataTables_wrapper .dataTables_filter,
-        .dataTables_wrapper .dataTables_paginate {
-            position: sticky;
-            top: 0;
-            background-color: #fff;
-            z-index: 1;
-            border-radius: 5px;
-            margin-bottom: 5px;
-            padding: 5px;
-            vertical-align: middle;
-        }
-
-        .dataTables_wrapper {
-            overflow-x: auto;
-        }
-
-        .table-responsive {
-            overflow-x: auto;
-        }
-
-        .row.align-items-center {
-            display: flex;
-            align-items: stretch;
-        }
-
-        .form-control {
-            height: auto;
-            resize: vertical;
-        }
-
-        .datatable-table th, .datatable-table td {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            max-width: 150px;
-            padding: 5px;
-        }
-
-        .loading-overlay {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 2000;
-            justify-content: center;
-            align-items: center;
-        }
-
-        .loading-message {
-            background: #fff;
-            padding: 15px 30px;
-            border-radius: 5px;
-            font-size: 16px;
-            font-weight: bold;
-            color: #333;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-        }
-    </style>
     <script>
         let historyTable = null;
 
+        function escapeHtml(value) {
+            return String(value ?? '')
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
+        }
+
+        function createTooltipCell(data) {
+            const safe = escapeHtml(data ?? '');
+            return `<span class="tooltip-trigger" data-tooltip="${safe}">${safe}</span>`;
+        }
+
+        function ensureTooltipContainer() {
+            let tip = document.querySelector('.custom-tooltip');
+            if (!tip) {
+                tip = document.createElement('div');
+                tip.className = 'custom-tooltip';
+                document.body.appendChild(tip);
+            }
+            return tip;
+        }
+
+        function attachTooltipEvents() {
+            document.querySelectorAll('.tooltip-trigger').forEach(el => {
+                if (el.dataset.tooltipBound === '1') return;
+
+                el.addEventListener('mouseover', (e) => {
+                    const tooltipText = el.getAttribute('data-tooltip') || '';
+                    if (!tooltipText) return;
+                    const tooltip = ensureTooltipContainer();
+                    tooltip.textContent = tooltipText;
+                    tooltip.style.display = 'block';
+                    tooltip.style.left = (e.pageX + 10) + 'px';
+                    tooltip.style.top = (e.pageY - 20) + 'px';
+                });
+
+                el.addEventListener('mousemove', (e) => {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip && tooltip.style.display === 'block') {
+                        tooltip.style.left = (e.pageX + 10) + 'px';
+                        tooltip.style.top = (e.pageY - 20) + 'px';
+                    }
+                });
+
+                el.addEventListener('mouseout', () => {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip) {
+                        tooltip.style.display = 'none';
+                    }
+                });
+
+                el.dataset.tooltipBound = '1';
+            });
+        }
+
+        function formatDateTime(value) {
+            if (!value) return '';
+            const dt = new Date(value);
+            if (Number.isNaN(dt.getTime())) {
+                return value;
+            }
+            return dt.toLocaleString();
+        }
+
         async function search() {
-            const sn = $("#serialNumber").val().trim().toUpperCase();
-            if (!sn) {
+            const snRaw = $("#serialNumber").val().trim();
+            if (!snRaw) {
                 Swal.fire("Thông báo", "Vui lòng nhập Serial Number!", "warning");
+                return;
+            }
+
+            const serialNumbers = snRaw.split(/\r?\n/).map(item => item.trim()).filter(Boolean);
+            if (serialNumbers.length === 0) {
+                Swal.fire("Thông báo", "Danh sách Serial Number không hợp lệ!", "warning");
                 return;
             }
 
@@ -167,31 +161,48 @@
                     showConfirmButton: false
                 });
 
-                const response = await fetch("http://10.220.130.119:9090/api/CheckInOut/get-fail-ate", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
-                    body: JSON.stringify(sn)
-                });
+                const aggregated = [];
+                const missing = [];
 
-                if (!response.ok) {
-                    throw new Error("API trả về lỗi: " + response.status);
+                for (const sn of serialNumbers) {
+                    const normalized = sn.toUpperCase();
+                    const response = await fetch("http://10.220.130.119:9090/api/CheckInOut/get-fail-ate", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify(normalized)
+                    });
+
+                    if (!response.ok) {
+                        throw new Error("API trả về lỗi: " + response.status);
+                    }
+
+                    const result = await response.json();
+
+                    if (!result.success || !Array.isArray(result.data) || result.data.length === 0) {
+                        missing.push(normalized);
+                        continue;
+                    }
+
+                    aggregated.push(...result.data);
                 }
-
-                const result = await response.json();
 
                 Swal.close();
 
-                if (!result.success || !result.data || result.data.length === 0) {
-                    Swal.fire("Không có dữ liệu!", "Không tìm thấy dữ liệu lỗi cho SN: " + sn, "info");
+                if (aggregated.length === 0) {
+                    Swal.fire("Không có dữ liệu!", "Không tìm thấy dữ liệu lỗi cho Serial Number đã nhập.", "info");
                     if (historyTable) {
                         historyTable.clear().draw();
                     }
                     return;
                 }
 
-                renderTable(result.data);
+                renderTable(aggregated);
+
+                if (missing.length > 0) {
+                    Swal.fire("Thông tin", `Không có dữ liệu cho: ${missing.join(', ')}`, "info");
+                }
             } catch (err) {
                 Swal.close();
                 console.error(err);
@@ -200,103 +211,73 @@
         }
 
         function renderTable(data) {
-            if (historyTable) {
+            const columns = [
+                { data: "serialNumber", render: data => createTooltipCell(data) },
+                { data: "modelName", render: data => createTooltipCell(data) },
+                { data: "lineName", render: data => createTooltipCell(data) },
+                { data: "sectionName", render: data => createTooltipCell(data) },
+                { data: "groupName", render: data => createTooltipCell(data) },
+                { data: "stationName", render: data => createTooltipCell(data) },
+                { data: "errorCode", render: data => createTooltipCell(data) },
+                { data: "errorDesc", render: data => createTooltipCell(data) },
+                { data: "data6", render: data => createTooltipCell(data) },
+                { data: "data12", render: data => createTooltipCell(data) },
+                { data: "passCount", render: data => createTooltipCell(data) },
+                { data: "retestCount", render: data => createTooltipCell(data) },
+                { data: "testValue", render: data => createTooltipCell(data) },
+                { data: "inStationTime", render: data => createTooltipCell(formatDateTime(data)) },
+                { data: "result", render: data => createTooltipCell(data) },
+                { data: "data2", render: data => createTooltipCell(data) },
+                { data: "testMode", render: data => createTooltipCell(data) },
+                { data: "scofMin", render: data => createTooltipCell(data) }
+            ];
+
+            if (!historyTable) {
+                historyTable = $('#historyDataTable').DataTable({
+                    data,
+                    pageLength: 10,
+                    order: [[0, "desc"]],
+                    scrollX: true,
+                    autoWidth: false,
+                    dom: '<"top d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2"lfB>rt<"bottom"ip>',
+                    buttons: [
+                        {
+                            extend: 'excelHtml5',
+                            text: '<i class="fa fa-file-excel me-2"></i>Xuất Excel',
+                            className: 'btn btn-nv btn-sm',
+                            title: null,
+                            filename: 'FAIL_ATE_' + new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-'),
+                            exportOptions: {
+                                columns: ':visible',
+                                format: {
+                                    body: function (data, row, column, node) {
+                                        return $(node).text();
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    columns,
+                    language: {
+                        search: "Tìm kiếm:",
+                        lengthMenu: "Hiển thị _MENU_ dòng",
+                        info: "Hiển thị _START_ - _END_ / _TOTAL_ dòng",
+                        paginate: {
+                            first: "Đầu",
+                            last: "Cuối",
+                            next: "→",
+                            previous: "←"
+                        },
+                        emptyTable: "Không có dữ liệu để hiển thị"
+                    }
+                });
+
+                historyTable.on('draw', attachTooltipEvents);
+            } else {
                 historyTable.clear().rows.add(data).draw();
-                return;
             }
 
-            historyTable = $('#historyDataTable').DataTable({
-                destroy: true,
-                data: data,
-                pageLength: 10,
-                order: [[0, "desc"]],
-                scrollX: true,
-                autoWidth: false,
-                dom: '<"top d-flex justify-content-between align-items-center"lfB>rt<"bottom"ip>',
-                buttons: [
-                    {
-                        extend: 'excelHtml5',
-                        text: '<i class="fa fa-file-excel"></i>',
-                        className: 'btn btn-success btn-sm',
-                        title:null,
-                        filename: 'FAIL_ATE_' + new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-'),
-                        exportOptions: {
-                            columns: ':visible'
-                        }
-                    }
-                ],
-                columns: [
-                    { data: "serialNumber" },
-                    { data: "modelName" },
-                    { data: "lineName" },
-                    { data: "sectionName" },
-                    { data: "groupName" },
-                    { data: "stationName" },
-                    { data: "errorCode" },
-                    {
-                        data: "errorDesc",
-                        render: function (data) {
-                            if (!data) return "";
-                            const text = data.toString().replace(/"/g, '&quot;');
-                            return `<span title="${text}">${text}</span>`;
-                        }
-                    },
-                    { data: "data6" },
-                    { data: "data12" },
-                    { data: "passCount" },
-                    { data: "retestCount" },
-                    { data: "testValue" },
-                    {
-                        data: "inStationTime",
-                        render: function (data) {
-                            return data ? new Date(data).toLocaleString() : "";
-                        }
-                    },
-                    { data: "result" },
-                    { data: "data2" },
-                    { data: "testMode" },
-                    { data: "scofMin" }
-                ],
-                language: {
-                    search: "Tìm kiếm:",
-                    lengthMenu: "Hiển thị _MENU_ dòng",
-                    info: "Hiển thị _START_ - _END_ / _TOTAL_ dòng",
-                    paginate: {
-                        first: "Đầu",
-                        last: "Cuối",
-                        next: "→",
-                        previous: "←"
-                    },
-                    emptyTable: "Không có dữ liệu để hiển thị"
-                },
-                createdRow: function (row, data, dataIndex) {
-                    $('td', row).each(function () {
-                        const text = $(this).text().trim();
-                        if (text.length > 0) {
-                            $(this).attr('title', text);
-                        }
-                    });
-                }
-            });
+            attachTooltipEvents();
         }
-
-
-        // ✅ CSS thêm tooltip đẹp + cắt nội dung dài
-        $(document).ready(function () {
-            const style = `
-            <style>
-                table.dataTable td {
-                    white-space: nowrap;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    max-width: 220px;
-                    vertical-align: middle;
-                }
-                table.dataTable td:hover {
-                    background-color: #fff9d6 !important;
-                }
-            </style>`;
-            $('head').append(style);
-        });
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/HE/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/HE/Index.cshtml
@@ -1,208 +1,138 @@
-﻿@{
-    ViewData["Title"] = "History Error";
-}
 @{
+    ViewData["Title"] = "History Error";
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
+<link rel="stylesheet" href="~/assets/Areas/Allpart/css/theme.css" asp-append-version="true" />
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">Tìm Kiếm Thông Tin lịch sử lỗi</h1>
-    </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)..."></textarea>
+<section class="allpart-page py-4">
+    <div class="allpart-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>History Error Insight</h1>
+                <p>Theo dõi lịch sử lỗi chi tiết theo Serial Number, truy xuất dữ liệu nhanh chóng và trực quan.</p>
             </div>
-            <div class="col-md-2">
-                <label for="type-options" class="form-label">Chọn kiểu tra cứu</label>
-                <select id="type-options" class="form-select">
-                    <option selected disabled>SELECT TYPE</option>
-                    <option value="1">Tra cứu theo SN-SFG</option>
-                    <option value="2">Tra cứu theo SN-FG</option>
-                </select>
-            </div>
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-            <div class="col-md-2">
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Tải xuống Excel</button>
-            </div>
-        </div>
-
-        <div id="loading-overlay" class="loading-overlay">
-            <div class="loading-message">Đang tải dữ liệu...</div>
-        </div>
-
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="historyDataTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>SERIAL_NUMBER</th>
-                            <th>KEY_PART_SN</th>
-                            <th>MO_NUMBER</th>
-                            <th>MODEL_NAME</th>
-                            <th>TEST_TIME</th>
-                            <th>TEST_GROUP</th>
-                            <th>TEST_CODE</th>
-                            <th>DATA1</th>
-                            <th>REASON_CODE</th>
-                        </tr>
-                    </thead>
-                    <tbody id="historyDataTableBody"></tbody>
-                </table>
+            <div class="allpart-badge-list">
+                <span class="badge"><i class="fas fa-database me-2"></i>Truy vấn đa nguồn</span>
+                <span class="badge"><i class="fas fa-file-export me-2"></i>Xuất báo cáo Excel</span>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="allpart-card shadow-sm">
+        <div class="allpart-card-header">
+            <div>
+                <h2 class="allpart-card-title">Tìm kiếm lịch sử lỗi</h2>
+                <p class="allpart-card-subtitle">Nhập danh sách Serial Number và chọn loại tra cứu phù hợp</p>
+            </div>
+        </div>
+        <div class="allpart-card-body">
+            <div class="row g-3 mb-4 align-items-end">
+                <div class="col-lg-5">
+                    <label class="form-label" for="serialNumber">Serial Number</label>
+                    <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)..."></textarea>
+                    <p class="allpart-hint mt-2 mb-0">Hỗ trợ nhiều Serial Number cùng lúc, mỗi dòng một giá trị.</p>
+                </div>
+                <div class="col-md-3 col-lg-2">
+                    <label class="form-label" for="type-options">Kiểu tra cứu</label>
+                    <select id="type-options" class="form-select">
+                        <option selected disabled>SELECT TYPE</option>
+                        <option value="1">Tra cứu theo SN-SFG</option>
+                        <option value="2">Tra cứu theo SN-FG</option>
+                    </select>
+                </div>
+                <div class="col-md-4 col-lg-3 d-grid gap-2">
+                    <button onclick="search()" class="btn btn-nv">Tìm kiếm</button>
+                    <button onclick="downloadExcel()" class="btn btn-nv">Tải xuống Excel</button>
+                </div>
+            </div>
+
+            <div class="allpart-table-wrapper">
+                <div class="table-responsive">
+                    <table id="historyDataTable" class="display table allpart-table table-hover align-middle w-100">
+                        <thead>
+                            <tr>
+                                <th>SERIAL_NUMBER</th>
+                                <th>KEY_PART_SN</th>
+                                <th>MO_NUMBER</th>
+                                <th>MODEL_NAME</th>
+                                <th>TEST_TIME</th>
+                                <th>TEST_GROUP</th>
+                                <th>TEST_CODE</th>
+                                <th>DATA1</th>
+                                <th>REASON_CODE</th>
+                            </tr>
+                        </thead>
+                        <tbody id="historyDataTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-    <style>
-        .bg-nvidia-green {
-            background-color: #76B900 !important;
-        }
-
-        .btn-nvidia-green {
-            background-color: #76B900 !important;
-            border-color: #76B900 !important;
-            color: #fff;
-            height: 100%;
-        }
-
-            .btn-nvidia-green:hover {
-                background-color: #639A00 !important;
-                border-color: #639A00 !important;
-            }
-
-        .custom-tooltip {
-            position: absolute;
-            background-color: #333;
-            color: #fff;
-            padding: 5px 10px;
-            border-radius: 3px;
-            font-size: 12px;
-            z-index: 1000;
-            display: none;
-            max-width: 200px;
-            word-wrap: break-word;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-        }
-
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76B900 !important;
-        }
-
-        .dataTables_wrapper .dataTables_filter,
-        .dataTables_wrapper .dataTables_paginate {
-            position: sticky;
-            top: 0;
-            background-color: #fff;
-            z-index: 1;
-            border-radius: 5px;
-            margin-bottom: 5px;
-            padding: 5px;
-            vertical-align: middle;
-        }
-
-        .dataTables_wrapper {
-            overflow-x: auto;
-        }
-
-        .table-responsive {
-            overflow-x: auto;
-        }
-
-        .row.align-items-center {
-            display: flex;
-            align-items: stretch;
-        }
-
-        .form-control {
-            height: auto;
-            resize: vertical;
-        }
-
-        .datatable-table th, .datatable-table td {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            max-width: 150px;
-            padding: 5px;
-        }
-
-        .loading-overlay {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 2000;
-            justify-content: center;
-            align-items: center;
-        }
-
-        .loading-message {
-            background: #fff;
-            padding: 15px 30px;
-            border-radius: 5px;
-            font-size: 16px;
-            font-weight: bold;
-            color: #333;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-        }
-    </style>
-
     <script>
-        let tableData = []; // Lưu dữ liệu để xuất Excel
-        let dataTable; // Lưu tham chiếu đến DataTable
+        let tableData = [];
+        let dataTable;
 
-        // Hàm tạo nội dung cho ô với tooltip
-        function createTooltipCell(data) {
-            return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
+        function escapeHtml(value) {
+            return String(value ?? '')
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
         }
 
-        // Hàm gắn sự kiện tooltip cho các phần tử
+        function createTooltipCell(data) {
+            const safe = escapeHtml(data ?? '');
+            return `<span class="tooltip-trigger" data-tooltip="${safe}">${safe}</span>`;
+        }
+
+        function ensureTooltipContainer() {
+            let tip = document.querySelector('.custom-tooltip');
+            if (!tip) {
+                tip = document.createElement('div');
+                tip.className = 'custom-tooltip';
+                document.body.appendChild(tip);
+            }
+            return tip;
+        }
+
         function attachTooltipEvents() {
-            $('.tooltip-trigger').each(function () {
-                const $this = $(this);
-                if (!$this.data('tooltip-initialized')) {
-                    $this.on('mouseover', function (e) {
-                        const tooltipText = $this.data('tooltip');
-                        if (tooltipText) {
-                            let tooltip = document.querySelector('.custom-tooltip');
-                            if (!tooltip) {
-                                tooltip = document.createElement('div');
-                                tooltip.className = 'custom-tooltip';
-                                document.body.appendChild(tooltip);
-                            }
-                            tooltip.textContent = tooltipText;
-                            tooltip.style.display = 'block';
-                            tooltip.style.left = (e.pageX + 10) + 'px';
-                            tooltip.style.top = (e.pageY - 20) + 'px';
-                        }
-                    }).on('mousemove', function (e) {
-                        const tooltip = document.querySelector('.custom-tooltip');
-                        if (tooltip && tooltip.style.display === 'block') {
-                            tooltip.style.left = (e.pageX + 10) + 'px';
-                            tooltip.style.top = (e.pageY - 20) + 'px';
-                        }
-                    }).on('mouseout', function () {
-                        const tooltip = document.querySelector('.custom-tooltip');
-                        if (tooltip) {
-                            tooltip.style.display = 'none';
-                        }
-                    });
-                    $this.data('tooltip-initialized', true);
-                }
+            document.querySelectorAll('.tooltip-trigger').forEach(el => {
+                if (el.dataset.tooltipBound === '1') return;
+
+                el.addEventListener('mouseover', (e) => {
+                    const tooltipText = el.getAttribute('data-tooltip') || '';
+                    if (!tooltipText) return;
+                    const tooltip = ensureTooltipContainer();
+                    tooltip.textContent = tooltipText;
+                    tooltip.style.display = 'block';
+                    tooltip.style.left = (e.pageX + 10) + 'px';
+                    tooltip.style.top = (e.pageY - 20) + 'px';
+                });
+
+                el.addEventListener('mousemove', (e) => {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip && tooltip.style.display === 'block') {
+                        tooltip.style.left = (e.pageX + 10) + 'px';
+                        tooltip.style.top = (e.pageY - 20) + 'px';
+                    }
+                });
+
+                el.addEventListener('mouseout', () => {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip) {
+                        tooltip.style.display = 'none';
+                    }
+                });
+
+                el.dataset.tooltipBound = '1';
             });
         }
 
         $(document).ready(function () {
-            // Khởi tạo DataTable một lần duy nhất
             dataTable = $('#historyDataTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
@@ -214,14 +144,13 @@
         async function search() {
             const serialNumbersText = document.getElementById('serialNumber').value.trim();
             const typeValue = document.getElementById('type-options').value;
-            const loadingOverlay = document.getElementById('loading-overlay');
 
             if (!serialNumbersText) {
                 alert('Vui lòng nhập ít nhất một Serial Number.');
                 return;
             }
 
-            if (typeValue === 'SELECT TYPE') {
+            if (!typeValue || typeValue === 'SELECT TYPE') {
                 alert('Vui lòng chọn kiểu tra cứu.');
                 return;
             }
@@ -232,8 +161,10 @@
                 return;
             }
 
-            // Hiển thị thông báo tải
-            loadingOverlay.style.display = 'flex';
+            const overlay = document.createElement('div');
+            overlay.className = 'loading-overlay';
+            overlay.innerHTML = `<div class="spinner"></div><div>Đang tải dữ liệu, vui lòng chờ...</div>`;
+            document.body.appendChild(overlay);
 
             try {
                 const response = await fetch('http://10.220.130.119:9090/api/SFC/history-error-by-sn', {
@@ -252,9 +183,8 @@
                 }
 
                 const data = await response.json();
-                tableData = data; // Lưu dữ liệu để xuất Excel
+                tableData = data;
 
-                // Xóa dữ liệu cũ trong DataTable
                 dataTable.clear();
 
                 if (data.length === 0) {
@@ -263,7 +193,6 @@
                     return;
                 }
 
-                // Thêm dữ liệu mới vào DataTable
                 data.forEach(row => {
                     dataTable.row.add([
                         createTooltipCell(row.SERIAL_NUMBER || ''),
@@ -278,18 +207,16 @@
                     ]);
                 });
 
-                // Vẽ lại bảng
                 dataTable.draw();
-
-                // Gắn lại sự kiện tooltip
                 attachTooltipEvents();
 
             } catch (error) {
                 console.error('Error:', error);
                 alert(`Đã xảy ra lỗi: ${error.message}`);
             } finally {
-                // Ẩn thông báo tải
-                loadingOverlay.style.display = 'none';
+                if (overlay.parentNode) {
+                    overlay.parentNode.removeChild(overlay);
+                }
             }
         }
 
@@ -299,7 +226,6 @@
                 return;
             }
 
-            // Lọc dữ liệu để chỉ xuất các cột hiển thị trong bảng
             const filteredData = tableData.map(row => ({
                 SERIAL_NUMBER: row.SERIAL_NUMBER || '',
                 KEY_PART_SN: row.KEY_PART_SN || '',
@@ -316,17 +242,16 @@
             const workbook = XLSX.utils.book_new();
             XLSX.utils.book_append_sheet(workbook, worksheet, 'HistoryError');
 
-            // Đặt tiêu đề cột
             worksheet['!cols'] = [
-                { wch: 20 }, // SERIAL_NUMBER
-                { wch: 20 }, // KEY_PART_SN
-                { wch: 15 }, // MO_NUMBER
-                { wch: 15 }, // MODEL_NAME
-                { wch: 20 }, // TEST_TIME
-                { wch: 10 }, // TEST_GROUP
-                { wch: 30 }, // TEST_CODE
-                { wch: 50 }, // DATA1
-                { wch: 15 }  // REASON_CODE
+                { wch: 20 },
+                { wch: 20 },
+                { wch: 15 },
+                { wch: 15 },
+                { wch: 20 },
+                { wch: 10 },
+                { wch: 30 },
+                { wch: 50 },
+                { wch: 15 }
             ];
 
             XLSX.writeFile(workbook, 'HistoryError.xlsx');

--- a/PESystem/Areas/Allpart/Views/ULT/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/ULT/Index.cshtml
@@ -1,83 +1,90 @@
-﻿@* File: Areas/Allpart/Views/ScanATestB/Index.cshtml *@
 @{
     ViewData["Title"] = "Check ULT data";
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
+<link rel="stylesheet" href="~/assets/Areas/Allpart/css/theme.css" asp-append-version="true" />
 
-<link href="~/assets/css/YRDCLC.css" rel="stylesheet" />
-
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">Tìm Kiếm Thông Tin ULT</h1>
-    </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <!-- Ô nhập danh sách SN/ULT -->
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber/ULT"></textarea>
+<section class="allpart-page py-4">
+    <div class="allpart-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>Tìm Kiếm Thông Tin ULT</h1>
+                <p>Tra cứu dữ liệu ULT theo SN hoặc mã ULT, lọc kết quả mới nhất và xuất báo cáo.</p>
             </div>
-
-            <!-- Chọn kiểu tra cứu -->
-            <div class="col-md-2">
-                <label for="type-options" class="form-label">Chọn kiểu tra cứu</label>
-                <select id="type-options" class="form-select">
-                    <option selected disabled>SELECT TYPE</option>
-                    <option value="SN">Tra cứu theo SN</option>
-                    <option value="ULT">Tra cứu theo ULT</option>
-                </select>
-            </div>
-
-            <!-- Chế độ hiển thị: ALL vs NEWEST -->
-            <div class="col-md-2">
-                <label for="view-mode" class="form-label">Chế độ hiển thị</label>
-                <select id="view-mode" class="form-select" title="Chọn dữ liệu cho bảng và xuất Excel">
-                    <option value="all" selected>Tất cả dữ liệu</option>
-                    <option value="latest">Kết quả mới nhất (mỗi SN)</option>
-                </select>
-            </div>
-
-            <!-- Nút hành động -->
-            <div class="col-md-2 d-flex flex-column gap-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Tải xuống Excel</button>
-            </div>
-        </div>
-
-        <div class="mt-4">
-            <div class="table-responsive align-items-center">
-                <table id="ULTDataTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>SERIAL_NUMBER</th>
-                            <th>MODEL_NAME</th>
-                            <th>GROUP_NAME</th>
-                            <th>TEST_TIME</th>
-                            <th>ULT</th>
-                            <th>STATION_NAME</th>
-                            <th>TEST_ON</th>
-                            <th>TEST_OFF</th>
-                            <th>TEST_RESULT</th>
-                        </tr>
-                    </thead>
-                    <tbody id="ULTDataTableBody"></tbody>
-                </table>
+            <div class="allpart-badge-list">
+                <span class="badge"><i class="fas fa-filter me-2"></i>Lọc kết quả</span>
+                <span class="badge"><i class="fas fa-download me-2"></i>Xuất Excel nhanh</span>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="allpart-card shadow-sm">
+        <div class="allpart-card-header">
+            <h2 class="allpart-card-title">Tìm kiếm dữ liệu ULT</h2>
+            <p class="allpart-card-subtitle">Nhập danh sách SN hoặc ULT để truy vấn</p>
+        </div>
+        <div class="allpart-card-body">
+            <div class="row g-3 mb-4 align-items-center">
+                <div class="col-md-4">
+                    <label class="form-label" for="serialNumber">SerialNumber/ULT</label>
+                    <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber/ULT"></textarea>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label" for="type-options">Kiểu tra cứu</label>
+                    <select id="type-options" class="form-select">
+                        <option selected disabled>SELECT TYPE</option>
+                        <option value="SN">Tra cứu theo SN</option>
+                        <option value="ULT">Tra cứu theo ULT</option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label" for="view-mode">Chế độ hiển thị</label>
+                    <select id="view-mode" class="form-select" title="Chọn dữ liệu cho bảng và xuất Excel">
+                        <option value="all" selected>Tất cả dữ liệu</option>
+                        <option value="latest">Kết quả mới nhất (mỗi SN)</option>
+                    </select>
+                </div>
+                <div class="col-md-2 d-grid gap-2">
+                    <button onclick="search()" class="btn btn-nv">Tìm kiếm</button>
+                    <button onclick="downloadExcel()" class="btn btn-nv">Tải xuống Excel</button>
+                </div>
+            </div>
+
+            <div class="allpart-table-wrapper">
+                <div class="table-responsive">
+                    <table id="ULTDataTable" class="display table allpart-table table-hover align-middle w-100">
+                        <thead>
+                            <tr>
+                                <th>SERIAL_NUMBER</th>
+                                <th>MODEL_NAME</th>
+                                <th>GROUP_NAME</th>
+                                <th>TEST_TIME</th>
+                                <th>ULT</th>
+                                <th>STATION_NAME</th>
+                                <th>TEST_ON</th>
+                                <th>TEST_OFF</th>
+                                <th>TEST_RESULT</th>
+                            </tr>
+                        </thead>
+                        <tbody id="ULTDataTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
     <script>
-        // === State ===
-        let rawResults = [];   // Dữ liệu gốc từ API
-        let tableData = [];   // Dữ liệu đang hiển thị / export
-        let dataTable;         // Tham chiếu DataTable
+        let rawResults = [];
+        let tableData = [];
+        let dataTable;
 
-        // === Tooltip helpers ===
         function createTooltipCell(data) {
             const v = data ?? '';
             return `<span class="tooltip-trigger" data-tooltip="${escapeHtml(String(v))}">${escapeHtml(String(v))}</span>`;
         }
+
         function attachTooltipEvents() {
             document.querySelectorAll('.tooltip-trigger').forEach(el => {
                 if (el.dataset.tooltipBound) return;
@@ -108,7 +115,6 @@
             });
         }
 
-        // Tránh XSS trong tooltip/cell
         function escapeHtml(s) {
             return s
                 .replaceAll('&', '&amp;')
@@ -118,7 +124,6 @@
                 .replaceAll("'", '&#39;');
         }
 
-        // === Date helpers ===
         function formatDateTime(dateTime) {
             if (!dateTime) return '';
             const d = new Date(dateTime);
@@ -128,6 +133,7 @@
             const day = String(d.getDate()).padStart(2, '0');
             return `${y}/${m}/${day}`;
         }
+
         function toTime(row) {
             const t = Date.parse(row?.TEST_TIME);
             return !Number.isNaN(t) ? t : -Infinity;
@@ -148,7 +154,6 @@
             return Array.from(bySn.values());
         }
 
-        // === Render ===
         function renderTable(rows) {
             if (!dataTable) return;
             dataTable.clear();
@@ -168,17 +173,13 @@
             dataTable.draw();
             attachTooltipEvents();
         }
+
         function applyViewAndRender() {
             const mode = document.getElementById('view-mode').value;
-            if (mode === 'latest') {
-                tableData = getLatestPerSN(rawResults);
-            } else {
-                tableData = [...rawResults];
-            }
+            tableData = mode === 'latest' ? getLatestPerSN(rawResults) : [...rawResults];
             renderTable(tableData);
         }
 
-        // === Search ===
         async function search() {
             const inputRaw = document.getElementById('serialNumber').value.trim();
             const typeOption = document.getElementById('type-options').value;
@@ -189,7 +190,6 @@
             const inputList = inputRaw.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
             if (inputList.length === 0) { alert('Danh sách trống.'); return; }
 
-            // Loading overlay
             const overlay = document.createElement('div');
             overlay.className = 'loading-overlay';
             overlay.innerHTML = `<div class="spinner"></div><div>Đang tải dữ liệu, vui lòng chờ...</div>`;
@@ -198,73 +198,59 @@
             try {
                 let allResults = [];
                 const batchSize = 100;
-                const url = 'http://10.220.130.119:9090/api/SFC/search-ult-data';
 
                 for (let i = 0; i < inputList.length; i += batchSize) {
                     const batch = inputList.slice(i, i + batchSize);
-                    const body = {
-                        type: typeOption,
-                        data: batch
-                    };
-                    const res = await fetch(url, {
+                    const response = await fetch('http://10.220.130.119:9090/api/CheckInOut/search-ult', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-                        body: JSON.stringify(body)
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            searchType: typeOption,
+                            values: batch
+                        })
                     });
-                    if (!res.ok) throw new Error(`Lỗi API: ${res.status} - ${await res.text()}`);
-                    const json = await res.json();
-                    if (!Array.isArray(json)) throw new Error('Dữ liệu trả về không hợp lệ.');
-                    allResults = allResults.concat(json);
+
+                    if (!response.ok) {
+                        throw new Error('API trả về lỗi: ' + response.status);
+                    }
+
+                    const result = await response.json();
+                    if (result.success && result.data) {
+                        allResults = allResults.concat(result.data);
+                    }
                 }
 
                 rawResults = allResults;
-                if (rawResults.length === 0) {
-                    alert('Không tìm thấy dữ liệu cho các thông tin đã nhập.');
-                }
                 applyViewAndRender();
-            } catch (err) {
-                alert(`Đã xảy ra lỗi: ${err.message}`);
+            } catch (error) {
+                alert(`Đã xảy ra lỗi: ${error.message}`);
             } finally {
-                overlay.remove();
+                document.body.removeChild(overlay);
             }
         }
 
-        // === Export ===
         function downloadExcel() {
             if (!tableData || tableData.length === 0) {
-                alert('Không có dữ liệu để xuất Excel.');
+                alert('Không có dữ liệu để tải xuống.');
                 return;
             }
-            const ws = XLSX.utils.json_to_sheet(tableData);
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws, 'ULTData');
 
-            // Widths (tham khảo theo thứ tự cột)
-            ws['!cols'] = [
-                { wch: 22 }, // SERIAL_NUMBER
-                { wch: 15 }, // MODEL_NAME
-                { wch: 12 }, // GROUP_NAME
-                { wch: 20 }, // TEST_TIME
-                { wch: 20 }, // ULT
-                { wch: 30 }, // STATION_NAME
-                { wch: 12 }, // TEST_ON
-                { wch: 12 }, // TEST_OFF
-                { wch: 18 }  // TEST_RESULT
-            ];
-            XLSX.writeFile(wb, 'ULTData.xlsx');
+            const worksheet = XLSX.utils.json_to_sheet(tableData);
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'ULT_DATA');
+            XLSX.writeFile(workbook, 'ULT_DATA.xlsx');
         }
 
-        // === Init ===
-        $(document).ready(function () {
+        document.addEventListener('DOMContentLoaded', () => {
             dataTable = $('#ULTDataTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
                 responsive: true,
-                fixedHeader: true
+                columnDefs: [
+                    { targets: '_all', width: '160px' }
+                ]
             });
-
-            // Thay đổi chế độ hiển thị -> render lại từ rawResults
-            $('#view-mode').on('change', applyViewAndRender);
+            attachTooltipEvents();
         });
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/YRDCLC/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/YRDCLC/Index.cshtml
@@ -1,86 +1,101 @@
-﻿@{
-    ViewData["Title"] = "YR follow DC-LC";
-}
 @{
+    ViewData["Title"] = "YR follow DC-LC";
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
+<link rel="stylesheet" href="~/assets/Areas/Allpart/css/theme.css" asp-append-version="true" />
 
-<link href="~/assets/css/yrdclc.css" rel="stylesheet" />
-
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">YR follow DC/LC</h1>
-    </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="date-time-range">
-                <label for="startDate">Bắt đầu:</label>
-                <input type="datetime-local" id="startDate" />
-                <label for="endDate">Kết thúc:</label>
-                <input type="datetime-local" id="endDate" />
+<section class="allpart-page py-4">
+    <div class="allpart-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>YR follow DC/LC</h1>
+                <p>Phân tích dữ liệu DC/LC theo thời gian, model và mã lỗi với giao diện trực quan.</p>
             </div>
-        </div>
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-2">
-                <input id="model" name="model" class="form-control" placeholder="Model Name" />
-            </div>
-            <div class="col-md-2">
-                <input id="PN" name="PN" class="form-control" placeholder="Mã Liệu" />
-            </div>
-            <div class="col-md-2">
-                <input id="location" name="location" class="form-control" placeholder="Vị trí" />
-            </div>
-            <div class="col-md-2">
-                <input id="station" name="station" class="form-control" placeholder="Trạm test" />
-            </div>
-            <div class="col-md-2">
-                <input id="error" name="error" class="form-control" placeholder="Mã lỗi" />
-            </div>
-        </div>
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-            <div class="col-md-2">
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Load data</button>
-            </div>
-        </div>
-
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="yrdcLcTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>MODEL_NAME</th>
-                            <th>MÃ_LIỆU</th>
-                            <th>DATE_CODE</th>
-                            <th>LOT_CODE</th>
-                            <th>VENDOR_NAME</th>
-                            <th>INPUT_QTY</th>
-                            <th>FAIL_QTY</th>
-                            <th>PASS_QTY</th>
-                            <th>DFR</th>
-                        </tr>
-                    </thead>
-                    <tbody id="yrdcLcTableBody"></tbody>
-                </table>
+            <div class="allpart-badge-list">
+                <span class="badge"><i class="fas fa-calendar me-2"></i>Lọc theo thời gian</span>
+                <span class="badge"><i class="fas fa-chart-line me-2"></i>Thống kê DFR</span>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="allpart-card shadow-sm">
+        <div class="allpart-card-header">
+            <h2 class="allpart-card-title">Tìm kiếm dữ liệu YR</h2>
+            <p class="allpart-card-subtitle">Thiết lập bộ lọc và tải dữ liệu nhanh chóng</p>
+        </div>
+        <div class="allpart-card-body">
+            <div class="row g-3 mb-3 align-items-center">
+                <div class="col-md-12 d-flex flex-wrap gap-3 align-items-center">
+                    <div class="d-flex align-items-center gap-2">
+                        <label for="startDate" class="form-label m-0">Bắt đầu:</label>
+                        <input type="datetime-local" id="startDate" class="form-control" />
+                    </div>
+                    <div class="d-flex align-items-center gap-2">
+                        <label for="endDate" class="form-label m-0">Kết thúc:</label>
+                        <input type="datetime-local" id="endDate" class="form-control" />
+                    </div>
+                </div>
+            </div>
+            <div class="row g-3 mb-4 align-items-center">
+                <div class="col-md-2">
+                    <label class="form-label" for="model">Model Name</label>
+                    <input id="model" name="model" class="form-control" placeholder="Model Name" />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label" for="PN">Mã Liệu</label>
+                    <input id="PN" name="PN" class="form-control" placeholder="Mã Liệu" />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label" for="location">Vị trí</label>
+                    <input id="location" name="location" class="form-control" placeholder="Vị trí" />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label" for="station">Trạm test</label>
+                    <input id="station" name="station" class="form-control" placeholder="Trạm test" />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label" for="error">Mã lỗi</label>
+                    <input id="error" name="error" class="form-control" placeholder="Mã lỗi" />
+                </div>
+                <div class="col-md-2 d-grid gap-2">
+                    <button onclick="search()" class="btn btn-nv">Tìm kiếm</button>
+                    <button onclick="downloadExcel()" class="btn btn-nv">Load data</button>
+                </div>
+            </div>
+
+            <div class="allpart-table-wrapper">
+                <div class="table-responsive">
+                    <table id="yrdcLcTable" class="display table allpart-table table-hover align-middle w-100">
+                        <thead>
+                            <tr>
+                                <th>MODEL_NAME</th>
+                                <th>MÃ_LIỆU</th>
+                                <th>DATE_CODE</th>
+                                <th>LOT_CODE</th>
+                                <th>VENDOR_NAME</th>
+                                <th>INPUT_QTY</th>
+                                <th>FAIL_QTY</th>
+                                <th>PASS_QTY</th>
+                                <th>DFR</th>
+                            </tr>
+                        </thead>
+                        <tbody id="yrdcLcTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-
     <script>
         let yrdcLcTable;
         let snDataCache = []; // Lưu dữ liệu BY-FAIL-SN để xuất Excel
 
-        // Hàm tạo nội dung cho ô với tooltip
         function createTooltipCell(data) {
             return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
         }
 
-        // Gắn sự kiện tooltip sử dụng event delegation
         function attachTooltipEvents() {
             $(document).on('mouseover', '.tooltip-trigger', function (e) {
                 const $this = $(this);
@@ -111,7 +126,6 @@
             });
         }
 
-        // Hàm định dạng ngày giờ từ datetime-local sang YYYY-MM-DD HH:MM:SS
         function formatDateTime(dateTime) {
             if (!dateTime) return '';
             const date = new Date(dateTime);
@@ -125,7 +139,6 @@
         }
 
         $(document).ready(function () {
-            // Khởi tạo DataTable
             yrdcLcTable = $('#yrdcLcTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
@@ -135,7 +148,6 @@
                 ]
             });
 
-            // Gắn sự kiện tooltip
             attachTooltipEvents();
         });
 
@@ -148,17 +160,14 @@
             const startDate = document.getElementById('startDate').value;
             const endDate = document.getElementById('endDate').value;
 
-            // Kiểm tra đầu vào
             if (!model || !PN || !station || !error || !location || !startDate || !endDate) {
                 alert('Vui lòng nhập đầy đủ tất cả các trường!');
                 return;
             }
 
-            // Định dạng thời gian
             const formattedStartDate = formatDateTime(startDate);
             const formattedEndDate = formatDateTime(endDate);
 
-            // Hiển thị loading overlay
             const loadingOverlay = document.createElement('div');
             loadingOverlay.className = 'loading-overlay';
             loadingOverlay.innerHTML = `
@@ -168,10 +177,8 @@
             document.body.appendChild(loadingOverlay);
 
             try {
-                // Làm mới bảng trước khi tìm kiếm
                 yrdcLcTable.clear();
 
-                // Lần gọi API đầu tiên (BY-FAIL-TOTAL)
                 const totalResponse = await fetch('http://10.220.130.119:9090/api/RepairStatus/check-yr-by-dclc', {
                     method: 'POST',
                     headers: {
@@ -201,14 +208,13 @@
                     return;
                 }
 
-                // Hiển thị dữ liệu từ lần gọi đầu tiên vào bảng
                 totalData.result.forEach(item => {
                     yrdcLcTable.row.add([
-                        createTooltipCell(item.p_no),
+                        createTooltipCell(item.model_name),
                         createTooltipCell(item.kp_no),
                         createTooltipCell(item.date_code),
                         createTooltipCell(item.lot_code),
-                        createTooltipCell(item.mfr_name),
+                        createTooltipCell(item.vendor_name),
                         createTooltipCell(item.input_qty),
                         createTooltipCell(item.fail_qty),
                         createTooltipCell(item.pass_qty),
@@ -216,7 +222,8 @@
                     ]).draw();
                 });
 
-                // Lần gọi API thứ hai (BY-FAIL-SN)
+                attachTooltipEvents();
+
                 const snResponse = await fetch('http://10.220.130.119:9090/api/RepairStatus/check-yr-by-dclc', {
                     method: 'POST',
                     headers: {
@@ -240,82 +247,25 @@
                 }
 
                 const snData = await snResponse.json();
-                if (!snData.result || snData.result.length === 0) {
-                    console.warn('Không có dữ liệu từ API BY-FAIL-SN.');
-                } else {
-                    // Lưu dữ liệu BY-FAIL-SN để xuất Excel
-                    snDataCache = snData.result;
-                }
-
-                // Gắn sự kiện tooltip
-                attachTooltipEvents();
+                snDataCache = snData.result || [];
 
             } catch (error) {
                 alert(`Đã xảy ra lỗi: ${error.message}`);
             } finally {
-                // Xóa loading overlay
-                if (document.body.contains(loadingOverlay)) {
-                    document.body.removeChild(loadingOverlay);
-                }
+                document.body.removeChild(loadingOverlay);
             }
         }
 
         function downloadExcel() {
-            if (!snDataCache.length && !yrdcLcTable.rows().data().toArray().length) {
-                alert('Không có dữ liệu để tải xuống Excel!');
+            if (!snDataCache || snDataCache.length === 0) {
+                alert('Không có dữ liệu SN để tải xuống. Vui lòng nhấn "Tìm kiếm" trước.');
                 return;
             }
 
-            // Dữ liệu cho sheet 1 (từ bảng yrdcLcTable)
-            const totalData = [
-                ['MODEL_NAME', 'MÃ_LIỆU', 'DATE_CODE', 'LOT_CODE', 'VENDOR_NAME', 'INPUT_QTY', 'FAIL_QTY', 'PASS_QTY', 'DFR']
-            ];
-            yrdcLcTable.rows().data().toArray().forEach(row => {
-                const rowData = Array.from(row).map(cell => {
-                    const div = document.createElement('div');
-                    div.innerHTML = cell;
-                    return div.textContent || '';
-                });
-                totalData.push(rowData);
-            });
-
-            // Dữ liệu cho sheet 2 (từ snDataCache)
-            const snData = [
-                ['P_SN', 'WO', 'P_NO', 'TR_SN', 'KP_NO', 'MFR_KP_NO', 'DATE_CODE', 'LOT_CODE', 'MFR_NAME', 'PROCESS_FLAG', 'STATION', 'GROUP_NAME', 'WORK_TIME', 'REF_DES', 'TEST_CODE', 'TEST_GROUP']
-            ];
-            snDataCache.forEach(item => {
-                snData.push([
-                    item.p_sn,
-                    item.wo,
-                    item.p_no,
-                    item.tr_sn,
-                    item.kp_no,
-                    item.mfr_kp_no,
-                    item.date_code,
-                    item.lot_code,
-                    item.mfr_name,
-                    item.process_flag,
-                    item.station,
-                    item.group_name,
-                    item.work_time,
-                    item.ref_des,
-                    item.test_code,
-                    item.test_group
-                ]);
-            });
-
-            // Tạo worksheet cho sheet 1
-            const ws1 = XLSX.utils.aoa_to_sheet(totalData);
-            // Tạo worksheet cho sheet 2
-            const ws2 = XLSX.utils.aoa_to_sheet(snData);
-
-            // Tạo workbook và thêm các sheet
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws1, "Total_Data");
-            XLSX.utils.book_append_sheet(wb, ws2, "SN_Data");
-
-            // Xuất file Excel
-            XLSX.writeFile(wb, 'yrdc_lc_data_' + new Date().toISOString().slice(0, 10) + '.xlsx');
+            const worksheet = XLSX.utils.json_to_sheet(snDataCache);
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'YR_BY_FAIL_SN');
+            XLSX.writeFile(workbook, 'YR_BY_FAIL_SN.xlsx');
         }
     </script>
 }

--- a/PESystem/Areas/Scrap/Views/Function/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function/Index.cshtml
@@ -1,222 +1,214 @@
-﻿﻿@{
-    ViewData["Title"] = "Scrap Area";
-}
 @{
-    Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
+    ViewData["Title"] = "Scrap Area";
+    Layout = "~/Areas/Scrap/Views/Shared/Layout_scrap.cshtml";
 }
 
-<div class="row">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="INPUT_SN">INPUT SN</option>
-                <option value="CREATE_TASK_FORM">CREATE TASK FORM</option>
-                <option value="CREATE_TASK_FORM_SN">CREATE TASK FORM BY SN</option>
-                <option value="UPDATE_DATA">UPDATE DATA</option>
-                <option value="HISTORY_APPLY">HISTORY APPLY</option>
-            </select>
-        </form>
+<section class="scrap-page container-fluid py-4">
+    <div class="scrap-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>SN - SPE Approved</h1>
+                <p>Quản lý danh sách bản lỗi đã được SPE phê duyệt và chuẩn bị gửi task nội bộ chỉ trong vài cú nhấp chuột.</p>
+            </div>
+            <div class="scrap-badge-list">
+                <span class="scrap-chip"><i class="fas fa-recycle"></i>Internal task mới nhất 3 tháng</span>
+                <span class="scrap-chip"><i class="fas fa-database"></i>Tổng hợp số lượng tự động</span>
+                <span class="scrap-chip"><i class="fas fa-bullseye"></i>Quản lý mục đích rõ ràng</span>
+            </div>
+        </div>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row align-items-end">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-input" class="form-control" rows="10" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-xl-4">
+            <div class="scrap-card h-100">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chức năng nhanh</h2>
+                    <p class="scrap-card-subtitle">Lựa chọn tác vụ phù hợp với nhu cầu hiện tại</p>
                 </div>
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <input type="text" id="description-input" name="description" class="form-control" placeholder="Tiêu đề mail khách hàng approved">
-                    </div>
-                    <div class="mb-2">
-                        <input type="text" id="NVmember-input" name="po" class="form-control" placeholder="Nhập tên khách hàng approved">
-                    </div>
-                    <div class="mb-2">
-                        <select id="Scrap-options" class="form-select">
-                            <option selected disabled>Select type scrap</option>
-                            <option value="0">SPE approve to scrap</option>
-                            <option value="1">Scrap to quarterly</option>
-                            <option value="2">Approved to engineer sample</option>
-                            <option value="3">Approved to master board</option>
-                            <option value="4">Approved to BGA</option>
-                        </select>
-                    </div>
-                    <div class="mb-2">
-                        <label for="speApproveTime-input" class="form-label">Thời gian khách hàng approve</label>
-                        <input type="date" id="speApproveTime-input" name="speApproveTime" class="form-control" />
-                    </div>
-                    <div class="mb-2">
-                        <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                    </div>
+                <div class="scrap-card-body">
+                    <form id="search-form" class="d-flex flex-column gap-3">
+                        <div>
+                            <label for="search-options" class="form-label">Chọn chức năng</label>
+                            <select id="search-options" class="form-select">
+                                <option selected disabled>SELECT FUNCTION</option>
+                                <option value="INPUT_SN">INPUT SN</option>
+                                <option value="CREATE_TASK_FORM">CREATE TASK FORM</option>
+                                <option value="CREATE_TASK_FORM_SN">CREATE TASK FORM BY SN</option>
+                                <option value="UPDATE_DATA">UPDATE DATA</option>
+                            </select>
+                        </div>
+                        <div class="scrap-hint">
+                            <i class="fas fa-lightbulb me-2"></i>
+                            Chọn một chức năng để hiển thị biểu mẫu tương ứng. Các thông tin được lưu lại cho lần thao tác tiếp theo.
+                        </div>
+                    </form>
                 </div>
             </div>
-        </form>
+        </div>
 
-        <!-- Form create task -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="CREATE_TASK_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="create-task-btn" class="btn btn-ne" type="button">Create task</button>
+        <div class="col-xl-8 d-flex flex-column gap-4">
+            <form id="input-sn-form" method="post" class="scrap-card hidden" data-search-type="INPUT_SN">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Nhập danh sách SN</h2>
+                    <p class="scrap-card-subtitle">Gửi thông tin bản lỗi và tạo internal task tự động</p>
                 </div>
-            </div>
-        </form>
-
-        <!-- Form create task by SN -->
-        <form id="custom-form-sn" method="post" class="hidden" data-search-type="CREATE_TASK_FORM_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-4">
-                    <textarea name="SN box" id="create-task-btn-sn-box" class="form-control" rows="5" placeholder="Nhập SN"></textarea>
-                </div>
-                <div class="col-md-2">
-                    <button id="create-task-btn-sn" class="btn btn-ne" type="button">Create task</button>
-                </div>
-            </div>
-        </form>
-
-        <!-- Form update data -->
-        <form id="update-data-form" method="post" class="hidden" data-search-type="UPDATE_DATA">
-            <div class="row">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-input-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
-                </div>
-
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="task-input" class="form-label">Task</label>
-                        <input type="text" id="task-input" name="task" class="form-control" placeholder="Nhập Task">
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-6">
+                            <label for="sn-input" class="form-label">Danh sách Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input" class="form-control" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                            <div class="scrap-hint">Mỗi SN tối đa 50 ký tự. Hệ thống sẽ kiểm tra tự động trước khi xử lý.</div>
+                        </div>
+                        <div class="col-lg-6 d-flex flex-column gap-3">
+                            <div>
+                                <label for="description-input" class="form-label">Tiêu đề phê duyệt</label>
+                                <input type="text" id="description-input" name="description" class="form-control" placeholder="Tiêu đề mail khách hàng approved" />
+                            </div>
+                            <div>
+                                <label for="NVmember-input" class="form-label">Khách hàng phê duyệt</label>
+                                <input type="text" id="NVmember-input" name="po" class="form-control" placeholder="Nhập tên khách hàng approved" />
+                            </div>
+                            <div>
+                                <label for="Scrap-options" class="form-label">Mục đích xử lý</label>
+                                <select id="Scrap-options" class="form-select">
+                                    <option selected disabled>Select type scrap</option>
+                                    <option value="0">SPE approve to scrap</option>
+                                    <option value="1">Scrap to quarterly</option>
+                                    <option value="2">Approved to engineer sample</option>
+                                    <option value="3">Approved to master board</option>
+                                    <option value="4">Approved to BGA</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label for="speApproveTime-input" class="form-label">Thời gian khách hàng approve</label>
+                                <input type="date" id="speApproveTime-input" name="speApproveTime" class="form-control" />
+                            </div>
+                            <div class="pt-2">
+                                <button id="input-sn-btn" class="btn btn-nv" type="button">INPUT SN</button>
+                            </div>
+                        </div>
                     </div>
-                    <div class="mb-2">
-                        <label for="po-input" class="form-label">PO</label>
-                        <input type="text" id="po-input" name="po" class="form-control" placeholder="Nhập PO">
-                    </div>
-                    <button id="update-task-btn" class="btn btn-ne mt-1" type="button">Update</button>
                 </div>
+            </form>
 
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="cost-input" class="form-label">Cost</label>
-                        <input type="text" id="cost-input" name="cost" class="form-control" placeholder="Nhập Cost">
-                    </div>
-                    <div class="mb-2">
-                        <label for="file-input" class="form-label">Upload Excel File (Board SN & Cost)</label>
-                        <input type="file" id="file-input" name="file" class="form-control" accept=".xlsx, .xls">
-                    </div>
-                    <button id="update-cost-btn" class="btn btn-ne mt-1" type="button">Update Cost</button>
+            <form id="custom-form" method="post" class="scrap-card hidden" data-search-type="CREATE_TASK_FORM">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Tạo task nội bộ</h2>
+                    <p class="scrap-card-subtitle">Kết nối dữ liệu SPE đã duyệt với hệ thống MRB</p>
                 </div>
-            </div>
-        </form>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0">
+                        <i class="fas fa-check-circle me-2"></i>Chọn các Internal Task bên dưới, sau đó nhấn tạo task.
+                    </div>
+                    <button id="create-task-btn" class="btn btn-nv" type="button">Create task</button>
+                </div>
+            </form>
 
-        <!-- Form history apply -->
-        <form id="history-apply-form" method="post" class="hidden" data-search-type="HISTORY_APPLY_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="create-history-task-btn" class="btn btn-ne" type="button">Data</button>
+            <form id="custom-form-sn" method="post" class="scrap-card hidden" data-search-type="CREATE_TASK_FORM_SN">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Tạo task theo Serial Number</h2>
+                    <p class="scrap-card-subtitle">Tải task trực tiếp cho danh sách SN cụ thể</p>
                 </div>
-            </div>
-        </form>
+                <div class="scrap-card-body">
+                    <div class="row g-4 align-items-start">
+                        <div class="col-lg-8">
+                            <label for="create-task-btn-sn-box" class="form-label">Danh sách SN</label>
+                            <textarea name="SN box" id="create-task-btn-sn-box" class="form-control" rows="6" placeholder="Nhập SN (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-lg-4 d-flex align-items-end">
+                            <button id="create-task-btn-sn" class="btn btn-nv w-100" type="button">Create task</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+
+            <form id="update-data-form" method="post" class="scrap-card hidden" data-search-type="UPDATE_DATA">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Cập nhật thông tin nội bộ</h2>
+                    <p class="scrap-card-subtitle">Điều chỉnh Task, PO và chi phí trực tiếp từ bảng ScrapList</p>
+                </div>
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-4">
+                            <label for="sn-input-update" class="form-label">Danh sách SN</label>
+                            <textarea name="serialNumbers" id="sn-input-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-lg-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="task-input" class="form-label">Task</label>
+                                <input type="text" id="task-input" name="task" class="form-control" placeholder="Nhập Task" />
+                            </div>
+                            <div>
+                                <label for="po-input" class="form-label">PO</label>
+                                <input type="text" id="po-input" name="po" class="form-control" placeholder="Nhập PO" />
+                            </div>
+                            <button id="update-task-btn" class="btn btn-nv" type="button">Update Task &amp; PO</button>
+                        </div>
+                        <div class="col-lg-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="cost-input" class="form-label">Cost</label>
+                                <input type="text" id="cost-input" name="cost" class="form-control" placeholder="Nhập Cost" />
+                            </div>
+                            <div>
+                                <label for="file-input" class="form-label">Upload Excel (Board SN &amp; Cost)</label>
+                                <input type="file" id="file-input" name="file" class="form-control" accept=".xlsx, .xls" />
+                            </div>
+                            <button id="update-cost-btn" class="btn btn-nv" type="button">Update Cost</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
     </div>
-</div>
 
-<!--hiển thị của chức năng input sn-->
-<div id="input-sn-result" class="hidden"></div>
+    <div class="d-flex flex-column gap-4 mt-4">
+        <div id="input-sn-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
 
-<!--hiển thị của chức năng create task-->
-<div id="create-task-result" class="hidden">
-    <table id="task-checkbox-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-        <thead>
-            <tr>
-                <th class="checkbox-column"><input type="checkbox" id="select-all"></th>
-                <th>INTERNAL_TASK</th>
-                <th>DESCRIPTION</th>
-                <th>NV_APPROVE</th>
-                <th>KANBAN_STATUS</th>
-                <th>CATEGORY</th>
-                <th>TYPE_BP</th>
-                <th>CREATE_TIME</th>
-                <th>CREATE_BY</th>
-                <th>APPLY_TASK_STATUS</th>
-                <th>TOTAL_Q'TY</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
+        <div id="create-task-result" class="scrap-card hidden">
+            <div class="scrap-card-header">
+                <h2 class="scrap-card-title">Danh sách Internal Task</h2>
+                <p class="scrap-card-subtitle">Tích chọn những Internal Task cần tạo task hệ thống</p>
+            </div>
+            <div class="scrap-card-body">
+                <div data-role="result-message" class="mb-3"></div>
+                <div class="scrap-table-wrapper">
+                    <div class="table-responsive">
+                        <table id="task-checkbox-table" class="table table-hover scrap-table align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th class="checkbox-column"><input type="checkbox" id="select-all" /></th>
+                                    <th>INTERNAL_TASK</th>
+                                    <th>DESCRIPTION</th>
+                                    <th>PURPOSE</th>
+                                    <th>NV_APPROVE</th>
+                                    <th>KANBAN_STATUS</th>
+                                    <th>CATEGORY</th>
+                                    <th>TYPE_BP</th>
+                                    <th>CREATE_TIME</th>
+                                    <th>CREATE_BY</th>
+                                    <th>APPLY_TASK_STATUS</th>
+                                    <th>TOTAL_Q'TY</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-<!--hiển thị của chức năng create task by sn-->
-<div id="create-task-result-sn" class="hidden"></div>
+        <div id="create-task-result-sn" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
 
-<!--hiển thị của chức năng update data-->
-<div id="update-data-result" class="hidden"></div>
-
-<!--hiển thị của chức năng update data-->
-<div id="history-apply-result" class="hidden">
-    <table id="history-task-checkbox-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-        <thead>
-            <tr>
-                <th class="checkbox-column"><input type="checkbox" id="select-all-history"></th>
-                <th>INTERNAL_TASK</th>
-                <th>DESCRIPTION</th>
-                <th>NV_APPROVE</th>
-                <th>KANBAN_STATUS</th>
-                <th>CATEGORY</th>
-                <th>TYPE_BP</th>
-                <th>CREATE_TIME</th>
-                <th>CREATE_BY</th>
-                <th>APPLY_TIME</th>
-                <th>APPLY_TASK_STATUS</th>
-                <th>TOTAL_Q'TY</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
-
-
+        <div id="update-data-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-    <!-- Script tùy chỉnh -->
-    <script src="~/assets/areas/scrap/js/function.js?v=@DateTime.Now.Ticks"></script>
-    <style>
-        .hidden {
-            display: none !important;
-        }
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 20px!important; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center !important;
-        }
-        /* Giới hạn độ rộng cột */
-        #task-checkbox-table th, #task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            /*max-width: 80px!important;  Giới hạn độ rộng cột */
-        }
-
-        /* Giới hạn độ rộng cột */
-        #history-task-checkbox-table th, #history-task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            /*max-width: 80px!important;  Giới hạn độ rộng cột */
-        }
-        #history-task-checkbox-table td, #task-checkbox-table td{
-            background-color:#fff;
-        }
-
-         /* Thêm hiệu ứng hover cho hàng */
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76b900 !important;
-            /*transition: background-color 0.2s ease;*/
-        }
-
-
-    </style>
+    <script src="~/assets/Areas/Scrap/js/Function.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
@@ -1,184 +1,114 @@
-﻿﻿﻿@{
-    ViewData["Title"] = "process can't repair";
-}
 @{
-    Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
+    ViewData["Title"] = "Process can't repair";
+    Layout = "~/Areas/Scrap/Views/Shared/Layout_scrap.cshtml";
 }
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="INPUT_SN_1">INPUT SN</option>
-                <option value="SN_PROCESS_CANT_REPAIR">SN process can't repair'</option>
-            </select>
-        </form>
+
+<section class="scrap-page container-fluid py-4">
+    <div class="scrap-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>Process Can't Repair</h1>
+                <p>Theo dõi và tải danh sách bản lỗi không thể sửa chữa, đồng thời cập nhật tình trạng nhanh chóng.</p>
+            </div>
+            <div class="scrap-badge-list">
+                <span class="scrap-chip"><i class="fas fa-screwdriver-wrench"></i>SN lỗi process</span>
+                <span class="scrap-chip"><i class="fas fa-upload"></i>Tải dữ liệu dạng Excel</span>
+            </div>
+        </div>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-1-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-xl-4">
+            <div class="scrap-card h-100">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chức năng nhanh</h2>
+                    <p class="scrap-card-subtitle">Chọn tác vụ để bắt đầu thao tác</p>
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="description-input" class="form-label">Description</label>
-                        <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
-                    </div>
-                    <!--<div class="mb-2">
-                        <label for="tpye-bp-input" class="form-label">Type Bonepile</label>
-                        <select id="bp-options" class="form-select">
-                            <option selected disabled>SELECT TYPE BONEPILE</option>
-                            <option value="BP-10">BONEPILE 1.0</option>
-                            <option value="BP-20">BONEPILE 2.0</option>
-                            <option value="B36R">AFFTER KANBAN</option>
-                        </select>
-                    </div>-->
-                    <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                </div>
-                <!--<div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="tpye-approve-input" class="form-label">Type approve input</label>
-                        <select id="approve-options" class="form-select">
-                            <option selected disabled>SELECT TYPE APPROVE</option>
-                            <option value="2">Waiting SPE Approve Scrap</option>
-                            <option value="4">Waiting SPE Approve BGA</option>
-                        </select>
-                    </div>
-                </div>-->
-            </div>
-        </form>
-
-        <!-- Form sn wait approve result -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="SN_WAIT_LIST_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
+                <div class="scrap-card-body">
+                    <form class="d-flex flex-column gap-3">
+                        <div>
+                            <label for="search-options" class="form-label">Chọn chức năng</label>
+                            <select id="search-options" class="form-select">
+                                <option selected disabled>SELECT FUNCTION</option>
+                                <option value="INPUT_SN_1">INPUT SN</option>
+                                <option value="SN_PROCESS_CANT_REPAIR">SN process can't repair</option>
+                            </select>
+                        </div>
+                        <div class="scrap-hint">
+                            <i class="fas fa-info-circle me-2"></i>Lựa chọn một chức năng để hiển thị biểu mẫu tương ứng ở bên phải.
+                        </div>
+                    </form>
                 </div>
             </div>
-        </form>
-    </div>
-</div>
-
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng input sn 1-->
-    <div id="input-sn-1-result" class="hidden"></div>
-    <!--hiển thị của chức năng sn đợi SPE approve-->
-    <div id="sn-wait-approve-result" class="hidden">
-        <div class="table-container">
-            <table id="table-sn-wait-approve" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>SERIAL_NUMBER</th>
-                        <th>DESCRIPTION</th>
-                        <th>CREATE_TIME</th>
-                        <th>APPLY_TASK_STATUS</th>
-                        <th>CREATE_BY</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </div>
 
+        <div class="col-xl-8 d-flex flex-column gap-4">
+            <form id="input-sn-1-form" method="post" class="scrap-card hidden" data-search-type="INPUT_SN">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Nhập danh sách SN lỗi process</h2>
+                    <p class="scrap-card-subtitle">Thêm mới danh sách SN không thể sửa chữa để thông báo SPE</p>
+                </div>
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-6">
+                            <label for="sn-input-1" class="form-label">Danh sách Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-lg-6">
+                            <label for="description-input-1" class="form-label">Mô tả lỗi</label>
+                            <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả chi tiết" />
+                            <div class="scrap-hint mt-2">Giữ thông tin mô tả rõ ràng để SPE dễ dàng theo dõi.</div>
+                            <button id="input-sn-btn" class="btn btn-nv mt-3" type="button">INPUT SN</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+
+            <form id="custom-form" method="post" class="scrap-card hidden" data-search-type="SN_WAIT_LIST_FORM">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Danh sách SN lỗi process</h2>
+                    <p class="scrap-card-subtitle">Tải dữ liệu hiện tại để phân tích và xử lý</p>
+                </div>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0"><i class="fas fa-download me-2"></i>Dữ liệu sẽ được xuất ra định dạng Excel.</div>
+                    <button id="sn-wait-list-btn" class="btn btn-nv" type="button">Download Excel</button>
+                </div>
+            </form>
+        </div>
     </div>
-</div>
+
+    <div class="d-flex flex-column gap-4 mt-4">
+        <div id="input-sn-1-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
+
+        <div id="sn-wait-approve-result" class="scrap-card hidden">
+            <div class="scrap-card-header">
+                <h2 class="scrap-card-title">SN process can't repair</h2>
+                <p class="scrap-card-subtitle">Danh sách cập nhật theo thời gian thực</p>
+            </div>
+            <div class="scrap-card-body">
+                <div class="scrap-table-wrapper">
+                    <div class="table-responsive">
+                        <table id="table-sn-wait-approve" class="table table-hover scrap-table align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th>SERIAL_NUMBER</th>
+                                    <th>DESCRIPTION</th>
+                                    <th>CREATE_TIME</th>
+                                    <th>APPLY_TASK_STATUS</th>
+                                    <th>CREATE_BY</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(3), td:nth-child(3), /* Cột Create Time */
-            th:nth-child(4), td:nth-child(4) { /* Cột Apply Task Status */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description) */
-            th:nth-child(2), td:nth-child(2) { /* Cột Description */
-                white-space: normal; /* Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
-    <script src="~/assets/areas/scrap/js/function0.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/Function0.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
@@ -1,185 +1,136 @@
-﻿﻿﻿@{
-    ViewData["Title"] = "Scrap Area";
-}
 @{
-    Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
+    ViewData["Title"] = "SN wait SPE approve";
+    Layout = "~/Areas/Scrap/Views/Shared/Layout_scrap.cshtml";
 }
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="INPUT_SN_1">INPUT SN</option>
-                <option value="SN_WAIT_SPE_APPROVE">SN WAIT SPE APPROVE</option>
-            </select>
-        </form>
+
+<section class="scrap-page container-fluid py-4">
+    <div class="scrap-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>SN - Wait SPE Approve</h1>
+                <p>Quản lý danh sách bản lỗi chờ SPE duyệt và cập nhật trạng thái xin phế nhanh chóng.</p>
+            </div>
+            <div class="scrap-badge-list">
+                <span class="scrap-chip"><i class="fas fa-user-check"></i>Chờ SPE duyệt</span>
+                <span class="scrap-chip"><i class="fas fa-file-export"></i>Xuất dữ liệu linh hoạt</span>
+            </div>
+        </div>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-1-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-xl-4">
+            <div class="scrap-card h-100">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chức năng nhanh</h2>
+                    <p class="scrap-card-subtitle">Lựa chọn tác vụ để làm việc với danh sách SN</p>
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="description-input" class="form-label">Description</label>
-                        <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
-                    </div>
-                    <div class="mb-2">
-                        <label for="tpye-bp-input" class="form-label">Type Bonepile</label>
-                        <select id="bp-options" class="form-select">
-                            <option selected disabled>SELECT TYPE BONEPILE</option>
-                            <option value="BP-10">BONEPILE 1.0</option>
-                            <option value="BP-20">BONEPILE 2.0</option>
-                            <option value="B36R">AFFTER KANBAN</option>
-                        </select>
-                    </div>
-                    <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="tpye-approve-input" class="form-label">Type approve input</label>
-                        <select id="approve-options" class="form-select">
-                            <option selected disabled>SELECT TYPE APPROVE</option>
-                            <option value="2">Waiting SPE Approve Scrap</option>
-                            <option value="4">Waiting SPE Approve BGA</option>
-                        </select>
-                    </div>
+                <div class="scrap-card-body">
+                    <form class="d-flex flex-column gap-3">
+                        <div>
+                            <label for="search-options" class="form-label">Chọn chức năng</label>
+                            <select id="search-options" class="form-select">
+                                <option selected disabled>SELECT FUNCTION</option>
+                                <option value="INPUT_SN_1">INPUT SN</option>
+                                <option value="SN_WAIT_SPE_APPROVE">SN WAIT SPE APPROVE</option>
+                            </select>
+                        </div>
+                        <div class="scrap-hint">
+                            <i class="fas fa-circle-info me-2"></i>Chọn tác vụ để hiển thị biểu mẫu tương ứng bên phải.
+                        </div>
+                    </form>
                 </div>
             </div>
-        </form>
-
-        <!-- Form sn wait approve result -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="SN_WAIT_LIST_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
-                </div>
-            </div>
-        </form>
-    </div>
-</div>
-
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng input sn 1-->
-    <div id="input-sn-1-result" class="hidden"></div>
-    <!--hiển thị của chức năng sn đợi SPE approve-->
-    <div id="sn-wait-approve-result" class="hidden">
-        <div class="table-container">
-            <table id="table-sn-wait-approve" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>SERIAL_NUMBER</th>
-                        <th>DESCRIPTION</th>
-                        <th>CREATE_TIME</th>
-                        <th>APPLY_TASK_STATUS</th>
-                        <th>BONEPILE_TYPE</th>
-                        <th>CREATE_BY</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </div>
 
+        <div class="col-xl-8 d-flex flex-column gap-4">
+            <form id="input-sn-1-form" method="post" class="scrap-card hidden" data-search-type="INPUT_SN">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Nhập SN chờ SPE duyệt</h2>
+                    <p class="scrap-card-subtitle">Thêm mới danh sách SN cần xin phế / thay BGA</p>
+                </div>
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-4">
+                            <label for="sn-input-1" class="form-label">Danh sách Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-lg-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="description-input-1" class="form-label">Mô tả</label>
+                                <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả" />
+                            </div>
+                            <div>
+                                <label for="bp-options" class="form-label">Type Bonepile</label>
+                                <select id="bp-options" class="form-select">
+                                    <option selected disabled>SELECT TYPE BONEPILE</option>
+                                    <option value="BP-10">BONEPILE 1.0</option>
+                                    <option value="BP-20">BONEPILE 2.0</option>
+                                    <option value="B36R">AFTER KANBAN</option>
+                                </select>
+                            </div>
+                            <button id="input-sn-btn" class="btn btn-nv" type="button">INPUT SN</button>
+                        </div>
+                        <div class="col-lg-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="approve-options" class="form-label">Loại yêu cầu</label>
+                                <select id="approve-options" class="form-select">
+                                    <option selected disabled>SELECT TYPE APPROVE</option>
+                                    <option value="2">Waiting SPE Approve Scrap</option>
+                                    <option value="4">Waiting SPE Approve BGA</option>
+                                </select>
+                            </div>
+                            <div class="scrap-hint">Chọn đúng loại xin phế để hệ thống phân loại chính xác.</div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+
+            <form id="custom-form" method="post" class="scrap-card hidden" data-search-type="SN_WAIT_LIST_FORM">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Danh sách SN chờ SPE duyệt</h2>
+                    <p class="scrap-card-subtitle">Tải dữ liệu hiện tại để theo dõi tiến độ phê duyệt</p>
+                </div>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0"><i class="fas fa-cloud-download-alt me-2"></i>Dữ liệu được xuất theo định dạng Excel.</div>
+                    <button id="sn-wait-list-btn" class="btn btn-nv" type="button">Download Excel</button>
+                </div>
+            </form>
+        </div>
     </div>
-</div>
+
+    <div class="d-flex flex-column gap-4 mt-4">
+        <div id="input-sn-1-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
+
+        <div id="sn-wait-approve-result" class="scrap-card hidden">
+            <div class="scrap-card-header">
+                <h2 class="scrap-card-title">SN chờ SPE duyệt</h2>
+                <p class="scrap-card-subtitle">Hiển thị theo thứ tự cập nhật mới nhất</p>
+            </div>
+            <div class="scrap-card-body">
+                <div class="scrap-table-wrapper">
+                    <div class="table-responsive">
+                        <table id="table-sn-wait-approve" class="table table-hover scrap-table align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th>SERIAL_NUMBER</th>
+                                    <th>DESCRIPTION</th>
+                                    <th>CREATE_TIME</th>
+                                    <th>APPLY_TASK_STATUS</th>
+                                    <th>BONEPILE_TYPE</th>
+                                    <th>CREATE_BY</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(3), td:nth-child(3), /* Cột Create Time */
-            th:nth-child(4), td:nth-child(4) { /* Cột Apply Task Status */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description) */
-            th:nth-child(2), td:nth-child(2) { /* Cột Description */
-                white-space: normal; /* Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
-    <script src="~/assets/areas/scrap/js/function1.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/Function1.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/MRB/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/MRB/Index.cshtml
@@ -1,164 +1,177 @@
-﻿@{
-    ViewData["Title"] = "Chuyển kho MRB";
-}
 @{
-    Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
+    ViewData["Title"] = "Chuyển kho MRB";
+    Layout = "~/Areas/Scrap/Views/Shared/Layout_scrap.cshtml";
 }
-
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
 
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-mrb-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="5">Chờ RE chuyển MRB</option>
-                <option value="6">Chờ kho MRB xác nhận</option>
-                <option value="7">Đã vào kho MRB</option>
-            </select>
-        </form>
+<section class="scrap-page container-fluid py-4">
+    <div class="scrap-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>Quản lý chuyển kho MRB</h1>
+                <p>Theo dõi và thao tác nhanh các Internal Task đang chờ chuyển kho, xác nhận hoặc đã hoàn tất.</p>
+            </div>
+            <div class="scrap-badge-list">
+                <span class="scrap-chip"><i class="fas fa-people-carry-box"></i>Chuyển kho RE</span>
+                <span class="scrap-chip"><i class="fas fa-warehouse"></i>MRB xác nhận</span>
+                <span class="scrap-chip"><i class="fas fa-check"></i>MRB hoàn tất</span>
+            </div>
+        </div>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form Chờ RE chuyển MRB -->
-        <form id="wait-re-move-mrb" method="post" class="hidden" data-search-type="wait-re-move-mrb">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    @{
-                        var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
-                        .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-                        var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
-                    }
+    <div class="row g-4 align-items-stretch">
+        <div class="col-xl-4">
+            <div class="scrap-card h-100">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chức năng nhanh</h2>
+                    <p class="scrap-card-subtitle">Chọn trạng thái để thao tác</p>
+                </div>
+                <div class="scrap-card-body">
+                    <form class="d-flex flex-column gap-3">
+                        <div>
+                            <label for="search-mrb-options" class="form-label">Chọn chức năng</label>
+                            <select id="search-mrb-options" class="form-select">
+                                <option selected disabled>SELECT FUNCTION</option>
+                                <option value="5">Chờ RE chuyển MRB</option>
+                                <option value="6">Chờ kho MRB xác nhận</option>
+                                <option value="7">Đã vào kho MRB</option>
+                            </select>
+                        </div>
+                        <div class="scrap-hint">
+                            <i class="fas fa-lightbulb me-2"></i>Tùy thuộc quyền truy cập, bạn có thể thực hiện chuyển kho hoặc xác nhận.
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xl-8 d-flex flex-column gap-4">
+            <form id="wait-re-move-mrb" method="post" class="scrap-card hidden" data-search-type="wait-re-move-mrb">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chờ RE chuyển MRB</h2>
+                    <p class="scrap-card-subtitle">Thực hiện chuyển kho đối với các Internal Task đã sẵn sàng</p>
+                </div>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0"><i class="fas fa-truck-ramp-box me-2"></i>Chỉ hiển thị nếu tài khoản có quyền Scrap.</div>
+                    @{ var allowedAreas = HttpContextAccessor.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                        var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap"); }
                     @if (Scrap)
                     {
-                        <button id="move-mrb-btn" class="btn btn-ne" type="button">Move MRB</button>
-                    }else
+                        <button id="move-mrb-btn" class="btn btn-nv" type="button">Move MRB</button>
+                    }
+                    else
                     {
-                        <button id="move-mrb-btn" class="btn btn-ne hidden" type="button">Move MRB</button>
+                        <button id="move-mrb-btn" class="btn btn-nv hidden" type="button">Move MRB</button>
                     }
                 </div>
-            </div>
-        </form>
+            </form>
 
-        <!-- Form Chờ kho MRB xác nhận -->
-        <form id="wait-mrb-confirm" method="post" class="hidden" data-search-type="wait-mrb-confirm">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    
-                    @{
-                        var allowedAreas1 = HttpContextAccessor.HttpContext.User.Claims
-                        .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-                        var Mrb = allowedAreas1 != null && allowedAreas1.Any(area => area.Trim() == "Mrb");
-                    }
+            <form id="wait-mrb-confirm" method="post" class="scrap-card hidden" data-search-type="wait-mrb-confirm">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chờ kho MRB xác nhận</h2>
+                    <p class="scrap-card-subtitle">MRB xác nhận các Internal Task đã chuyển kho</p>
+                </div>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0"><i class="fas fa-clipboard-check me-2"></i>Chỉ hiển thị khi tài khoản có quyền MRB.</div>
+                    @{ var allowedAreas1 = HttpContextAccessor.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                        var Mrb = allowedAreas1 != null && allowedAreas1.Any(area => area.Trim() == "Mrb"); }
                     @if (Mrb)
                     {
-                        <button id="confirm-mrb-btn" class="btn btn-ne" type="button">Confirm</button>
-                    }else
+                        <button id="confirm-mrb-btn" class="btn btn-nv" type="button">Confirm</button>
+                    }
+                    else
                     {
-                        <button id="confirm-mrb-btn" class="btn btn-ne hidden" type="button">Confirm</button>
+                        <button id="confirm-mrb-btn" class="btn btn-nv hidden" type="button">Confirm</button>
                     }
                 </div>
-            </div>
-        </form>
+            </form>
 
-        <!-- Form Đã vào kho MRB -->
-        <form id="moved-mrb-form" method="post" class="hidden" data-search-type="moved-mrb">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <button id="moved-mrb-btn" class="btn btn-ne" type="button">Load data</button>
+            <form id="moved-mrb-form" method="post" class="scrap-card hidden" data-search-type="moved-mrb">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Đã vào kho MRB</h2>
+                    <p class="scrap-card-subtitle">Kiểm tra các Internal Task đã hoàn tất chuyển kho</p>
+                </div>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0"><i class="fas fa-box-archive me-2"></i>Luôn cập nhật dữ liệu mới nhất.</div>
+                    <button id="moved-mrb-btn" class="btn btn-nv" type="button">Load data</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="d-flex flex-column gap-4 mt-4">
+        <div id="wait-re-move-mrb-result" class="scrap-card hidden">
+            <div class="scrap-card-header">
+                <h2 class="scrap-card-title">Chờ RE chuyển MRB</h2>
+            </div>
+            <div class="scrap-card-body">
+                <div class="scrap-table-wrapper">
+                    <div class="table-responsive">
+                        <table id="wait-re-move-mrb-table" class="table table-hover scrap-table align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th class="checkbox-column"><input type="checkbox" id="select-all-5"></th>
+                                    <th>Task Number</th>
+                                    <th>Apply Time</th>
+                                    <th>Total Qty</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
-        </form>
-    </div>
-</div>
+        </div>
 
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng Chờ RE chuyển MRB-->
-    <div id="wait-re-move-mrb-result" class="hidden">
-        <table id="wait-re-move-mrb-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-5"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+        <div id="wait-mrb-confirm-result" class="scrap-card hidden">
+            <div class="scrap-card-header">
+                <h2 class="scrap-card-title">Chờ kho MRB xác nhận</h2>
+            </div>
+            <div class="scrap-card-body">
+                <div class="scrap-table-wrapper">
+                    <div class="table-responsive">
+                        <table id="wait-mrb-confirm-table" class="table table-hover scrap-table align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th class="checkbox-column"><input type="checkbox" id="select-all-6"></th>
+                                    <th>Task Number</th>
+                                    <th>Apply Time</th>
+                                    <th>Total Qty</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="moved-mrb-form-result" class="scrap-card hidden">
+            <div class="scrap-card-header">
+                <h2 class="scrap-card-title">Đã vào kho MRB</h2>
+            </div>
+            <div class="scrap-card-body">
+                <div class="scrap-table-wrapper">
+                    <div class="table-responsive">
+                        <table id="moved-mrb-form-table" class="table table-hover scrap-table align-middle w-100">
+                            <thead>
+                                <tr>
+                                    <th class="checkbox-column"><input type="checkbox" id="select-all-7"></th>
+                                    <th>Task Number</th>
+                                    <th>Apply Time</th>
+                                    <th>Total Qty</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-    <!--hiển thị của chức năng Chờ kho MRB xác nhận-->
-    <div id="wait-mrb-confirm-result" class="hidden">
-        <table id="wait-mrb-confirm-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-6"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
-    <!--hiển thị của chức năng Đã vào kho MRB-->
-    <div id="moved-mrb-form-result" class="hidden">
-        <table id="moved-mrb-form-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-7"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
-</div>
+</section>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important; /* Đảm bảo ẩn hoàn toàn */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 20px!important; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center !important;
-        }
-        /* Giới hạn độ rộng cột */
-        #task-checkbox-table th, #task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            max-width: 80px!important; /* Giới hạn độ rộng cột */
-        }
-
-        /* Giới hạn độ rộng cột */
-        #history-task-checkbox-table th, #history-task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            max-width: 80px!important; /* Giới hạn độ rộng cột */
-        }
-        #history-task-checkbox-table td, #task-checkbox-table td{
-            background-color:#fff;
-        }
-
-         /* Thêm hiệu ứng hover cho hàng */
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76b900 !important;
-            /*transition: background-color 0.2s ease;*/
-        }
-    </style>
-    <script src="~/assets/areas/scrap/js/mrb.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/MRB.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
@@ -1,239 +1,184 @@
-﻿﻿@{
-    ViewData["Title"] = "Scrap Area";
-}
 @{
-    Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
+    ViewData["Title"] = "Scrap Progress";
+    Layout = "~/Areas/Scrap/Views/Shared/Layout_scrap.cshtml";
 }
-
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
 
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-2">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
-                <!--<option value="UPDATE_STATUS">UPDATE STATUS</option>-->
-                <option value="SEARCH_STATUS">Tìm kiếm</option>
-                <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
-            </select>
-        </form>
+<section class="scrap-page container-fluid py-4">
+    <div class="scrap-hero mb-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+            <div>
+                <h1>Scrap Progress &amp; History</h1>
+                <p>Tìm kiếm trạng thái theo SN, Internal Task, Task NV và theo dõi lịch sử thay đổi chi tiết.</p>
+            </div>
+            <div class="scrap-badge-list">
+                <span class="scrap-chip"><i class="fas fa-database"></i>Checking scrap quarterly</span>
+                <span class="scrap-chip"><i class="fas fa-search"></i>Tìm kiếm linh hoạt</span>
+                <span class="scrap-chip"><i class="fas fa-history"></i>Lịch sử SN</span>
+            </div>
+        </div>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-10">
-
-        <!-- Form Checking scrap quaterly -->
-        <form id="task-stock-status-form" method="post" class="hidden" data-search-type="TASK_STOCK_STATUS_FORM">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-2">
-                    <button id="task-stock-status-btn" class="btn btn-ne" type="button">Detail</button>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-xl-4">
+            <div class="scrap-card h-100">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Chức năng nhanh</h2>
+                    <p class="scrap-card-subtitle">Lựa chọn thao tác phù hợp</p>
+                </div>
+                <div class="scrap-card-body">
+                    <form class="d-flex flex-column gap-3">
+                        <div>
+                            <label for="search-options" class="form-label">Chọn chức năng</label>
+                            <select id="search-options" class="form-select">
+                                <option selected disabled>SELECT FUNCTION</option>
+                                <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
+                                <!--<option value="UPDATE_STATUS">UPDATE STATUS</option>-->
+                                <option value="SEARCH_STATUS">Tìm kiếm</option>
+                                <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
+                            </select>
+                        </div>
+                        <div class="scrap-hint">
+                            <i class="fas fa-circle-info me-2"></i>Các biểu mẫu được thiết kế để lọc nhanh và dễ sử dụng.
+                        </div>
+                    </form>
                 </div>
             </div>
-        </form>
+        </div>
 
-        <!-- Form UPDATE STATUS 
-        <form id="update-status-form" method="post" class="hidden" data-search-type="UPDATE_STATUS">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-status-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+        <div class="col-xl-8 d-flex flex-column gap-4">
+            <form id="task-stock-status-form" method="post" class="scrap-card hidden" data-search-type="TASK_STOCK_STATUS_FORM">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Checking scrap quarterly</h2>
+                    <p class="scrap-card-subtitle">Tải dữ liệu định kỳ để đối chiếu trạng thái</p>
                 </div>
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="status-input" class="form-label">Update trạng thái</label>
-                        <select id="status-options" class="form-select">
-                            <option selected disabled>SELECT STATUS</option>
-                            <option value="1">Đã tìm thấy bản</option>
-                            <option value="2">Đã chuyển kho phế</option>
-                        </select>
+                <div class="scrap-card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div class="scrap-hint mb-0"><i class="fas fa-table me-2"></i>Dữ liệu sẽ được tải và hiển thị trong bảng bên dưới.</div>
+                    <button id="task-stock-status-btn" class="btn btn-nv" type="button">Detail</button>
+                </div>
+            </form>
+
+            <!--<form id="update-status-form" method="post" class="scrap-card hidden" data-search-type="UPDATE_STATUS">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Update trạng thái</h2>
+                    <p class="scrap-card-subtitle">Cập nhật nhanh trạng thái SN</p>
+                </div>
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-6">
+                            <label for="sn-status-update" class="form-label">Danh sách SN</label>
+                            <textarea name="serialNumbers" id="sn-status-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-lg-6 d-flex flex-column gap-3">
+                            <div>
+                                <label for="status-options" class="form-label">Update trạng thái</label>
+                                <select id="status-options" class="form-select">
+                                    <option selected disabled>SELECT STATUS</option>
+                                    <option value="1">Đã tìm thấy bản</option>
+                                    <option value="2">Đã chuyển kho phế</option>
+                                </select>
+                            </div>
+                            @{ var allowedAreas = HttpContextAccessor.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                                var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap"); }
+                            @if (Scrap)
+                            {
+                                <button id="update-status-btn" class="btn btn-nv" type="button">Update</button>
+                            }
+                            else
+                            {
+                                <button id="update-status-btn" class="btn btn-nv hidden" type="button">Update</button>
+                            }
+                        </div>
                     </div>
-                    
+                </div>
+            </form>-->
 
-                    <div>
-                        @{
-                            var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
-                            .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-
-                            var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
-                            
-                        }
-                        @if (Scrap)
-                        {
-                            <button id="update-status-btn" class="md-2 btn btn-ne" type="button">Update</button>
-                        }else
-                        {
-                            <button id="update-status-btn" class="md-2 btn btn-ne hidden" type="button">Update</button>
-                        }
+            <form id="search-status-form" method="post" class="scrap-card hidden" data-search-type="SEARCH_STATUS">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Tìm kiếm trạng thái</h2>
+                    <p class="scrap-card-subtitle">Tìm theo SN, Internal Task hoặc Task NV</p>
+                </div>
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-4">
+                            <label for="search-status-update" class="form-label">Danh sách SN / Internal Task</label>
+                            <textarea name="SN/TASK" id="search-status-update" class="form-control" rows="8" placeholder="Nhập SN/Internal Task"></textarea>
+                        </div>
+                        <div class="col-lg-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="search-status-options" class="form-label">Tiêu chí tìm kiếm</label>
+                                <select id="search-status-options" class="form-select">
+                                    <option selected disabled>SELECT STATUS</option>
+                                    <option value="1">Tìm kiếm theo SN</option>
+                                    <option value="2">Tìm kiếm theo Internal Task</option>
+                                    <option value="3">Tìm kiếm theo Task NV</option>
+                                </select>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <button id="search-status-btn" class="btn btn-nv flex-fill" type="button">Search</button>
+                                <button id="load-status-btn" class="btn btn-nv flex-fill" type="button">Load List</button>
+                            </div>
+                        </div>
+                        <div class="col-lg-4">
+                            <div class="scrap-card-subtitle">Tham chiếu trạng thái</div>
+                            <div class="scrap-hint mb-1">0. Phế, chưa gửi xin task</div>
+                            <div class="scrap-hint mb-1">1. Phế, đã gửi xin task nhưng chưa có</div>
+                            <div class="scrap-hint mb-1">2. Chờ SPE approved phế</div>
+                            <div class="scrap-hint mb-1">3. Đã approved thay BGA</div>
+                            <div class="scrap-hint mb-1">4. Chờ approved thay BGA</div>
+                            <div class="scrap-hint mb-1">5. Đã có task, chờ chuyển kho phế</div>
+                            <div class="scrap-hint mb-1">6. Đã chuyển kho phế chờ MRB xác nhận</div>
+                            <div class="scrap-hint mb-1">7. MRB đã nhận bản phế</div>
+                            <div class="scrap-hint">8. Lỗi process, không thể sửa chữa</div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </form>-->
+            </form>
 
-        <!-- Form SEARCH STATUS -->
-        <form id="search-status-form" method="post" class="hidden" data-search-type="SEARCH_STATUS">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="SN/TASK" id="search-status-update" class="form-control" rows="8" placeholder="Nhập SN/Internal Task"></textarea>
+            <form id="search-history-form" method="post" class="scrap-card hidden" data-search-type="SEARCH_HISTORY">
+                <div class="scrap-card-header">
+                    <h2 class="scrap-card-title">Tra lịch sử SN</h2>
+                    <p class="scrap-card-subtitle">Theo dõi chi tiết trạng thái thay đổi của SN</p>
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="SNTASK-input" class="form-label">Tìm kiếm trạng thái</label>
-                        <select id="search-status-options" class="form-select">
-                            <option selected disabled>SELECT STATUS</option>
-                            <option value="1">Tìm kiếm theo SN</option>
-                            <option value="2">Tìm kiếm theo Internal Task</option>
-                            <option value="3">Tìm kiếm theo Task NV</option>
-                        </select>
+                <div class="scrap-card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-6">
+                            <label for="history-search-update" class="form-label">Danh sách SN</label>
+                            <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-lg-6 d-flex flex-column gap-3">
+                            <div class="scrap-hint">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</div>
+                            <div class="d-flex gap-2">
+                                <button id="history-search-btn" class="btn btn-nv flex-fill" type="button">Search history</button>
+                                <button id="history-download-btn" class="btn btn-nv flex-fill" type="button">Download Excel</button>
+                            </div>
+                        </div>
                     </div>
-                    <button id="search-status-btn" class="md-2 btn btn-ne" type="button">Search</button>
-                    <button id="load-status-btn" class="md-2 btn btn-ne" type="button">Load List</button>
                 </div>
-                <div class="col-md-2">
-                    <div>ApplyTaskStatus</div>
-                    <div>0. Phế, chưa gửi xin task</div>
-                    <div>1. Phế, đã gửi xin task nhưng chưa có</div>
-                    <div>2. Chờ SPE approved phế</div>
-                    <div>3. Đã approved thay BGA</div>
-                    
-                </div>
-                <div class="col-md-2">
-                    <div>4. Chờ approved thay BGA</div>
-                    <div>5. Đã có task, chờ chuyển kho phế</div>
-                    <div>6. Đã chuyển kho phế chờ MRB xác nhận</div>
-                    <div>7. MRB đã nhận bản phế</div>
-                    <div>8. Lỗi process, không thể sửa chữa</div>
-                </div>
-            </div>
-        </form>
-
-        <!-- Form SEARCH HISTORY -->
-        <form id="search-history-form" method="post" class="hidden" data-search-type="SEARCH_HISTORY">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label class="form-label">Tra cứu lịch sử SN</label>
-                        <p class="form-text">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</p>
-                    </div>
-                    <button id="history-search-btn" class="md-2 btn btn-ne" type="button">Search history</button>
-                    <button id="history-download-btn" class="md-2 btn btn-ne" type="button">Download Excel</button>
-                </div>
-            </div>
-        </form>
+            </form>
+        </div>
     </div>
-</div>
 
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng create task-->
-    <div id="task-stock-status-result" class="hidden"></div>
-    <!--hiển thị của chức năng update data
-    <div id="update-status-result" class="hidden"></div>-->
-    <!--hiển thị của chức năng search data-->
-    <div id="search-status-result" class="hidden"></div>
-    <!--hiển thị của chức năng history search-->
-    <div id="history-search-result" class="hidden"></div>
-</div>
+    <div class="d-flex flex-column gap-4 mt-4">
+        <div id="task-stock-status-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
+
+        <!--<div id="update-status-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>-->
+
+        <div id="search-status-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
+
+        <div id="history-search-result" class="scrap-card hidden">
+            <div data-role="result-message"></div>
+        </div>
+    </div>
+</section>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(9), td:nth-child(9), /* Cột Cost */
-            th:nth-child(13), td:nth-child(13), /* Cột Create Time */
-            th:nth-child(14), td:nth-child(14) { /* Cột Apply Time */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description, Remark) */
-            th:nth-child(1), td:nth-child(1), /* Cột internal task */
-            th:nth-child(2), td:nth-child(2), /* Cột internal task */
-            th:nth-child(3), td:nth-child(3), /* Cột Description */
-            th:nth-child(10), td:nth-child(10) { /* Cột Remark */
-                /*white-space: normal; * Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
-    <script src="~/assets/areas/scrap/js/progress.js?v=@DateTime.Now.Ticks"></script>
+    <script src="~/assets/Areas/Scrap/js/Progress.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Shared/Layout_scrap.cshtml
+++ b/PESystem/Areas/Scrap/Views/Shared/Layout_scrap.cshtml
@@ -11,10 +11,11 @@
     <link href="~/lib/datatable/style.css" rel="stylesheet" />
     <link href="~/lib/datatable/jquery.datatables.min.css" rel="stylesheet" />
     <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="~/assets/Areas/Scrap/css/theme.css" asp-append-version="true" />
     <script src="~/lib/gsap-particles/particles.min.js"></script>
     <script src="~/lib/gsap-particles/gsap.min.js"></script>
 </head>
-<body>
+<body class="scrap-body">
     <script>
         (function () {
             const isSidebarFixed = localStorage.getItem('isSidebarFixed') === 'true';

--- a/PESystem/wwwroot/assets/Areas/Allpart/css/theme.css
+++ b/PESystem/wwwroot/assets/Areas/Allpart/css/theme.css
@@ -1,0 +1,282 @@
+:root {
+    --nv-green: #76b900;
+    --nv-green-dark: #4a7a00;
+    --nv-green-light: #9fe62d;
+    --nv-bg: #040a04;
+    --nv-panel: rgba(15, 24, 15, 0.95);
+    --nv-text: #ecffe3;
+    --nv-muted: #a7c98b;
+}
+
+.allpart-page {
+    background: radial-gradient(circle at 20% 0%, rgba(118, 185, 0, 0.14), transparent 55%),
+        radial-gradient(circle at 80% 10%, rgba(159, 230, 45, 0.1), transparent 55%),
+        var(--nv-bg);
+    color: var(--nv-text);
+    min-height: 100vh;
+    font-family: 'Segoe UI', 'Roboto', sans-serif;
+}
+
+.allpart-hero {
+    background: linear-gradient(135deg, rgba(118, 185, 0, 0.15), rgba(118, 185, 0, 0.05));
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    border-radius: 22px;
+    padding: 1.8rem;
+    box-shadow: 0 35px 75px -55px rgba(118, 185, 0, 0.85);
+}
+
+.allpart-hero h1 {
+    font-size: 1.8rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--nv-green-light);
+}
+
+.allpart-hero p {
+    color: var(--nv-muted);
+    margin-top: 0.5rem;
+}
+
+.allpart-badge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.allpart-badge-list .badge {
+    background: rgba(118, 185, 0, 0.18);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    color: var(--nv-green-light);
+    border-radius: 999px;
+    padding: 0.45rem 0.9rem;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+}
+
+.allpart-card {
+    position: relative;
+    background: var(--nv-panel);
+    border-radius: 20px;
+    border: 1px solid rgba(118, 185, 0, 0.28);
+    padding: 1.6rem;
+    color: var(--nv-text);
+    box-shadow: 0 32px 80px -60px rgba(118, 185, 0, 0.85);
+    overflow: hidden;
+}
+
+.allpart-card::before {
+    content: "";
+    position: absolute;
+    top: -45%;
+    right: -15%;
+    width: 60%;
+    height: 150%;
+    background: radial-gradient(circle, rgba(118, 185, 0, 0.35), transparent 65%);
+    opacity: 0.2;
+    transform: rotate(16deg);
+}
+
+.allpart-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.allpart-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid rgba(118, 185, 0, 0.25);
+    margin-bottom: 1.1rem;
+}
+
+.allpart-card-title {
+    font-size: 1.12rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--nv-green-light);
+    margin: 0;
+}
+
+.allpart-card-subtitle {
+    font-size: 0.85rem;
+    color: var(--nv-muted);
+    margin: 0;
+}
+
+.allpart-card .form-label {
+    font-weight: 600;
+    color: rgba(236, 255, 227, 0.85);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+}
+
+.allpart-card .form-control,
+.allpart-card .form-select {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    color: var(--nv-text);
+    border-radius: 12px;
+    padding: 0.68rem 0.85rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.allpart-card .form-control:focus,
+.allpart-card .form-select:focus {
+    border-color: var(--nv-green-light);
+    box-shadow: 0 0 0 0.16rem rgba(118, 185, 0, 0.32);
+}
+
+.btn-nvidia-green,
+.btn-nv,
+.btn.btn-nv {
+    background: linear-gradient(135deg, var(--nv-green), var(--nv-green-light));
+    border: none;
+    color: #041401;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-radius: 14px;
+    padding: 0.65rem 1.5rem;
+    box-shadow: 0 24px 45px -24px rgba(118, 185, 0, 0.85);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-nvidia-green:hover,
+.btn-nv:hover,
+.btn.btn-nv:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 28px 55px -20px rgba(159, 230, 45, 0.85);
+    color: #041401;
+}
+
+.allpart-hint {
+    font-size: 0.85rem;
+    color: rgba(236, 255, 227, 0.72);
+}
+
+.allpart-table-wrapper {
+    border-radius: 18px;
+    border: 1px solid rgba(118, 185, 0, 0.22);
+    overflow: hidden;
+    background: rgba(10, 17, 10, 0.8);
+    box-shadow: inset 0 0 0 1px rgba(118, 185, 0, 0.08);
+}
+
+.allpart-table {
+    color: var(--nv-text);
+}
+
+.allpart-table thead th {
+    background: linear-gradient(90deg, rgba(118, 185, 0, 0.85), rgba(118, 185, 0, 0.62));
+    color: #031401;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+}
+
+.allpart-table tbody tr:hover {
+    background-color: rgba(118, 185, 0, 0.16);
+}
+
+.allpart-table td {
+    border-top: 1px solid rgba(118, 185, 0, 0.18);
+    font-size: 0.84rem;
+    vertical-align: middle;
+}
+
+.custom-tooltip {
+    position: absolute;
+    background-color: rgba(12, 18, 12, 0.92);
+    color: var(--nv-text);
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    box-shadow: 0 8px 20px -12px rgba(0, 0, 0, 0.6);
+    display: none;
+    z-index: 2000;
+    max-width: 320px;
+    word-wrap: break-word;
+    border: 1px solid rgba(118, 185, 0, 0.35);
+}
+
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 3000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    color: #ffffff;
+    font-size: 1.1rem;
+    gap: 1rem;
+}
+
+.spinner {
+    border: 4px solid rgba(255, 255, 255, 0.2);
+    border-top: 4px solid var(--nv-green);
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.dataTables_wrapper .dataTables_filter input,
+.dataTables_wrapper .dataTables_length select {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    color: var(--nv-text);
+    border-radius: 12px;
+    padding: 0.45rem 0.6rem;
+}
+
+.dataTables_wrapper .dataTables_filter label,
+.dataTables_wrapper .dataTables_length label,
+.dataTables_wrapper .dataTables_info {
+    color: var(--nv-muted);
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+    color: var(--nv-text) !important;
+    border-radius: 50px;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current,
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+    color: #031401 !important;
+    background: linear-gradient(135deg, var(--nv-green), var(--nv-green-light)) !important;
+    border-color: transparent;
+}
+
+@media (max-width: 991.98px) {
+    .allpart-card {
+        padding: 1.3rem;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .allpart-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .allpart-badge-list {
+        justify-content: center;
+    }
+}

--- a/PESystem/wwwroot/assets/Areas/Scrap/css/theme.css
+++ b/PESystem/wwwroot/assets/Areas/Scrap/css/theme.css
@@ -1,0 +1,352 @@
+:root {
+    --scrap-green: #76b900;
+    --scrap-green-dark: #4e7d00;
+    --scrap-green-light: #9fe62d;
+    --scrap-bg: #030a03;
+    --scrap-panel: rgba(12, 19, 12, 0.92);
+    --scrap-panel-alt: rgba(17, 32, 17, 0.92);
+    --scrap-text: #e8ffe3;
+    --scrap-muted: #a0c97a;
+}
+
+.scrap-body {
+    background: radial-gradient(circle at 20% 0%, rgba(118, 185, 0, 0.12), transparent 45%),
+        radial-gradient(circle at 90% 10%, rgba(159, 230, 45, 0.1), transparent 50%),
+        var(--scrap-bg);
+    color: var(--scrap-text);
+    min-height: 100vh;
+    font-family: 'Segoe UI', 'Roboto', sans-serif;
+    letter-spacing: 0.01em;
+}
+
+.scrap-page {
+    position: relative;
+}
+
+.scrap-hero {
+    background: linear-gradient(135deg, rgba(118, 185, 0, 0.18), rgba(118, 185, 0, 0.06));
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    border-radius: 22px;
+    padding: 1.8rem;
+    color: var(--scrap-text);
+    box-shadow: 0 35px 70px -50px rgba(118, 185, 0, 0.85);
+}
+
+.scrap-hero h1 {
+    font-weight: 700;
+    font-size: 1.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--scrap-green-light);
+}
+
+.scrap-hero p {
+    margin-top: 0.5rem;
+    font-size: 1rem;
+    color: var(--scrap-muted);
+}
+
+.scrap-badge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+
+.scrap-hero .badge {
+    background: rgba(118, 185, 0, 0.16);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    color: var(--scrap-green-light);
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.scrap-card {
+    position: relative;
+    background: var(--scrap-panel);
+    border-radius: 20px;
+    border: 1px solid rgba(118, 185, 0, 0.28);
+    padding: 1.5rem;
+    color: var(--scrap-text);
+    box-shadow: 0 30px 80px -60px rgba(118, 185, 0, 0.9);
+    overflow: hidden;
+}
+
+.scrap-card::before {
+    content: "";
+    position: absolute;
+    top: -40%;
+    right: -15%;
+    width: 65%;
+    height: 160%;
+    background: radial-gradient(circle, rgba(118, 185, 0, 0.35), transparent 60%);
+    opacity: 0.18;
+    transform: rotate(18deg);
+}
+
+.scrap-card::after {
+    content: "";
+    position: absolute;
+    bottom: -35%;
+    left: -10%;
+    width: 55%;
+    height: 120%;
+    background: radial-gradient(circle, rgba(118, 185, 0, 0.22), transparent 70%);
+    opacity: 0.2;
+    transform: rotate(-12deg);
+}
+
+.scrap-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.scrap-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid rgba(118, 185, 0, 0.25);
+    margin-bottom: 1.1rem;
+}
+
+.scrap-card-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--scrap-green-light);
+    margin: 0;
+}
+
+.scrap-card-subtitle {
+    font-size: 0.85rem;
+    color: var(--scrap-muted);
+    margin: 0;
+}
+
+.scrap-card .form-label {
+    font-weight: 600;
+    color: rgba(232, 255, 227, 0.86);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+}
+
+.scrap-card .form-control,
+.scrap-card .form-select {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    color: var(--scrap-text);
+    border-radius: 12px;
+    padding: 0.7rem 0.85rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.scrap-card textarea.form-control {
+    min-height: 220px;
+    resize: vertical;
+}
+
+.scrap-card .form-control:focus,
+.scrap-card .form-select:focus {
+    border-color: var(--scrap-green-light);
+    box-shadow: 0 0 0 0.15rem rgba(118, 185, 0, 0.35);
+    transform: translateY(-2px);
+}
+
+.btn-nv {
+    background: linear-gradient(135deg, var(--scrap-green), var(--scrap-green-light));
+    border: none;
+    color: #031401;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-radius: 14px;
+    padding: 0.7rem 1.6rem;
+    box-shadow: 0 22px 40px -22px rgba(118, 185, 0, 0.85);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-nv:hover,
+.btn-nv:focus {
+    transform: translateY(-3px);
+    box-shadow: 0 25px 50px -20px rgba(159, 230, 45, 0.85);
+    color: #031401;
+}
+
+.btn-nv:active {
+    transform: translateY(1px);
+}
+
+.scrap-hint {
+    font-size: 0.85rem;
+    color: rgba(232, 255, 227, 0.7);
+    margin-top: 0.3rem;
+}
+
+.scrap-table-wrapper {
+    border-radius: 18px;
+    border: 1px solid rgba(118, 185, 0, 0.25);
+    overflow: hidden;
+    background: var(--scrap-panel-alt);
+    box-shadow: inset 0 0 0 1px rgba(118, 185, 0, 0.08);
+}
+
+.scrap-table {
+    color: var(--scrap-text);
+    margin-bottom: 0;
+}
+
+.scrap-table thead th {
+    background: linear-gradient(90deg, rgba(118, 185, 0, 0.85), rgba(118, 185, 0, 0.6));
+    color: #041203;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    border-bottom: none;
+}
+
+.scrap-table tbody tr {
+    background-color: transparent;
+    transition: background-color 0.25s ease, transform 0.2s ease;
+}
+
+.scrap-table tbody tr:hover {
+    background-color: rgba(118, 185, 0, 0.16);
+}
+
+.scrap-table td {
+    border-top: 1px solid rgba(118, 185, 0, 0.2);
+    vertical-align: middle;
+    font-size: 0.85rem;
+}
+
+.scrap-table .badge {
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.scrap-table .badge.bg-scrap {
+    background: rgba(118, 185, 0, 0.22);
+    color: var(--scrap-green-light);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+}
+
+.scrap-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(118, 185, 0, 0.14);
+    color: var(--scrap-green-light);
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    border: 1px solid rgba(118, 185, 0, 0.3);
+}
+
+.scrap-chip i {
+    font-size: 0.9rem;
+}
+
+.dataTables_wrapper .dataTables_filter input,
+.dataTables_wrapper .dataTables_length select {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    color: var(--scrap-text);
+    border-radius: 10px;
+    padding: 0.45rem 0.6rem;
+}
+
+.dataTables_wrapper .dataTables_filter label,
+.dataTables_wrapper .dataTables_length label,
+.dataTables_wrapper .dataTables_info {
+    color: var(--scrap-muted);
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+    color: var(--scrap-text) !important;
+    border-radius: 50px;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current,
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+    color: #031401 !important;
+    background: linear-gradient(135deg, var(--scrap-green), var(--scrap-green-light)) !important;
+    border-color: transparent;
+}
+
+.badge-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    padding: 0.3rem 0.65rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.badge-status.bg-wait {
+    background: rgba(255, 193, 7, 0.18);
+    color: #ffecb5;
+}
+
+.badge-status.bg-progress {
+    background: rgba(13, 110, 253, 0.2);
+    color: #bcd5ff;
+}
+
+.badge-status.bg-success {
+    background: rgba(118, 185, 0, 0.22);
+    color: var(--scrap-green-light);
+}
+
+.hidden {
+    display: none !important;
+}
+
+.scrap-section-label {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.72rem;
+    color: rgba(232, 255, 227, 0.6);
+}
+
+.scrap-table-wrapper .table-responsive {
+    margin-bottom: 0;
+}
+
+@media (max-width: 991.98px) {
+    .scrap-card {
+        padding: 1.25rem;
+    }
+
+    .scrap-card textarea.form-control {
+        min-height: 160px;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .scrap-hero {
+        text-align: center;
+    }
+
+    .scrap-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .scrap-hero .badge,
+    .scrap-chip {
+        width: 100%;
+        justify-content: center;
+    }
+}

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
@@ -1,10 +1,70 @@
-﻿let selectedInternalTasks = new Set(); // Cho CREATE_TASK_FORM
-let selectedHistoryInternalTasks = new Set(); // Cho HISTORY_APPLY
+let selectedInternalTasks = new Set(); // Cho CREATE_TASK_FORM
+
+const purposeLabels = {
+    "0": "SPE approve to scrap",
+    "1": "Scrap to quarterly",
+    "2": "Approved to engineer sample",
+    "3": "Approved to master board",
+    "4": "Approved to BGA"
+};
+
+const statusLabels = {
+    0: "SPE đã duyệt - chờ xin task",
+    1: "Đang xin task nội bộ",
+    2: "Chờ SPE phê duyệt phế",
+    3: "Đã approved thay BGA",
+    4: "Chờ approved thay BGA",
+    5: "Đã có task - chờ chuyển MRB",
+    6: "Chờ kho MRB xác nhận",
+    7: "MRB đã nhận bản phế",
+    8: "Lỗi process - không thể sửa",
+    10: "Đang tổng hợp dữ liệu"
+};
+
+function renderPurposeBadge(purpose) {
+    if (!purpose && purpose !== 0) {
+        return '<span class="badge bg-secondary">N/A</span>';
+    }
+    const label = purposeLabels[String(purpose)] || `Purpose ${purpose}`;
+    return `<span class="badge bg-scrap" data-bs-toggle="tooltip" data-bs-title="${label}">${label}</span>`;
+}
+
+function renderStatusBadge(status) {
+    if (status === undefined || status === null) {
+        return '<span class="badge-status bg-progress">N/A</span>';
+    }
+
+    const numericStatus = Number(status);
+    const label = statusLabels[numericStatus] || `Trạng thái ${numericStatus}`;
+    let styleClass = "bg-progress";
+
+    if ([5, 6, 7].includes(numericStatus)) {
+        styleClass = "bg-success";
+    } else if ([0, 1, 4, 10].includes(numericStatus)) {
+        styleClass = "bg-wait";
+    }
+
+    return `<span class="badge-status ${styleClass}" data-bs-toggle="tooltip" data-bs-title="${label}">${numericStatus}</span>`;
+}
+
+function setResultMessage(containerId, html) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+
+    const target = container.querySelector('[data-role="result-message"]');
+    if (target) {
+        target.innerHTML = html;
+    } else {
+        container.innerHTML = html;
+    }
+}
 
 // Hàm ẩn tất cả form và khu vực kết quả
 function hideAllElements() {
-    const forms = ["input-sn-form", "custom-form", "custom-form-sn", "update-data-form", "history-apply-form"];
-    const results = ["input-sn-result", "create-task-result", "update-data-result", "history-apply-result", "create-task-result-sn"];
+    const forms = ["input-sn-form", "custom-form", "custom-form-sn", "update-data-form"];
+    const results = ["input-sn-result", "create-task-result", "create-task-result-sn", "update-data-result"];
 
     forms.forEach(formId => {
         const form = document.getElementById(formId);
@@ -13,7 +73,13 @@ function hideAllElements() {
 
     results.forEach(resultId => {
         const result = document.getElementById(resultId);
-        if (result) result.classList.add("hidden");
+        if (result) {
+            result.classList.add("hidden");
+            const messageTarget = result.querySelector('[data-role="result-message"]');
+            if (messageTarget) {
+                messageTarget.innerHTML = "";
+            }
+        }
     });
 
     ["sn-input", "sn-input-update", "description-input", "NVmember-input", "speApproveTime-input", "task-input", "po-input", "cost-input", "file-input"].forEach(id => {
@@ -41,8 +107,7 @@ function exportToExcel(data, filename) {
 
 // Xử lý tạo task
 async function processCreateTask(internalTasks, saveApplyStatus, resultDivId) {
-    const resultDiv = document.getElementById(resultDivId);
-    resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`;
+    setResultMessage(resultDivId, `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`);
 
     const requestData = { internalTasks, saveApplyStatus };
 
@@ -106,18 +171,17 @@ async function processCreateTask(internalTasks, saveApplyStatus, resultDivId) {
             XLSX.writeFile(workbook, filename);
             setTimeout(() => location.reload(), 1000);
         } else {
-            resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
+            setResultMessage(resultDivId, `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`);
         }
     } catch (error) {
-        resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
+        setResultMessage(resultDivId, `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`);
         console.error("Error:", error);
     }
 }
 
 // Xử lý tạo task bằng SN
 async function processCreateTaskBySN(sNs, saveApplyStatus, resultDivId) {
-    const resultDiv = document.getElementById(resultDivId);
-    resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`;
+    setResultMessage(resultDivId, `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`);
 
     const requestData = { sNs, saveApplyStatus };
 
@@ -181,42 +245,67 @@ async function processCreateTaskBySN(sNs, saveApplyStatus, resultDivId) {
             XLSX.writeFile(workbook, filename);
             setTimeout(() => location.reload(), 1000);
         } else {
-            resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
+            setResultMessage(resultDivId, `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`);
         }
     } catch (error) {
-        resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
+        setResultMessage(resultDivId, `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`);
         console.error("Error:", error);
     }
 }
 
 // Hiển thị bảng với DataTables
 function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
-    const currentSelectedSet = checkboxName === "task-checkbox" ? selectedInternalTasks : selectedHistoryInternalTasks;
-    const tableBody = document.querySelector(`#${tableId} tbody`);
-    tableBody.innerHTML = ""; // Xóa nội dung cũ
+    const table = document.getElementById(tableId);
+    if (!table) {
+        return;
+    }
+
+    const container = table.closest('.scrap-card');
+    const containerId = container ? container.id : null;
+    const tableBody = table.querySelector('tbody');
+    if (!tableBody) {
+        return;
+    }
+
+    tableBody.innerHTML = "";
+    if (!data || data.length === 0) {
+        if (containerId) {
+            setResultMessage(containerId, '<div class="alert alert-warning">Không tìm thấy Internal Task hợp lệ trong 3 tháng gần nhất.</div>');
+        }
+        return;
+    }
+
+    if (containerId) {
+        setResultMessage(containerId, "");
+    }
 
     data.forEach(item => {
-        const isChecked = currentSelectedSet.has(item.internalTask) ? 'checked' : '';
+        const isChecked = selectedInternalTasks.has(item.internalTask) ? 'checked' : '';
+        const purposeBadge = renderPurposeBadge(item.purpose);
+        const statusBadge = renderStatusBadge(item.applyTaskStatus);
+        const totalQtyDisplay = typeof item.totalQty === 'number'
+            ? item.totalQty.toLocaleString('en-US')
+            : (item.totalQty || 'N/A');
+
         const row = `
             <tr>
                 <td class="checkbox-column"><input type="checkbox" name="${checkboxName}" value="${item.internalTask}" ${isChecked}></td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.internalTask || 'N/A'}">${item.internalTask || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.description || 'N/A'}">${item.description || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.approveScrapPerson || 'N/A'}">${item.approveScrapPerson || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.kanBanStatus || 'N/A'}">${item.kanBanStatus || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.category || 'N/A'}">${item.category || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.remark || 'N/A'}">${item.remark || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.createTime || 'N/A'}">${item.createTime || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.createBy || 'N/A'}">${item.createBy || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${checkboxName === 'history-task-checkbox' ? (item.applyTime || 'N/A') : (item.applyTaskStatus || 'N/A')}">${checkboxName === "history-task-checkbox" ? (item.applyTime || "N/A") : (item.applyTaskStatus || "N/A")}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${checkboxName === 'history-task-checkbox' ? (item.applyTaskStatus || 'N/A') : (item.totalQty || 'N/A')}">${checkboxName === "history-task-checkbox" ? (item.applyTaskStatus || "N/A") : (item.totalQty || "N/A")}</td>
-                ${checkboxName === "history-task-checkbox" ? `<td data-bs-toggle="tooltip" data-bs-title="${item.totalQty || 'N/A'}">${item.totalQty || "N/A"}</td>` : ""}
+                <td data-bs-toggle="tooltip" data-bs-title="${item.internalTask || 'N/A'}">${item.internalTask || 'N/A'}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.description || 'N/A'}">${item.description || 'N/A'}</td>
+                <td>${purposeBadge}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.approveScrapPerson || 'N/A'}">${item.approveScrapPerson || 'N/A'}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.kanBanStatus || 'N/A'}">${item.kanBanStatus || 'N/A'}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.category || 'N/A'}">${item.category || 'N/A'}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.remark || 'N/A'}">${item.remark || 'N/A'}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.createTime || 'N/A'}">${item.createTime || 'N/A'}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${item.createBy || 'N/A'}">${item.createBy || 'N/A'}</td>
+                <td>${statusBadge}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${totalQtyDisplay}">${totalQtyDisplay}</td>
             </tr>
         `;
         tableBody.insertAdjacentHTML('beforeend', row);
     });
 
-    // Khởi tạo DataTables
     const dataTable = $(`#${tableId}`).DataTable({
         pageLength: 10,
         lengthMenu: [10, 25, 50, 100],
@@ -224,7 +313,8 @@ function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
         columnDefs: [
             { orderable: false, targets: 0 },
             { width: "40px", targets: 0 },
-            { width: "300px", targets: [1, 2, 3] }
+            { width: "220px", targets: [1, 2] },
+            { width: "180px", targets: [4, 5, 6, 7] }
         ],
         language: {
             search: "Tìm kiếm:",
@@ -239,39 +329,39 @@ function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
         },
         destroy: true,
         drawCallback: function () {
-            // Khởi tạo Bootstrap Tooltip sau khi bảng được vẽ
             const tooltipTriggerList = document.querySelectorAll(`#${tableId} [data-bs-toggle="tooltip"]`);
             tooltipTriggerList.forEach(tooltipTriggerEl => {
                 new bootstrap.Tooltip(tooltipTriggerEl, {
-                    placement: 'top', // Vị trí tooltip (top, bottom, left, right)
-                    trigger: 'hover' // Kích hoạt khi hover
+                    placement: 'top',
+                    trigger: 'hover'
                 });
             });
         }
     });
 
-    // Xử lý checkbox "Select All"
     const selectAllCheckbox = document.getElementById(selectAllId);
     if (selectAllCheckbox) {
-        selectAllCheckbox.checked = data.length > 0 && data.every(item => currentSelectedSet.has(item.internalTask));
+        selectAllCheckbox.checked = data.length > 0 && data.every(item => selectedInternalTasks.has(item.internalTask));
         selectAllCheckbox.addEventListener("change", function () {
             const isChecked = this.checked;
             data.forEach(item => {
-                if (isChecked) currentSelectedSet.add(item.internalTask);
-                else currentSelectedSet.delete(item.internalTask);
+                if (isChecked) selectedInternalTasks.add(item.internalTask);
+                else selectedInternalTasks.delete(item.internalTask);
             });
             $(`input[name="${checkboxName}"]`).prop("checked", isChecked);
         });
     }
 
-    // Xử lý checkbox riêng lẻ
     $(document).off("change", `input[name="${checkboxName}"]`).on("change", `input[name="${checkboxName}"]`, function () {
         const internalTask = this.value;
-        if (this.checked) currentSelectedSet.add(internalTask);
-        else currentSelectedSet.delete(internalTask);
-        selectAllCheckbox.checked = data.every(item => currentSelectedSet.has(item.internalTask));
+        if (this.checked) selectedInternalTasks.add(internalTask);
+        else selectedInternalTasks.delete(internalTask);
+        if (selectAllCheckbox) {
+            selectAllCheckbox.checked = data.every(item => selectedInternalTasks.has(item.internalTask));
+        }
     });
 }
+
 
 // Xử lý khi trang tải
 document.addEventListener("DOMContentLoaded", function () {
@@ -315,8 +405,8 @@ document.addEventListener("DOMContentLoaded", function () {
             return;
         }
 
-        const resultDiv = document.getElementById("input-sn-result");
-        resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`;
+        const resultContainerId = "input-sn-result";
+        setResultMessage(resultContainerId, `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`);
 
         try {
             const requestData = { sNs, createdBy: currentUsername, description, approveScrapPerson, purpose, speApproveTime };
@@ -347,14 +437,15 @@ document.addEventListener("DOMContentLoaded", function () {
                 });
 
                 const updateProductResult = await updateProductResponse.json();
-                resultDiv.innerHTML = updateProductResponse.ok && updateProductResult.success
+                const feedbackHtml = updateProductResponse.ok && updateProductResult.success
                     ? `<div class="alert alert-success"><strong>${inputSnResult.message}</strong><br>Internal Task: ${inputSnResult.internalTask}<br>Update Product: ${updateProductResult.message}</div>`
                     : `<div class="alert alert-warning"><strong>${inputSnResult.message}</strong><br>Internal Task: ${inputSnResult.internalTask}<br><strong>Lỗi khi cập nhật Product:</strong> ${updateProductResult.message || "Không có thông tin lỗi"}</div>`;
+                setResultMessage(resultContainerId, feedbackHtml);
             } else {
-                resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${inputSnResult.message}</div>`;
+                setResultMessage(resultContainerId, `<div class="alert alert-danger"><strong>Lỗi:</strong> ${inputSnResult.message}</div>`);
             }
         } catch (error) {
-            resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
+            setResultMessage(resultContainerId, `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`);
             console.error("Error:", error);
         }
     });
@@ -389,17 +480,6 @@ document.addEventListener("DOMContentLoaded", function () {
             await processCreateTask(selectedTasksArray, "0", "create-task-result");
             selectedInternalTasks.clear();
         });
-    });
-
-    // Xử lý nút "Tạo History Task"
-    document.getElementById("create-history-task-btn").addEventListener("click", async function () {
-        const selectedHistoryTasksArray = Array.from(selectedHistoryInternalTasks);
-        if (selectedHistoryTasksArray.length === 0) {
-            alert("Vui lòng chọn ít nhất một Internal Task.");
-            return;
-        }
-        await processCreateTask(selectedHistoryTasksArray, "1", "history-apply-result");
-        selectedHistoryInternalTasks.clear();
     });
 
     // Xử lý nút "Tạo Task bằng SN"
@@ -440,8 +520,8 @@ document.addEventListener("DOMContentLoaded", function () {
         const po = document.getElementById("po-input").value.trim();
         const snList = snInput.split(/\r?\n/).map(sn => sn.trim()).filter(sn => sn);
 
-        const resultDiv = document.getElementById("update-data-result");
-        resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`;
+        const updateResultContainer = "update-data-result";
+        setResultMessage(updateResultContainer, `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`);
 
         if (!snList.length) {
             alert("Vui lòng nhập ít nhất một Serial Number hợp lệ.");
@@ -466,12 +546,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
             const updateResult = await updateResponse.json();
             if (updateResponse.ok) {
-                resultDiv.innerHTML = `<div class="alert alert-success"><strong>Thành công:</strong> ${updateResult.message}</div>`;
+                setResultMessage(updateResultContainer, `<div class="alert alert-success"><strong>Thành công:</strong> ${updateResult.message}</div>`);
             } else {
-                resultDiv.innerHTML = `<div class="alert alert-warning"><strong>Lỗi khi cập nhật Task PO:</strong> ${updateResult.message}</div>`;
+                setResultMessage(updateResultContainer, `<div class="alert alert-warning"><strong>Lỗi khi cập nhật Task PO:</strong> ${updateResult.message}</div>`);
             }
         } catch (error) {
-            resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
+            setResultMessage(updateResultContainer, `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`);
             console.error("Error:", error);
         }
     });
@@ -479,7 +559,7 @@ document.addEventListener("DOMContentLoaded", function () {
     // Xử lý nút "Cập nhật Chi phí"
     document.getElementById("update-cost-btn").addEventListener("click", async function () {
         const fileInput = document.getElementById("file-input");
-        const resultDiv = document.getElementById("update-data-result");
+        const updateResultContainer = "update-data-result";
 
         if (!fileInput.files || fileInput.files.length === 0) {
             alert("Vui lòng chọn một file Excel để tải lên.");
@@ -527,7 +607,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
 
                 const requestData = { boardSNs, costs };
-                resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`;
+                setResultMessage(updateResultContainer, `<div class="alert alert-info"><strong>Thông báo:</strong> Đang chờ xử lý...</div>`);
 
                 const response = await fetch("http://10.220.130.119:9090/api/Scrap/update-cost", {
                     method: "POST",
@@ -536,11 +616,12 @@ document.addEventListener("DOMContentLoaded", function () {
                 });
 
                 const result = await response.json();
-                resultDiv.innerHTML = response.ok
+                const messageHtml = response.ok
                     ? `<div class="alert alert-success"><strong>${result.message}</strong></div>`
                     : `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
+                setResultMessage(updateResultContainer, messageHtml);
             } catch (error) {
-                resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể xử lý file Excel hoặc kết nối đến API.</div>`;
+                setResultMessage(updateResultContainer, `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể xử lý file Excel hoặc kết nối đến API.</div>`);
                 console.error("Error:", error);
             }
         };
@@ -556,8 +637,6 @@ document.addEventListener("DOMContentLoaded", function () {
         console.log("Dropdown changed to:", this.value);
         hideAllElements();
         selectedInternalTasks.clear();
-        selectedHistoryInternalTasks.clear();
-
         const selectedValue = this.value;
         if (selectedValue === "INPUT_SN") {
             document.getElementById("input-sn-form").classList.remove("hidden");
@@ -577,10 +656,10 @@ document.addEventListener("DOMContentLoaded", function () {
                     const sortedData = result.sort((a, b) => new Date(a.createTime) - new Date(b.createTime));
                     renderTableWithDataTable(sortedData, "task-checkbox-table", "task-checkbox", "select-all");
                 } else {
-                    document.getElementById("create-task-result").innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
+                    setResultMessage("create-task-result", `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`);
                 }
             } catch (error) {
-                document.getElementById("create-task-result").innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API.</div>`;
+                setResultMessage("create-task-result", `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API.</div>`);
                 console.error("Error:", error);
             }
         } else if (selectedValue === "CREATE_TASK_FORM_SN") {
@@ -589,27 +668,6 @@ document.addEventListener("DOMContentLoaded", function () {
         } else if (selectedValue === "UPDATE_DATA") {
             document.getElementById("update-data-form").classList.remove("hidden");
             document.getElementById("update-data-result").classList.remove("hidden");
-        } else if (selectedValue === "HISTORY_APPLY") {
-            document.getElementById("history-apply-form").classList.remove("hidden");
-            document.getElementById("history-apply-result").classList.remove("hidden");
-
-            try {
-                const response = await fetch("http://10.220.130.119:9090/api/Scrap/get-history-apply", {
-                    method: "GET",
-                    headers: { "Content-Type": "application/json" }
-                });
-
-                const result = await response.json();
-                if (response.ok) {
-                    const sortedData = result.sort((a, b) => new Date(b.applyTime) - new Date(a.applyTime));
-                    renderTableWithDataTable(sortedData, "history-task-checkbox-table", "history-task-checkbox", "select-all-history");
-                } else {
-                    document.getElementById("history-apply-result").innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
-                }
-            } catch (error) {
-                document.getElementById("history-apply-result").innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API.</div>`;
-                console.error("Error:", error);
-            }
         }
     });
 });


### PR DESCRIPTION
## Summary
- update the scrap status endpoint to return internal tasks from the last three months and expose their purpose
- restyle scrap area pages with the new NVIDIA-green theme and supporting scripts
- refresh Allpart pages, including FailATE and History Error, to use the shared theme and modernized layouts

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ef00dda0d08326b85747d3fcd40f0a