### PR TITLE
Update scrap status API and refresh scrap/Allpart UIs

### DIFF
--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -651,7 +651,7 @@ namespace API_WEB.Controllers.Scrap
                     return BadRequest(new { message = $"Các SN sau không tồn tại trong bảng ScrapList: {string.Join(", ", nonExistingSNs)}" });
                 }
 
-                // Kiểm tra trạng thái ApplyTaskStatus của các SN
+                // Kiểm tra trạng thái ApplyTaskStatus của các SN: chỉ chấp nhận các giá trị khác 2, 4, 8
                 var rejectedSNs = new List<string>();
                 var validSNs = new List<ScrapList>();
 
@@ -664,16 +664,6 @@ namespace API_WEB.Controllers.Scrap
                             2 => "đang chờ SPE approve scrap",
                             4 => "đang chờ approved thay BGA",
                             8 => "lỗi process, không thể sửa chữa",
-                            _ => $"trạng thái không hợp lệ ({sn.ApplyTaskStatus})"
-                        };
-                        rejectedSNs.Add($"{sn.SN} ({reason})");
-                    }
-                    else if (sn.ApplyTaskStatus != 0 && sn.ApplyTaskStatus != 3)
-                    {
-                        string reason = sn.ApplyTaskStatus switch
-                        {
-                            1 => "đã có task",
-                            2 => "đang chờ SPE approve scrap",
                             _ => $"trạng thái không hợp lệ ({sn.ApplyTaskStatus})"
                         };
                         rejectedSNs.Add($"{sn.SN} ({reason})");
@@ -691,7 +681,7 @@ namespace API_WEB.Controllers.Scrap
 
                 if (!validSNs.Any())
                 {
-                    return BadRequest(new { message = "Không có SN nào hợp lệ để tạo task (yêu cầu ApplyTaskStatus = 0 hoặc 3)." });
+                    return BadRequest(new { message = "Không có SN nào hợp lệ để tạo task." });
                 }
 
                 // Tạo danh sách SN để gửi đến API bên thứ ba

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -447,28 +447,33 @@ namespace API_WEB.Controllers.Scrap
             {
                 var threeMonthsAgo = DateTime.Now.AddMonths(-3);
 
-                // Lấy dữ liệu từ bảng ScrapList với InternalTask hợp lệ và CreateTime trong 3 tháng gần nhất
-                var scrapData = await _sqlContext.ScrapLists
-                    .Where(s => s.InternalTask != null
-                                && s.InternalTask != "N/A"
-                                && s.CreateTime != default
-                                && s.CreateTime >= threeMonthsAgo)
-                    .GroupBy(s => s.InternalTask) // Nhóm theo InternalTask
-                    .Select(g => new
-                    {
-                        InternalTask = g.Key,
-                        Description = g.First().Desc, // Lấy giá trị đầu tiên của Description
-                        ApproveScrapPerson = g.First().ApproveScrapperson, // Lấy giá trị đầu tiên
-                        KanBanStatus = g.First().KanBanStatus, // Lấy giá trị đầu tiên
-                        Category = g.First().Category,
-                        Remark = g.First().Remark,
-                        CreateTime = g.First().CreateTime.ToString("yyyy-MM-dd"), // Chỉ lấy ngày tháng năm
-                        CreateBy = g.First().CreatedBy, // Lấy giá trị đầu tiên
-                        ApplyTaskStatus = g.First().ApplyTaskStatus, // Lấy giá trị đầu tiên
-                        Purpose = g.First().Purpose,
-                        TotalQty = g.Count() // Đếm số lượng SN trong mỗi InternalTask
-                    })
+                // Lấy dữ liệu từ bảng ScrapList với InternalTask hợp lệ
+                var scrapRecords = await _sqlContext.ScrapLists
+                    .Where(s => s.InternalTask != null && s.InternalTask != "N/A")
                     .ToListAsync();
+
+                var scrapData = scrapRecords
+                    .Where(s => s.CreateTime != default && s.CreateTime >= threeMonthsAgo)
+                    .GroupBy(s => s.InternalTask)
+                    .Select(g =>
+                    {
+                        var first = g.First();
+                        return new
+                        {
+                            InternalTask = g.Key,
+                            Description = first.Desc,
+                            ApproveScrapPerson = first.ApproveScrapperson,
+                            KanBanStatus = first.KanBanStatus,
+                            Category = first.Category,
+                            Remark = first.Remark,
+                            CreateTime = first.CreateTime.ToString("yyyy-MM-dd"),
+                            CreateBy = first.CreatedBy,
+                            ApplyTaskStatus = first.ApplyTaskStatus,
+                            Purpose = first.Purpose,
+                            TotalQty = g.Count()
+                        };
+                    })
+                    .ToList();
 
                 if (!scrapData.Any())
                 {

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -507,7 +507,7 @@ namespace API_WEB.Controllers.Scrap
 
                 var rejectedStatuses = new[] { 2, 4, 8 };
                 var rejectedSNs = scrapRecords
-                    .Where(s => rejectedStatuses.Contains(s.ApplyTaskStatus ?? -1))
+                    .Where(s => rejectedStatuses.Contains(s.ApplyTaskStatus))
                     .Select(s =>
                     {
                         var reason = s.ApplyTaskStatus switch

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -140,32 +140,48 @@ namespace API_WEB.Controllers.Scrap
 
                 foreach (var sn in existingSNs)
                 {
-                    if (sn.ApplyTaskStatus == 2)
+                    if (sn.ApplyTaskStatus == 0)
                     {
-                        rejectedSNs.Add($"{sn.SN} (ApplyTaskStatus = 2 - trạng thái không được phép tạo task)");
+                        rejectedSNs.Add($"{sn.SN} (SPE đã đồng ý phế, chờ xin task)");
                     }
-                    else if (sn.ApplyTaskStatus == 4)
+                    else if (sn.ApplyTaskStatus == 1)
                     {
-                        rejectedSNs.Add($"{sn.SN} (ApplyTaskStatus = 4 - trạng thái không được phép tạo task)");
+                        rejectedSNs.Add($"{sn.SN} (đang xin task, chờ NV gửi task)");
                     }
-                    else if (sn.ApplyTaskStatus == 8)
+                    else if (sn.ApplyTaskStatus == 3)
                     {
-                        rejectedSNs.Add($"{sn.SN} (ApplyTaskStatus = 8 - trạng thái không được phép tạo task)");
+                        rejectedSNs.Add($"{sn.SN} (NV đã approved thay BGA)");
+                    }
+                    else if (sn.ApplyTaskStatus == 5)
+                    {
+                        rejectedSNs.Add($"{sn.SN} (Đã có task, chờ chuyển MRB)");
+                    }
+                    else if (sn.ApplyTaskStatus == 6)
+                    {
+                        rejectedSNs.Add($"{sn.SN} (Đã chuyển kho phế, chờ MRB xác nhận)");
+                    }
+                    else if (sn.ApplyTaskStatus == 7)
+                    {
+                        rejectedSNs.Add($"{sn.SN} (Đã chuyển kho phế thành công)");
+                    }
+                    else if (sn.ApplyTaskStatus == 2 || sn.ApplyTaskStatus == 4)
+                    {
+                        validSNs.Add(sn); // SN hợp lệ để cập nhật
                     }
                     else
                     {
-                        validSNs.Add(sn);
+                        rejectedSNs.Add($"{sn.SN} (trạng thái không xác định: {sn.ApplyTaskStatus})");
                     }
                 }
 
                 if (rejectedSNs.Any())
                 {
-                    return BadRequest(new { message = $"Các SN sau không hợp lệ để cập nhật (ApplyTaskStatus phải khác 2, 4, 8): {string.Join(", ", rejectedSNs)}" });
+                    return BadRequest(new { message = $"Các SN sau không hợp lệ để cập nhật: {string.Join(", ", rejectedSNs)}" });
                 }
 
                 if (!validSNs.Any())
                 {
-                    return BadRequest(new { message = "Không có SN nào hợp lệ để cập nhật (ApplyTaskStatus phải khác 2, 4, 8)." });
+                    return BadRequest(new { message = "Không có SN nào hợp lệ để cập nhật (yêu cầu ApplyTaskStatus = 2 & 4)." });
                 }
 
                 // kiểm tra xem có lẫn lộn bản giữa Bonepile 1.0 và SN 2.0 không

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -439,15 +439,20 @@ namespace API_WEB.Controllers.Scrap
             }
         }
 
-        // API: Lấy dữ liệu từ ScrapList với ApplyTaskStatus = 0 hoặc 10
+        // API: Lấy dữ liệu từ ScrapList theo InternalTask trong 3 tháng gần nhất
         [HttpGet("get-scrap-status-zero")]
         public async Task<IActionResult> GetScrapStatusZero()
         {
             try
             {
-                // Lấy dữ liệu từ bảng ScrapList với ApplyTaskStatus = 0 hoặc 10
+                var threeMonthsAgo = DateTime.Now.AddMonths(-3);
+
+                // Lấy dữ liệu từ bảng ScrapList với InternalTask hợp lệ và CreateTime trong 3 tháng gần nhất
                 var scrapData = await _sqlContext.ScrapLists
-                    .Where(s => s.ApplyTaskStatus == 0 || s.ApplyTaskStatus == 10) // Lọc theo ApplyTaskStatus = 0 hoặc 10
+                    .Where(s => s.InternalTask != null
+                                && s.InternalTask != "N/A"
+                                && s.CreateTime != default
+                                && s.CreateTime >= threeMonthsAgo)
                     .GroupBy(s => s.InternalTask) // Nhóm theo InternalTask
                     .Select(g => new
                     {
@@ -460,13 +465,14 @@ namespace API_WEB.Controllers.Scrap
                         CreateTime = g.First().CreateTime.ToString("yyyy-MM-dd"), // Chỉ lấy ngày tháng năm
                         CreateBy = g.First().CreatedBy, // Lấy giá trị đầu tiên
                         ApplyTaskStatus = g.First().ApplyTaskStatus, // Lấy giá trị đầu tiên
+                        Purpose = g.First().Purpose,
                         TotalQty = g.Count() // Đếm số lượng SN trong mỗi InternalTask
                     })
                     .ToListAsync();
 
                 if (!scrapData.Any())
                 {
-                    return NotFound(new { message = "Không tìm thấy dữ liệu với ApplyTaskStatus = 0 hoặc 3." });
+                    return NotFound(new { message = "Không tìm thấy dữ liệu phù hợp trong 3 tháng gần nhất." });
                 }
 
                 return Ok(scrapData);

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -495,11 +495,6 @@ namespace API_WEB.Controllers.Scrap
                     return BadRequest(new { message = "Danh sách InternalTasks không được để trống." });
                 }
 
-                if (string.IsNullOrEmpty(request.SaveApplyStatus) || (request.SaveApplyStatus != "0" && request.SaveApplyStatus != "1"))
-                {
-                    return BadRequest(new { message = "SaveApplyStatus phải là '0' hoặc '1'." });
-                }
-
                 // Lấy tất cả SN từ ScrapList dựa trên InternalTasks
                 var scrapRecords = await _sqlContext.ScrapLists
                     .Where(s => request.InternalTasks.Contains(s.InternalTask))
@@ -508,6 +503,27 @@ namespace API_WEB.Controllers.Scrap
                 if (!scrapRecords.Any())
                 {
                     return NotFound(new { message = "Không tìm thấy dữ liệu cho các InternalTasks được cung cấp." });
+                }
+
+                var rejectedStatuses = new[] { 2, 4, 8 };
+                var rejectedSNs = scrapRecords
+                    .Where(s => rejectedStatuses.Contains(s.ApplyTaskStatus ?? -1))
+                    .Select(s =>
+                    {
+                        var reason = s.ApplyTaskStatus switch
+                        {
+                            2 => "đang chờ SPE approve scrap",
+                            4 => "đang chờ approved thay BGA",
+                            8 => "lỗi process, không thể sửa chữa",
+                            _ => $"trạng thái không hợp lệ ({s.ApplyTaskStatus})"
+                        };
+                        return $"{s.SN} ({reason})";
+                    })
+                    .ToList();
+
+                if (rejectedSNs.Any())
+                {
+                    return BadRequest(new { message = $"Các SN sau không hợp lệ để tạo task: {string.Join(", ", rejectedSNs)}" });
                 }
 
                 // Tạo danh sách SN để gửi đến API bên thứ ba
@@ -615,24 +631,6 @@ namespace API_WEB.Controllers.Scrap
                     message = $"Không tìm thấy dữ liệu từ API bên thứ ba cho các SN: {string.Join(", ", unmatchedSNs)}";
                 }
 
-                // Xử lý cập nhật ApplyTaskStatus và ApplyTime nếu SaveApplyStatus = "1"
-                if (request.SaveApplyStatus == "1")
-                {
-                    var currentTime = DateTime.Now; // Lấy thời gian hiện tại
-                    var recordsToUpdate = await _sqlContext.ScrapLists
-                        .Where(s => request.InternalTasks.Contains(s.InternalTask) && s.ApplyTaskStatus == 0)
-                        .ToListAsync();
-
-                    foreach (var record in recordsToUpdate)
-                    {
-                        record.ApplyTaskStatus = 1;
-                        record.ApplyTime = currentTime; // Cập nhật ApplyTime
-                    }
-
-                    await AddHistoryEntriesAsync(recordsToUpdate);
-                    await _sqlContext.SaveChangesAsync();
-                }
-
                 return Ok(new { message, data = result });
             }
             catch (Exception ex)
@@ -653,11 +651,6 @@ namespace API_WEB.Controllers.Scrap
                     return BadRequest(new { message = "Danh sách SNs không được để trống." });
                 }
 
-                if (string.IsNullOrEmpty(request.SaveApplyStatus) || (request.SaveApplyStatus != "0" && request.SaveApplyStatus != "1"))
-                {
-                    return BadRequest(new { message = "SaveApplyStatus phải là '0' hoặc '1'." });
-                }
-
                 // Kiểm tra xem tất cả SNs có tồn tại trong bảng ScrapList không
                 var existingSNs = await _sqlContext.ScrapLists
                     .Where(s => request.SNs.Contains(s.SN))
@@ -675,7 +668,18 @@ namespace API_WEB.Controllers.Scrap
 
                 foreach (var sn in existingSNs)
                 {
-                    if (sn.ApplyTaskStatus != 0 && sn.ApplyTaskStatus != 3)
+                    if (sn.ApplyTaskStatus == 2 || sn.ApplyTaskStatus == 4 || sn.ApplyTaskStatus == 8)
+                    {
+                        string reason = sn.ApplyTaskStatus switch
+                        {
+                            2 => "đang chờ SPE approve scrap",
+                            4 => "đang chờ approved thay BGA",
+                            8 => "lỗi process, không thể sửa chữa",
+                            _ => $"trạng thái không hợp lệ ({sn.ApplyTaskStatus})"
+                        };
+                        rejectedSNs.Add($"{sn.SN} ({reason})");
+                    }
+                    else if (sn.ApplyTaskStatus != 0 && sn.ApplyTaskStatus != 3)
                     {
                         string reason = sn.ApplyTaskStatus switch
                         {
@@ -804,24 +808,6 @@ namespace API_WEB.Controllers.Scrap
                 if (unmatchedSNs.Any())
                 {
                     message = $"Không tìm thấy dữ liệu từ API bên thứ ba cho các SN: {string.Join(", ", unmatchedSNs)}";
-                }
-
-                // Xử lý cập nhật ApplyTaskStatus và ApplyTime nếu SaveApplyStatus = "1"
-                if (request.SaveApplyStatus == "1")
-                {
-                    var currentTime = DateTime.Now; // Lấy thời gian hiện tại
-                    var recordsToUpdate = await _sqlContext.ScrapLists
-                        .Where(s => request.SNs.Contains(s.SN) && s.ApplyTaskStatus == 0)
-                        .ToListAsync();
-
-                    foreach (var record in recordsToUpdate)
-                    {
-                        record.ApplyTaskStatus = 1;
-                        record.ApplyTime = currentTime; // Cập nhật ApplyTime
-                    }
-
-                    await AddHistoryEntriesAsync(recordsToUpdate);
-                    await _sqlContext.SaveChangesAsync();
                 }
 
                 return Ok(new { message, data = result });

--- a/API_WEB/Controllers/Scrap/ScrapController.cs
+++ b/API_WEB/Controllers/Scrap/ScrapController.cs
@@ -140,48 +140,32 @@ namespace API_WEB.Controllers.Scrap
 
                 foreach (var sn in existingSNs)
                 {
-                    if (sn.ApplyTaskStatus == 0)
+                    if (sn.ApplyTaskStatus == 2)
                     {
-                        rejectedSNs.Add($"{sn.SN} (SPE đã đồng ý phế, chờ xin task)");
+                        rejectedSNs.Add($"{sn.SN} (ApplyTaskStatus = 2 - trạng thái không được phép tạo task)");
                     }
-                    else if (sn.ApplyTaskStatus == 1)
+                    else if (sn.ApplyTaskStatus == 4)
                     {
-                        rejectedSNs.Add($"{sn.SN} (đang xin task, chờ NV gửi task)");
+                        rejectedSNs.Add($"{sn.SN} (ApplyTaskStatus = 4 - trạng thái không được phép tạo task)");
                     }
-                    else if (sn.ApplyTaskStatus == 3)
+                    else if (sn.ApplyTaskStatus == 8)
                     {
-                        rejectedSNs.Add($"{sn.SN} (NV đã approved thay BGA)");
-                    }
-                    else if (sn.ApplyTaskStatus == 5)
-                    {
-                        rejectedSNs.Add($"{sn.SN} (Đã có task, chờ chuyển MRB)");
-                    }
-                    else if (sn.ApplyTaskStatus == 6)
-                    {
-                        rejectedSNs.Add($"{sn.SN} (Đã chuyển kho phế, chờ MRB xác nhận)");
-                    }
-                    else if (sn.ApplyTaskStatus == 7)
-                    {
-                        rejectedSNs.Add($"{sn.SN} (Đã chuyển kho phế thành công)");
-                    }
-                    else if (sn.ApplyTaskStatus == 2 || sn.ApplyTaskStatus == 4)
-                    {
-                        validSNs.Add(sn); // SN hợp lệ để cập nhật
+                        rejectedSNs.Add($"{sn.SN} (ApplyTaskStatus = 8 - trạng thái không được phép tạo task)");
                     }
                     else
                     {
-                        rejectedSNs.Add($"{sn.SN} (trạng thái không xác định: {sn.ApplyTaskStatus})");
+                        validSNs.Add(sn);
                     }
                 }
 
                 if (rejectedSNs.Any())
                 {
-                    return BadRequest(new { message = $"Các SN sau không hợp lệ để cập nhật: {string.Join(", ", rejectedSNs)}" });
+                    return BadRequest(new { message = $"Các SN sau không hợp lệ để cập nhật (ApplyTaskStatus phải khác 2, 4, 8): {string.Join(", ", rejectedSNs)}" });
                 }
 
                 if (!validSNs.Any())
                 {
-                    return BadRequest(new { message = "Không có SN nào hợp lệ để cập nhật (yêu cầu ApplyTaskStatus = 2 & 4)." });
+                    return BadRequest(new { message = "Không có SN nào hợp lệ để cập nhật (ApplyTaskStatus phải khác 2, 4, 8)." });
                 }
 
                 // kiểm tra xem có lẫn lộn bản giữa Bonepile 1.0 và SN 2.0 không

--- a/PESystem/Areas/Allpart/Views/DCLC/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/DCLC/Index.cshtml
@@ -1,54 +1,75 @@
-﻿@{
+@{
     ViewData["Title"] = "Allpart DC-LC";
 }
 @{
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
 
-<link href="~/assets/css/dclc.css" rel="stylesheet" />
+<link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">Tìm Kiếm Thông Tin Linh Kiện</h1>
+<div class="allpart-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">Tìm kiếm thông tin linh kiện DC/LC</h1>
+        <p>Tra cứu nhanh và tải xuống dữ liệu DC/LC với giao diện hiện đại mang sắc xanh NVIDIA.</p>
     </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)"></textarea>
-            </div>
-            <div class="col-md-4">
-                <textarea id="refDes" class="form-control" rows="3" placeholder="Nhập vị trí (mỗi dòng một giá trị)..."></textarea>
-            </div>
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-            <div class="col-md-2">
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Tải xuống Excel</button>
+
+    <div class="row g-4 align-items-stretch">
+        <div class="col-12">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Bộ lọc tìm kiếm</h2>
+                    <span class="badge-nvidia">DC-LC</span>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-4">
+                            <label for="serialNumber" class="form-label">Serial Number</label>
+                            <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)"></textarea>
+                        </div>
+                        <div class="col-md-4">
+                            <label for="refDes" class="form-label">Vị trí</label>
+                            <textarea id="refDes" class="form-control" rows="3" placeholder="Nhập vị trí (mỗi dòng một giá trị)..."></textarea>
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="search()" class="btn btn-ne w-100">Tìm kiếm</button>
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="downloadExcel()" class="btn btn-ne w-100">Tải xuống Excel</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="dcLcTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>P_SN</th>
-                            <th>MODEL_NAME</th>
-                            <th>MÃ_LIỆU</th>
-                            <th>VENDOR_CODE</th>
-                            <th>VENDOR_NAME</th>
-                            <th>REF_DES</th>
-                            <th>DATE_CODE</th>
-                            <th>LOT_CODE</th>
-                            <th>PROCESS_FLAG</th>
-                            <th>STATION</th>
-                            <th>GROUP_NAME</th>
-                            <th>WORK_TIME</th>
-                            <th>WO</th>
-                        </tr>
-                    </thead>
-                    <tbody id="dcLcTableBody"></tbody>
-                </table>
+        <div class="col-12">
+            <div class="nvidia-card">
+                <div class="nvidia-card-header">
+                    <h2>Kết quả tra cứu</h2>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="table-responsive">
+                        <table id="dcLcTable" class="display table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                            <thead>
+                                <tr>
+                                    <th>P_SN</th>
+                                    <th>MODEL_NAME</th>
+                                    <th>MÃ_LIỆU</th>
+                                    <th>VENDOR_CODE</th>
+                                    <th>VENDOR_NAME</th>
+                                    <th>REF_DES</th>
+                                    <th>DATE_CODE</th>
+                                    <th>LOT_CODE</th>
+                                    <th>PROCESS_FLAG</th>
+                                    <th>STATION</th>
+                                    <th>GROUP_NAME</th>
+                                    <th>WORK_TIME</th>
+                                    <th>WO</th>
+                                </tr>
+                            </thead>
+                            <tbody id="dcLcTableBody"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -127,6 +148,7 @@
                         <div class="spinner"></div>
                         <div>Đang tải dữ liệu, vui lòng chờ...</div>
                     `;
+            loadingOverlay.style.display = 'flex';
             document.body.appendChild(loadingOverlay);
 
             try {
@@ -198,34 +220,31 @@
         function downloadExcel() {
             const allData = dcLcTable.rows().data().toArray();
 
-            const excelData = [
-                ['P_SN', 'MODEL_NAME', 'MÃ_LIỆU', 'VENDOR_CODE', 'VENDOR_NAME', 'REF_DES', 'DATE_CODE', 'LOT_CODE', 'PROCESS_FLAG', 'STATION', 'GROUP_NAME', 'WORK_TIME', 'WO']
-            ];
+            if (allData.length === 0) {
+                alert('Không có dữ liệu để tải xuống.');
+                return;
+            }
 
-            allData.forEach(row => {
-                const rowData = Array.from(row).map(cell => {
-                    const div = document.createElement('div');
-                    div.innerHTML = cell;
-                    return div.textContent || '';
-                });
-                excelData.push(rowData);
-            });
+            const exportData = allData.map(row => ({
+                P_SN: $(row[0]).text(),
+                MODEL_NAME: $(row[1]).text(),
+                MÃ_LIỆU: $(row[2]).text(),
+                VENDOR_CODE: $(row[3]).text(),
+                VENDOR_NAME: $(row[4]).text(),
+                REF_DES: $(row[5]).text(),
+                DATE_CODE: $(row[6]).text(),
+                LOT_CODE: $(row[7]).text(),
+                PROCESS_FLAG: $(row[8]).text(),
+                STATION: $(row[9]).text(),
+                GROUP_NAME: $(row[10]).text(),
+                WORK_TIME: $(row[11]).text(),
+                WO: $(row[12]).text()
+            }));
 
-            const ws = XLSX.utils.aoa_to_sheet(excelData);
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws, "Sheet1");
-
-            const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
-            const blob = new Blob([wbout], { type: 'application/octet-stream' });
-
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = 'data_dclc_' + new Date().toISOString().slice(0, 10) + '.xlsx';
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            window.URL.revokeObjectURL(url);
+            const worksheet = XLSX.utils.json_to_sheet(exportData);
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'DCLC');
+            XLSX.writeFile(workbook, `DCLC_${new Date().toISOString().split('T')[0]}.xlsx`);
         }
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/DCLC/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/DCLC/Index.cshtml
@@ -6,6 +6,7 @@
 }
 
 <link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+<script src="~/lib/chart.umd.min.js"></script>
 
 <div class="allpart-interface nvidia-section">
     <div class="section-heading text-center text-lg-start">
@@ -77,17 +78,38 @@
 
 @section Scripts {
     <script>
+        const TOOLTIP_OFFSET_X = 10;
+        const TOOLTIP_OFFSET_Y = 10;
         let dcLcTable;
 
+        function positionTooltip(evt, tooltip) {
+            const pageX = evt.pageX ?? (evt.clientX + window.scrollX);
+            const pageY = evt.pageY ?? (evt.clientY + window.scrollY);
+            tooltip.style.left = (pageX + TOOLTIP_OFFSET_X) + 'px';
+            tooltip.style.top = (pageY + TOOLTIP_OFFSET_Y) + 'px';
+        }
+
+        function htmlEscape(value) {
+            return String(value ?? '')
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
+        }
+
         function createTooltipCell(data) {
-            return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
+            const text = htmlEscape(data);
+            return `<span class="tooltip-trigger" data-tooltip="${text}">${text}</span>`;
         }
 
         function attachTooltipEvents() {
-            $(document).on('mouseover', '.tooltip-trigger', function (e) {
-                const $this = $(this);
-                const tooltipText = $this.data('tooltip');
-                if (tooltipText) {
+            $(document)
+                .off('.tooltipHover')
+                .on('mouseover.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltipText = $(this).data('tooltip');
+                    if (!tooltipText) return;
+
                     let tooltip = document.querySelector('.custom-tooltip');
                     if (!tooltip) {
                         tooltip = document.createElement('div');
@@ -96,30 +118,30 @@
                     }
                     tooltip.textContent = tooltipText;
                     tooltip.style.display = 'block';
-                    tooltip.style.left = (e.pageX + 10) + 'px';
-                    tooltip.style.top = (e.pageY - 20) + 'px';
-                }
-            }).on('mousemove', '.tooltip-trigger', function (e) {
-                const tooltip = document.querySelector('.custom-tooltip');
-                if (tooltip && tooltip.style.display === 'block') {
-                    tooltip.style.left = (e.pageX + 10) + 'px';
-                    tooltip.style.top = (e.pageY - 20) + 'px';
-                }
-            }).on('mouseout', '.tooltip-trigger', function () {
-                const tooltip = document.querySelector('.custom-tooltip');
-                if (tooltip) {
-                    tooltip.style.display = 'none';
-                }
-            });
+                    positionTooltip(e, tooltip);
+                })
+                .on('mousemove.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip && tooltip.style.display === 'block') {
+                        positionTooltip(e, tooltip);
+                    }
+                })
+                .on('mouseout.tooltipHover', '.tooltip-trigger', function () {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip) {
+                        tooltip.style.display = 'none';
+                    }
+                });
         }
 
         $(document).ready(function () {
             dcLcTable = $('#dcLcTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
-                responsive: true,
+                responsive: false,
+                autoWidth: false,
                 columnDefs: [
-                    { targets: '_all', width: '150px' }
+                    { targets: '_all', width: '210px' }
                 ]
             });
 

--- a/PESystem/Areas/Allpart/Views/FailATE/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/FailATE/Index.cshtml
@@ -1,154 +1,79 @@
-﻿@{
+@{
     ViewData["Title"] = "History Error";
 }
 @{
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">FAIL ATE</h1>
+<link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+
+<div class="allpart-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">FAIL ATE</h1>
+        <p>Tra cứu lịch sử lỗi ATE với bảng dữ liệu trực quan và dễ đọc.</p>
     </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="1" placeholder="Nhập SerialNumber..."></textarea>
-            </div>
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
+
+    <div class="row g-4 align-items-stretch">
+        <div class="col-12">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Bộ lọc tìm kiếm</h2>
+                    <span class="badge-nvidia">ATE</span>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-4">
+                            <label for="serialNumber" class="form-label">Serial Number</label>
+                            <textarea id="serialNumber" class="form-control" rows="1" placeholder="Nhập SerialNumber..."></textarea>
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="search()" class="btn btn-ne w-100">Tìm kiếm</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="historyDataTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>SERIAL_NUMBER</th>
-                            <th>MODEL_NAME</th>
-                            <th>LINE_NAME</th>
-                            <th>SECTION_NAME</th>
-                            <th>GROUP_NAME</th>
-                            <th>STATION_NAME</th>
-                            <th>ERROR_CODE</th>
-                            <th>ERROR_DESC</th>
-                            <th>DATA6</th>
-                            <th>DATA12</th>
-                            <th>PASS_COUNT</th>
-                            <th>RETEST_COUNT</th>
-                            <th>TEST_VALUE</th>
-                            <th>IN_STATION_TIME</th>
-                            <th>RESULT</th>
-                            <th>DATA2</th>
-                            <th>TEST_MODE</th>
-                            <th>SCOF_MIN</th>
-                        </tr>
-                    </thead>
-                    <tbody id="historyDataTableBody"></tbody>
-                </table>
+        <div class="col-12">
+            <div class="nvidia-card">
+                <div class="nvidia-card-header">
+                    <h2>Kết quả tra cứu</h2>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="table-responsive">
+                        <table id="historyDataTable" class="display table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                            <thead>
+                                <tr>
+                                    <th>SERIAL_NUMBER</th>
+                                    <th>MODEL_NAME</th>
+                                    <th>LINE_NAME</th>
+                                    <th>SECTION_NAME</th>
+                                    <th>GROUP_NAME</th>
+                                    <th>STATION_NAME</th>
+                                    <th>ERROR_CODE</th>
+                                    <th>ERROR_DESC</th>
+                                    <th>DATA6</th>
+                                    <th>DATA12</th>
+                                    <th>PASS_COUNT</th>
+                                    <th>RETEST_COUNT</th>
+                                    <th>TEST_VALUE</th>
+                                    <th>IN_STATION_TIME</th>
+                                    <th>RESULT</th>
+                                    <th>DATA2</th>
+                                    <th>TEST_MODE</th>
+                                    <th>SCOF_MIN</th>
+                                </tr>
+                            </thead>
+                            <tbody id="historyDataTableBody"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .bg-nvidia-green {
-            background-color: #76B900 !important;
-        }
-
-        .btn-nvidia-green {
-            background-color: #76B900 !important;
-            border-color: #76B900 !important;
-            color: #fff;
-            height: 100%;
-        }
-
-            .btn-nvidia-green:hover {
-                background-color: #639A00 !important;
-                border-color: #639A00 !important;
-            }
-
-        .custom-tooltip {
-            position: absolute;
-            background-color: #333;
-            color: #fff;
-            padding: 5px 10px;
-            border-radius: 3px;
-            font-size: 12px;
-            z-index: 1000;
-            display: none;
-            max-width: 200px;
-            word-wrap: break-word;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-        }
-
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76B900 !important;
-        }
-
-        .dataTables_wrapper .dataTables_filter,
-        .dataTables_wrapper .dataTables_paginate {
-            position: sticky;
-            top: 0;
-            background-color: #fff;
-            z-index: 1;
-            border-radius: 5px;
-            margin-bottom: 5px;
-            padding: 5px;
-            vertical-align: middle;
-        }
-
-        .dataTables_wrapper {
-            overflow-x: auto;
-        }
-
-        .table-responsive {
-            overflow-x: auto;
-        }
-
-        .row.align-items-center {
-            display: flex;
-            align-items: stretch;
-        }
-
-        .form-control {
-            height: auto;
-            resize: vertical;
-        }
-
-        .datatable-table th, .datatable-table td {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            max-width: 150px;
-            padding: 5px;
-        }
-
-        .loading-overlay {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 2000;
-            justify-content: center;
-            align-items: center;
-        }
-
-        .loading-message {
-            background: #fff;
-            padding: 15px 30px;
-            border-radius: 5px;
-            font-size: 16px;
-            font-weight: bold;
-            color: #333;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-        }
-    </style>
     <script>
         let historyTable = null;
 
@@ -200,103 +125,78 @@
         }
 
         function renderTable(data) {
-            if (historyTable) {
-                historyTable.clear().rows.add(data).draw();
-                return;
+            if (!historyTable) {
+                historyTable = $('#historyDataTable').DataTable({
+                    pageLength: 10,
+                    scrollX: true,
+                    responsive: true,
+                    columnDefs: [
+                        { targets: '_all', defaultContent: '' }
+                    ]
+                });
+            } else {
+                historyTable.clear();
             }
 
-            historyTable = $('#historyDataTable').DataTable({
-                destroy: true,
-                data: data,
-                pageLength: 10,
-                order: [[0, "desc"]],
-                scrollX: true,
-                autoWidth: false,
-                dom: '<"top d-flex justify-content-between align-items-center"lfB>rt<"bottom"ip>',
-                buttons: [
-                    {
-                        extend: 'excelHtml5',
-                        text: '<i class="fa fa-file-excel"></i>',
-                        className: 'btn btn-success btn-sm',
-                        title:null,
-                        filename: 'FAIL_ATE_' + new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-'),
-                        exportOptions: {
-                            columns: ':visible'
-                        }
+            data.forEach(item => {
+                historyTable.row.add([
+                    createTooltipCell(item.serial_Number),
+                    createTooltipCell(item.model_Name),
+                    createTooltipCell(item.line_Name),
+                    createTooltipCell(item.section_Name),
+                    createTooltipCell(item.group_Name),
+                    createTooltipCell(item.station_Name),
+                    createTooltipCell(item.error_Code),
+                    createTooltipCell(item.error_Desc),
+                    createTooltipCell(item.data6),
+                    createTooltipCell(item.data12),
+                    createTooltipCell(item.pass_Count),
+                    createTooltipCell(item.retest_Count),
+                    createTooltipCell(item.test_Value),
+                    createTooltipCell(item.in_Station_Time),
+                    createTooltipCell(item.result),
+                    createTooltipCell(item.data2),
+                    createTooltipCell(item.test_Mode),
+                    createTooltipCell(item.scof_Min)
+                ]);
+            });
+
+            historyTable.draw();
+            attachTooltipEvents();
+        }
+
+        function createTooltipCell(data) {
+            return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
+        }
+
+        function attachTooltipEvents() {
+            $(document).on('mouseover', '.tooltip-trigger', function (e) {
+                const $this = $(this);
+                const tooltipText = $this.data('tooltip');
+                if (tooltipText) {
+                    let tooltip = document.querySelector('.custom-tooltip');
+                    if (!tooltip) {
+                        tooltip = document.createElement('div');
+                        tooltip.className = 'custom-tooltip';
+                        document.body.appendChild(tooltip);
                     }
-                ],
-                columns: [
-                    { data: "serialNumber" },
-                    { data: "modelName" },
-                    { data: "lineName" },
-                    { data: "sectionName" },
-                    { data: "groupName" },
-                    { data: "stationName" },
-                    { data: "errorCode" },
-                    {
-                        data: "errorDesc",
-                        render: function (data) {
-                            if (!data) return "";
-                            const text = data.toString().replace(/"/g, '&quot;');
-                            return `<span title="${text}">${text}</span>`;
-                        }
-                    },
-                    { data: "data6" },
-                    { data: "data12" },
-                    { data: "passCount" },
-                    { data: "retestCount" },
-                    { data: "testValue" },
-                    {
-                        data: "inStationTime",
-                        render: function (data) {
-                            return data ? new Date(data).toLocaleString() : "";
-                        }
-                    },
-                    { data: "result" },
-                    { data: "data2" },
-                    { data: "testMode" },
-                    { data: "scofMin" }
-                ],
-                language: {
-                    search: "Tìm kiếm:",
-                    lengthMenu: "Hiển thị _MENU_ dòng",
-                    info: "Hiển thị _START_ - _END_ / _TOTAL_ dòng",
-                    paginate: {
-                        first: "Đầu",
-                        last: "Cuối",
-                        next: "→",
-                        previous: "←"
-                    },
-                    emptyTable: "Không có dữ liệu để hiển thị"
-                },
-                createdRow: function (row, data, dataIndex) {
-                    $('td', row).each(function () {
-                        const text = $(this).text().trim();
-                        if (text.length > 0) {
-                            $(this).attr('title', text);
-                        }
-                    });
+                    tooltip.textContent = tooltipText;
+                    tooltip.style.display = 'block';
+                    tooltip.style.left = (e.pageX + 10) + 'px';
+                    tooltip.style.top = (e.pageY - 20) + 'px';
+                }
+            }).on('mousemove', '.tooltip-trigger', function (e) {
+                const tooltip = document.querySelector('.custom-tooltip');
+                if (tooltip && tooltip.style.display === 'block') {
+                    tooltip.style.left = (e.pageX + 10) + 'px';
+                    tooltip.style.top = (e.pageY - 20) + 'px';
+                }
+            }).on('mouseout', '.tooltip-trigger', function () {
+                const tooltip = document.querySelector('.custom-tooltip');
+                if (tooltip) {
+                    tooltip.style.display = 'none';
                 }
             });
         }
-
-
-        // ✅ CSS thêm tooltip đẹp + cắt nội dung dài
-        $(document).ready(function () {
-            const style = `
-            <style>
-                table.dataTable td {
-                    white-space: nowrap;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    max-width: 220px;
-                    vertical-align: middle;
-                }
-                table.dataTable td:hover {
-                    background-color: #fff9d6 !important;
-                }
-            </style>`;
-            $('head').append(style);
-        });
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/FailATE/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/FailATE/Index.cshtml
@@ -6,6 +6,7 @@
 }
 
 <link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+<script src="~/lib/chart.umd.min.js"></script>
 
 <div class="allpart-interface nvidia-section">
     <div class="section-heading text-center text-lg-start">
@@ -75,7 +76,34 @@
 
 @section Scripts {
     <script>
+        const TOOLTIP_OFFSET_X = 10;
+        const TOOLTIP_OFFSET_Y = 10;
         let historyTable = null;
+
+        function positionTooltip(evt, tooltip) {
+            const pageX = evt.pageX ?? (evt.clientX + window.scrollX);
+            const pageY = evt.pageY ?? (evt.clientY + window.scrollY);
+            tooltip.style.left = (pageX + TOOLTIP_OFFSET_X) + 'px';
+            tooltip.style.top = (pageY + TOOLTIP_OFFSET_Y) + 'px';
+        }
+
+        const pick = (obj, ...keys) => {
+            for (const key of keys) {
+                if (obj && obj[key] !== undefined && obj[key] !== null) {
+                    return obj[key];
+                }
+            }
+            return '';
+        };
+
+        function htmlEscape(value) {
+            return String(value ?? '')
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
+        }
 
         async function search() {
             const sn = $("#serialNumber").val().trim().toUpperCase();
@@ -101,7 +129,8 @@
                 });
 
                 if (!response.ok) {
-                    throw new Error("API trả về lỗi: " + response.status);
+                    const errorText = await response.text();
+                    throw new Error(`API trả về lỗi: ${response.status} - ${errorText}`);
                 }
 
                 const result = await response.json();
@@ -129,9 +158,10 @@
                 historyTable = $('#historyDataTable').DataTable({
                     pageLength: 10,
                     scrollX: true,
-                    responsive: true,
+                    responsive: false,
+                    autoWidth: false,
                     columnDefs: [
-                        { targets: '_all', defaultContent: '' }
+                        { targets: '_all', defaultContent: '', width: '210px' }
                     ]
                 });
             } else {
@@ -140,24 +170,24 @@
 
             data.forEach(item => {
                 historyTable.row.add([
-                    createTooltipCell(item.serial_Number),
-                    createTooltipCell(item.model_Name),
-                    createTooltipCell(item.line_Name),
-                    createTooltipCell(item.section_Name),
-                    createTooltipCell(item.group_Name),
-                    createTooltipCell(item.station_Name),
-                    createTooltipCell(item.error_Code),
-                    createTooltipCell(item.error_Desc),
-                    createTooltipCell(item.data6),
-                    createTooltipCell(item.data12),
-                    createTooltipCell(item.pass_Count),
-                    createTooltipCell(item.retest_Count),
-                    createTooltipCell(item.test_Value),
-                    createTooltipCell(item.in_Station_Time),
-                    createTooltipCell(item.result),
-                    createTooltipCell(item.data2),
-                    createTooltipCell(item.test_Mode),
-                    createTooltipCell(item.scof_Min)
+                    createTooltipCell(pick(item, 'serial_Number', 'serialNumber')),
+                    createTooltipCell(pick(item, 'model_Name', 'modelName')),
+                    createTooltipCell(pick(item, 'line_Name', 'lineName')),
+                    createTooltipCell(pick(item, 'section_Name', 'sectionName')),
+                    createTooltipCell(pick(item, 'group_Name', 'groupName')),
+                    createTooltipCell(pick(item, 'station_Name', 'stationName')),
+                    createTooltipCell(pick(item, 'error_Code', 'errorCode')),
+                    createTooltipCell(pick(item, 'error_Desc', 'errorDesc')),
+                    createTooltipCell(pick(item, 'data6', 'dataSix', 'data_6')),
+                    createTooltipCell(pick(item, 'data12', 'dataTwelve', 'data_12')),
+                    createTooltipCell(pick(item, 'pass_Count', 'passCount')),
+                    createTooltipCell(pick(item, 'retest_Count', 'retestCount')),
+                    createTooltipCell(pick(item, 'test_Value', 'testValue')),
+                    createTooltipCell(pick(item, 'in_Station_Time', 'inStationTime')),
+                    createTooltipCell(pick(item, 'result')),
+                    createTooltipCell(pick(item, 'data2', 'data_2')),
+                    createTooltipCell(pick(item, 'test_Mode', 'testMode')),
+                    createTooltipCell(pick(item, 'scof_Min', 'scofMin'))
                 ]);
             });
 
@@ -166,14 +196,17 @@
         }
 
         function createTooltipCell(data) {
-            return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
+            const text = htmlEscape(data);
+            return `<span class="tooltip-trigger" data-tooltip="${text}">${text}</span>`;
         }
 
         function attachTooltipEvents() {
-            $(document).on('mouseover', '.tooltip-trigger', function (e) {
-                const $this = $(this);
-                const tooltipText = $this.data('tooltip');
-                if (tooltipText) {
+            $(document)
+                .off('.tooltipHover')
+                .on('mouseover.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltipText = $(this).data('tooltip');
+                    if (!tooltipText) return;
+
                     let tooltip = document.querySelector('.custom-tooltip');
                     if (!tooltip) {
                         tooltip = document.createElement('div');
@@ -182,21 +215,20 @@
                     }
                     tooltip.textContent = tooltipText;
                     tooltip.style.display = 'block';
-                    tooltip.style.left = (e.pageX + 10) + 'px';
-                    tooltip.style.top = (e.pageY - 20) + 'px';
-                }
-            }).on('mousemove', '.tooltip-trigger', function (e) {
-                const tooltip = document.querySelector('.custom-tooltip');
-                if (tooltip && tooltip.style.display === 'block') {
-                    tooltip.style.left = (e.pageX + 10) + 'px';
-                    tooltip.style.top = (e.pageY - 20) + 'px';
-                }
-            }).on('mouseout', '.tooltip-trigger', function () {
-                const tooltip = document.querySelector('.custom-tooltip');
-                if (tooltip) {
-                    tooltip.style.display = 'none';
-                }
-            });
+                    positionTooltip(e, tooltip);
+                })
+                .on('mousemove.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip && tooltip.style.display === 'block') {
+                        positionTooltip(e, tooltip);
+                    }
+                })
+                .on('mouseout.tooltipHover', '.tooltip-trigger', function () {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip) {
+                        tooltip.style.display = 'none';
+                    }
+                });
         }
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/HE/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/HE/Index.cshtml
@@ -6,6 +6,7 @@
 }
 
 <link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+<script src="~/lib/chart.umd.min.js"></script>
 
 <div class="allpart-interface nvidia-section">
     <div class="section-heading text-center text-lg-start">
@@ -81,55 +82,75 @@
 
 @section Scripts {
     <script>
+        const TOOLTIP_OFFSET_X = 10;
+        const TOOLTIP_OFFSET_Y = 10;
         let tableData = [];
         let dataTable;
 
+        function positionTooltip(evt, tooltip) {
+            const pageX = evt.pageX ?? (evt.clientX + window.scrollX);
+            const pageY = evt.pageY ?? (evt.clientY + window.scrollY);
+            tooltip.style.left = (pageX + TOOLTIP_OFFSET_X) + 'px';
+            tooltip.style.top = (pageY + TOOLTIP_OFFSET_Y) + 'px';
+        }
+
+        function htmlEscape(value) {
+            return String(value ?? '')
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
+        }
+
         function createTooltipCell(data) {
-            return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
+            const text = htmlEscape(data);
+            return `<span class="tooltip-trigger" data-tooltip="${text}">${text}</span>`;
         }
 
         function attachTooltipEvents() {
-            $('.tooltip-trigger').each(function () {
-                const $this = $(this);
-                if (!$this.data('tooltip-initialized')) {
-                    $this.on('mouseover', function (e) {
-                        const tooltipText = $this.data('tooltip');
-                        if (tooltipText) {
-                            let tooltip = document.querySelector('.custom-tooltip');
-                            if (!tooltip) {
-                                tooltip = document.createElement('div');
-                                tooltip.className = 'custom-tooltip';
-                                document.body.appendChild(tooltip);
-                            }
-                            tooltip.textContent = tooltipText;
-                            tooltip.style.display = 'block';
-                            tooltip.style.left = (e.pageX + 10) + 'px';
-                            tooltip.style.top = (e.pageY - 20) + 'px';
-                        }
-                    }).on('mousemove', function (e) {
-                        const tooltip = document.querySelector('.custom-tooltip');
-                        if (tooltip && tooltip.style.display === 'block') {
-                            tooltip.style.left = (e.pageX + 10) + 'px';
-                            tooltip.style.top = (e.pageY - 20) + 'px';
-                        }
-                    }).on('mouseout', function () {
-                        const tooltip = document.querySelector('.custom-tooltip');
-                        if (tooltip) {
-                            tooltip.style.display = 'none';
-                        }
-                    });
-                    $this.data('tooltip-initialized', true);
-                }
-            });
+            $(document)
+                .off('.tooltipHover')
+                .on('mouseover.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltipText = $(this).data('tooltip');
+                    if (!tooltipText) return;
+
+                    let tooltip = document.querySelector('.custom-tooltip');
+                    if (!tooltip) {
+                        tooltip = document.createElement('div');
+                        tooltip.className = 'custom-tooltip';
+                        document.body.appendChild(tooltip);
+                    }
+                    tooltip.textContent = tooltipText;
+                    tooltip.style.display = 'block';
+                    positionTooltip(e, tooltip);
+                })
+                .on('mousemove.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip && tooltip.style.display === 'block') {
+                        positionTooltip(e, tooltip);
+                    }
+                })
+                .on('mouseout.tooltipHover', '.tooltip-trigger', function () {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip) {
+                        tooltip.style.display = 'none';
+                    }
+                });
         }
 
         $(document).ready(function () {
             dataTable = $('#historyDataTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
-                responsive: true,
+                responsive: false,
+                autoWidth: false,
+                columnDefs: [
+                    { targets: '_all', width: '210px' }
+                ],
                 fixedHeader: true
             });
+            attachTooltipEvents();
         });
 
         async function search() {

--- a/PESystem/Areas/Allpart/Views/HE/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/HE/Index.cshtml
@@ -1,171 +1,93 @@
-﻿@{
+@{
     ViewData["Title"] = "History Error";
 }
 @{
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">Tìm Kiếm Thông Tin lịch sử lỗi</h1>
+<link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+
+<div class="allpart-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">Tìm kiếm thông tin lịch sử lỗi</h1>
+        <p>Tra cứu chi tiết lịch sử lỗi với giao diện dễ đọc, đồng bộ màu xanh NVIDIA.</p>
     </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)..."></textarea>
-            </div>
-            <div class="col-md-2">
-                <label for="type-options" class="form-label">Chọn kiểu tra cứu</label>
-                <select id="type-options" class="form-select">
-                    <option selected disabled>SELECT TYPE</option>
-                    <option value="1">Tra cứu theo SN-SFG</option>
-                    <option value="2">Tra cứu theo SN-FG</option>
-                </select>
-            </div>
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-            <div class="col-md-2">
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Tải xuống Excel</button>
+
+    <div class="row g-4 align-items-stretch">
+        <div class="col-12">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Bộ lọc tìm kiếm</h2>
+                    <span class="badge-nvidia">History Error</span>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-4">
+                            <label for="serialNumber" class="form-label">Serial Number</label>
+                            <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber (mỗi dòng một giá trị)..."></textarea>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="type-options" class="form-label">Chọn kiểu tra cứu</label>
+                            <select id="type-options" class="form-select">
+                                <option selected disabled>SELECT TYPE</option>
+                                <option value="1">Tra cứu theo SN-SFG</option>
+                                <option value="2">Tra cứu theo SN-FG</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="search()" class="btn btn-ne w-100">Tìm kiếm</button>
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="downloadExcel()" class="btn btn-ne w-100">Tải xuống Excel</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div id="loading-overlay" class="loading-overlay">
-            <div class="loading-message">Đang tải dữ liệu...</div>
-        </div>
-
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="historyDataTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>SERIAL_NUMBER</th>
-                            <th>KEY_PART_SN</th>
-                            <th>MO_NUMBER</th>
-                            <th>MODEL_NAME</th>
-                            <th>TEST_TIME</th>
-                            <th>TEST_GROUP</th>
-                            <th>TEST_CODE</th>
-                            <th>DATA1</th>
-                            <th>REASON_CODE</th>
-                        </tr>
-                    </thead>
-                    <tbody id="historyDataTableBody"></tbody>
-                </table>
+        <div class="col-12">
+            <div class="nvidia-card">
+                <div class="nvidia-card-header">
+                    <h2>Kết quả tra cứu</h2>
+                </div>
+                <div class="nvidia-card-body">
+                    <div id="loading-overlay" class="loading-overlay">
+                        <div class="spinner"></div>
+                        <div>Đang tải dữ liệu...</div>
+                    </div>
+                    <div class="table-responsive">
+                        <table id="historyDataTable" class="display table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                            <thead>
+                                <tr>
+                                    <th>SERIAL_NUMBER</th>
+                                    <th>KEY_PART_SN</th>
+                                    <th>MO_NUMBER</th>
+                                    <th>MODEL_NAME</th>
+                                    <th>TEST_TIME</th>
+                                    <th>TEST_GROUP</th>
+                                    <th>TEST_CODE</th>
+                                    <th>DATA1</th>
+                                    <th>REASON_CODE</th>
+                                </tr>
+                            </thead>
+                            <tbody id="historyDataTableBody"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .bg-nvidia-green {
-            background-color: #76B900 !important;
-        }
-
-        .btn-nvidia-green {
-            background-color: #76B900 !important;
-            border-color: #76B900 !important;
-            color: #fff;
-            height: 100%;
-        }
-
-            .btn-nvidia-green:hover {
-                background-color: #639A00 !important;
-                border-color: #639A00 !important;
-            }
-
-        .custom-tooltip {
-            position: absolute;
-            background-color: #333;
-            color: #fff;
-            padding: 5px 10px;
-            border-radius: 3px;
-            font-size: 12px;
-            z-index: 1000;
-            display: none;
-            max-width: 200px;
-            word-wrap: break-word;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-        }
-
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76B900 !important;
-        }
-
-        .dataTables_wrapper .dataTables_filter,
-        .dataTables_wrapper .dataTables_paginate {
-            position: sticky;
-            top: 0;
-            background-color: #fff;
-            z-index: 1;
-            border-radius: 5px;
-            margin-bottom: 5px;
-            padding: 5px;
-            vertical-align: middle;
-        }
-
-        .dataTables_wrapper {
-            overflow-x: auto;
-        }
-
-        .table-responsive {
-            overflow-x: auto;
-        }
-
-        .row.align-items-center {
-            display: flex;
-            align-items: stretch;
-        }
-
-        .form-control {
-            height: auto;
-            resize: vertical;
-        }
-
-        .datatable-table th, .datatable-table td {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            max-width: 150px;
-            padding: 5px;
-        }
-
-        .loading-overlay {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 2000;
-            justify-content: center;
-            align-items: center;
-        }
-
-        .loading-message {
-            background: #fff;
-            padding: 15px 30px;
-            border-radius: 5px;
-            font-size: 16px;
-            font-weight: bold;
-            color: #333;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
-        }
-    </style>
-
     <script>
-        let tableData = []; // Lưu dữ liệu để xuất Excel
-        let dataTable; // Lưu tham chiếu đến DataTable
+        let tableData = [];
+        let dataTable;
 
-        // Hàm tạo nội dung cho ô với tooltip
         function createTooltipCell(data) {
             return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
         }
 
-        // Hàm gắn sự kiện tooltip cho các phần tử
         function attachTooltipEvents() {
             $('.tooltip-trigger').each(function () {
                 const $this = $(this);
@@ -202,7 +124,6 @@
         }
 
         $(document).ready(function () {
-            // Khởi tạo DataTable một lần duy nhất
             dataTable = $('#historyDataTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
@@ -232,7 +153,6 @@
                 return;
             }
 
-            // Hiển thị thông báo tải
             loadingOverlay.style.display = 'flex';
 
             try {
@@ -252,9 +172,8 @@
                 }
 
                 const data = await response.json();
-                tableData = data; // Lưu dữ liệu để xuất Excel
+                tableData = data;
 
-                // Xóa dữ liệu cũ trong DataTable
                 dataTable.clear();
 
                 if (data.length === 0) {
@@ -263,7 +182,6 @@
                     return;
                 }
 
-                // Thêm dữ liệu mới vào DataTable
                 data.forEach(row => {
                     dataTable.row.add([
                         createTooltipCell(row.SERIAL_NUMBER || ''),
@@ -278,17 +196,13 @@
                     ]);
                 });
 
-                // Vẽ lại bảng
                 dataTable.draw();
-
-                // Gắn lại sự kiện tooltip
                 attachTooltipEvents();
 
             } catch (error) {
                 console.error('Error:', error);
                 alert(`Đã xảy ra lỗi: ${error.message}`);
             } finally {
-                // Ẩn thông báo tải
                 loadingOverlay.style.display = 'none';
             }
         }
@@ -299,7 +213,6 @@
                 return;
             }
 
-            // Lọc dữ liệu để chỉ xuất các cột hiển thị trong bảng
             const filteredData = tableData.map(row => ({
                 SERIAL_NUMBER: row.SERIAL_NUMBER || '',
                 KEY_PART_SN: row.KEY_PART_SN || '',
@@ -316,20 +229,19 @@
             const workbook = XLSX.utils.book_new();
             XLSX.utils.book_append_sheet(workbook, worksheet, 'HistoryError');
 
-            // Đặt tiêu đề cột
             worksheet['!cols'] = [
-                { wch: 20 }, // SERIAL_NUMBER
-                { wch: 20 }, // KEY_PART_SN
-                { wch: 15 }, // MO_NUMBER
-                { wch: 15 }, // MODEL_NAME
-                { wch: 20 }, // TEST_TIME
-                { wch: 10 }, // TEST_GROUP
-                { wch: 30 }, // TEST_CODE
-                { wch: 50 }, // DATA1
-                { wch: 15 }  // REASON_CODE
+                { wch: 20 },
+                { wch: 20 },
+                { wch: 15 },
+                { wch: 20 },
+                { wch: 20 },
+                { wch: 15 },
+                { wch: 15 },
+                { wch: 20 },
+                { wch: 20 }
             ];
 
-            XLSX.writeFile(workbook, 'HistoryError.xlsx');
+            XLSX.writeFile(workbook, `HistoryError_${new Date().toISOString().split('T')[0]}.xlsx`);
         }
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/Shared/layout_allpart.cshtml
+++ b/PESystem/Areas/Allpart/Views/Shared/layout_allpart.cshtml
@@ -67,6 +67,7 @@
     <script src="~/lib/buttons.html5.min.js"></script> <!-- HTML5 export -->
     <script src="~/lib/jszip.min.js"></script> <!-- JSZip (Excel support) -->
     <script src="~/lib/excel/xlsx.full.min.js"></script> <!-- Excel Export (optional) -->
+    <script src="~/lib/chart.umd.min.js"></script>
     <script src="~/lib/chartjs-plugin-datalabels.js"></script>
     <script src="~/lib/sweetalert2/dist/sweetalert2.all.js"></script>
     <script src="~/js/site.min.js" asp-append-version="true"></script> <!-- Site Scripts -->

--- a/PESystem/Areas/Allpart/Views/ULT/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/ULT/Index.cshtml
@@ -5,6 +5,7 @@
 }
 
 <link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+<script src="~/lib/chart.umd.min.js"></script>
 
 <div class="allpart-interface nvidia-section">
     <div class="section-heading text-center text-lg-start">
@@ -89,6 +90,16 @@
             const v = data ?? '';
             return `<span class="tooltip-trigger" data-tooltip="${escapeHtml(String(v))}">${escapeHtml(String(v))}</span>`;
         }
+        const TOOLTIP_OFFSET_X = 10;
+        const TOOLTIP_OFFSET_Y = 10;
+
+        function positionTooltip(evt, tooltip) {
+            const pageX = evt.pageX ?? (evt.clientX + window.scrollX);
+            const pageY = evt.pageY ?? (evt.clientY + window.scrollY);
+            tooltip.style.left = (pageX + TOOLTIP_OFFSET_X) + 'px';
+            tooltip.style.top = (pageY + TOOLTIP_OFFSET_Y) + 'px';
+        }
+
         function attachTooltipEvents() {
             document.querySelectorAll('.tooltip-trigger').forEach(el => {
                 if (el.dataset.tooltipBound) return;
@@ -101,14 +112,12 @@
                     }
                     tip.textContent = el.getAttribute('data-tooltip') || '';
                     tip.style.display = 'block';
-                    tip.style.left = (e.pageX + 10) + 'px';
-                    tip.style.top = (e.pageY - 20) + 'px';
+                    positionTooltip(e, tip);
                 });
                 el.addEventListener('mousemove', (e) => {
                     const tip = document.querySelector('.custom-tooltip');
                     if (tip) {
-                        tip.style.left = (e.pageX + 10) + 'px';
-                        tip.style.top = (e.pageY - 20) + 'px';
+                        positionTooltip(e, tip);
                     }
                 });
                 el.addEventListener('mouseout', () => {
@@ -190,9 +199,10 @@
             dataTable = $('#ULTDataTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
-                responsive: true,
+                responsive: false,
+                autoWidth: false,
                 columnDefs: [
-                    { targets: '_all', width: '150px' }
+                    { targets: '_all', width: '210px' }
                 ]
             });
             attachTooltipEvents();
@@ -219,33 +229,36 @@
                 let allResults = [];
                 const batchSize = 100;
                 for (let i = 0; i < inputList.length; i += batchSize) {
-                    const batch = inputList.slice(i, i + batchSize);
-                    const payload = {
-                        type: 'GET_ULT',
-                        item: typeOption === 'SN' ? 'BY-SN' : 'BY-ULT',
-                        var_1: batch.join(';')
-                    };
+                const batch = inputList.slice(i, i + batchSize);
+                const payload = {
+                    type: typeOption,
+                    data: batch
+                };
 
-                    const response = await fetch('http://10.220.130.119:9090/api/RepairStatus/check-ult', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify(payload)
-                    });
+                const response = await fetch('http://10.220.130.119:9090/api/SFC/search-ult-data', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(payload)
+                });
 
-                    if (!response.ok) {
-                        const errorText = await response.text();
-                        throw new Error(`Lỗi khi gọi API: ${response.status} - ${errorText}`);
-                    }
-
-                    const result = await response.json();
-                    if (Array.isArray(result) && result.length > 0) {
-                        allResults = allResults.concat(result);
-                    }
+                if (response.status === 404) {
+                    continue;
                 }
 
-                rawResults = allResults.map(item => ({
+                if (!response.ok) {
+                    const errorText = await response.text();
+                    throw new Error(`Lỗi khi gọi API: ${response.status} - ${errorText}`);
+                }
+
+                const result = await response.json();
+                if (Array.isArray(result) && result.length > 0) {
+                    allResults = allResults.concat(result);
+                }
+            }
+
+            rawResults = allResults.map(item => ({
                     SERIAL_NUMBER: item.SERIAL_NUMBER ?? '',
                     MODEL_NAME: item.MODEL_NAME ?? '',
                     GROUP_NAME: item.GROUP_NAME ?? '',

--- a/PESystem/Areas/Allpart/Views/ULT/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/ULT/Index.cshtml
@@ -1,66 +1,79 @@
-﻿@* File: Areas/Allpart/Views/ScanATestB/Index.cshtml *@
+@* File: Areas/Allpart/Views/ScanATestB/Index.cshtml *@
 @{
     ViewData["Title"] = "Check ULT data";
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
 
-<link href="~/assets/css/YRDCLC.css" rel="stylesheet" />
+<link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">Tìm Kiếm Thông Tin ULT</h1>
+<div class="allpart-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">Tìm kiếm thông tin ULT</h1>
+        <p>Kiểm tra dữ liệu ULT với bảng thống kê hiện đại và dễ theo dõi.</p>
     </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <!-- Ô nhập danh sách SN/ULT -->
-            <div class="col-md-4">
-                <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber/ULT"></textarea>
-            </div>
 
-            <!-- Chọn kiểu tra cứu -->
-            <div class="col-md-2">
-                <label for="type-options" class="form-label">Chọn kiểu tra cứu</label>
-                <select id="type-options" class="form-select">
-                    <option selected disabled>SELECT TYPE</option>
-                    <option value="SN">Tra cứu theo SN</option>
-                    <option value="ULT">Tra cứu theo ULT</option>
-                </select>
-            </div>
-
-            <!-- Chế độ hiển thị: ALL vs NEWEST -->
-            <div class="col-md-2">
-                <label for="view-mode" class="form-label">Chế độ hiển thị</label>
-                <select id="view-mode" class="form-select" title="Chọn dữ liệu cho bảng và xuất Excel">
-                    <option value="all" selected>Tất cả dữ liệu</option>
-                    <option value="latest">Kết quả mới nhất (mỗi SN)</option>
-                </select>
-            </div>
-
-            <!-- Nút hành động -->
-            <div class="col-md-2 d-flex flex-column gap-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Tải xuống Excel</button>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-12">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Bộ lọc tìm kiếm</h2>
+                    <span class="badge-nvidia">ULT</span>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-4">
+                            <label for="serialNumber" class="form-label">Serial Number / ULT</label>
+                            <textarea id="serialNumber" class="form-control" rows="3" placeholder="Nhập SerialNumber/ULT"></textarea>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="type-options" class="form-label">Chọn kiểu tra cứu</label>
+                            <select id="type-options" class="form-select">
+                                <option selected disabled>SELECT TYPE</option>
+                                <option value="SN">Tra cứu theo SN</option>
+                                <option value="ULT">Tra cứu theo ULT</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="view-mode" class="form-label">Chế độ hiển thị</label>
+                            <select id="view-mode" class="form-select" title="Chọn dữ liệu cho bảng và xuất Excel">
+                                <option value="all" selected>Tất cả dữ liệu</option>
+                                <option value="latest">Kết quả mới nhất (mỗi SN)</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2 d-flex flex-column gap-2">
+                            <button onclick="search()" class="btn btn-ne w-100">Tìm kiếm</button>
+                            <button onclick="downloadExcel()" class="btn btn-ne w-100">Tải xuống Excel</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="mt-4">
-            <div class="table-responsive align-items-center">
-                <table id="ULTDataTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>SERIAL_NUMBER</th>
-                            <th>MODEL_NAME</th>
-                            <th>GROUP_NAME</th>
-                            <th>TEST_TIME</th>
-                            <th>ULT</th>
-                            <th>STATION_NAME</th>
-                            <th>TEST_ON</th>
-                            <th>TEST_OFF</th>
-                            <th>TEST_RESULT</th>
-                        </tr>
-                    </thead>
-                    <tbody id="ULTDataTableBody"></tbody>
-                </table>
+        <div class="col-12">
+            <div class="nvidia-card">
+                <div class="nvidia-card-header">
+                    <h2>Kết quả tra cứu</h2>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="table-responsive">
+                        <table id="ULTDataTable" class="display table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                            <thead>
+                                <tr>
+                                    <th>SERIAL_NUMBER</th>
+                                    <th>MODEL_NAME</th>
+                                    <th>GROUP_NAME</th>
+                                    <th>TEST_TIME</th>
+                                    <th>ULT</th>
+                                    <th>STATION_NAME</th>
+                                    <th>TEST_ON</th>
+                                    <th>TEST_OFF</th>
+                                    <th>TEST_RESULT</th>
+                                </tr>
+                            </thead>
+                            <tbody id="ULTDataTableBody"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -68,12 +81,10 @@
 
 @section Scripts {
     <script>
-        // === State ===
-        let rawResults = [];   // Dữ liệu gốc từ API
-        let tableData = [];   // Dữ liệu đang hiển thị / export
-        let dataTable;         // Tham chiếu DataTable
+        let rawResults = [];
+        let tableData = [];
+        let dataTable;
 
-        // === Tooltip helpers ===
         function createTooltipCell(data) {
             const v = data ?? '';
             return `<span class="tooltip-trigger" data-tooltip="${escapeHtml(String(v))}">${escapeHtml(String(v))}</span>`;
@@ -108,7 +119,6 @@
             });
         }
 
-        // Tránh XSS trong tooltip/cell
         function escapeHtml(s) {
             return s
                 .replaceAll('&', '&amp;')
@@ -118,7 +128,6 @@
                 .replaceAll("'", '&#39;');
         }
 
-        // === Date helpers ===
         function formatDateTime(dateTime) {
             if (!dateTime) return '';
             const d = new Date(dateTime);
@@ -148,7 +157,6 @@
             return Array.from(bySn.values());
         }
 
-        // === Render ===
         function renderTable(rows) {
             if (!dataTable) return;
             dataTable.clear();
@@ -178,7 +186,19 @@
             renderTable(tableData);
         }
 
-        // === Search ===
+        $(document).ready(function () {
+            dataTable = $('#ULTDataTable').DataTable({
+                pageLength: 10,
+                scrollX: true,
+                responsive: true,
+                columnDefs: [
+                    { targets: '_all', width: '150px' }
+                ]
+            });
+            attachTooltipEvents();
+            document.getElementById('view-mode').addEventListener('change', applyViewAndRender);
+        });
+
         async function search() {
             const inputRaw = document.getElementById('serialNumber').value.trim();
             const typeOption = document.getElementById('type-options').value;
@@ -189,82 +209,84 @@
             const inputList = inputRaw.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
             if (inputList.length === 0) { alert('Danh sách trống.'); return; }
 
-            // Loading overlay
             const overlay = document.createElement('div');
             overlay.className = 'loading-overlay';
             overlay.innerHTML = `<div class="spinner"></div><div>Đang tải dữ liệu, vui lòng chờ...</div>`;
+            overlay.style.display = 'flex';
             document.body.appendChild(overlay);
 
             try {
                 let allResults = [];
                 const batchSize = 100;
-                const url = 'http://10.220.130.119:9090/api/SFC/search-ult-data';
-
                 for (let i = 0; i < inputList.length; i += batchSize) {
                     const batch = inputList.slice(i, i + batchSize);
-                    const body = {
-                        type: typeOption,
-                        data: batch
+                    const payload = {
+                        type: 'GET_ULT',
+                        item: typeOption === 'SN' ? 'BY-SN' : 'BY-ULT',
+                        var_1: batch.join(';')
                     };
-                    const res = await fetch(url, {
+
+                    const response = await fetch('http://10.220.130.119:9090/api/RepairStatus/check-ult', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-                        body: JSON.stringify(body)
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(payload)
                     });
-                    if (!res.ok) throw new Error(`Lỗi API: ${res.status} - ${await res.text()}`);
-                    const json = await res.json();
-                    if (!Array.isArray(json)) throw new Error('Dữ liệu trả về không hợp lệ.');
-                    allResults = allResults.concat(json);
+
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(`Lỗi khi gọi API: ${response.status} - ${errorText}`);
+                    }
+
+                    const result = await response.json();
+                    if (Array.isArray(result) && result.length > 0) {
+                        allResults = allResults.concat(result);
+                    }
                 }
 
-                rawResults = allResults;
-                if (rawResults.length === 0) {
-                    alert('Không tìm thấy dữ liệu cho các thông tin đã nhập.');
-                }
+                rawResults = allResults.map(item => ({
+                    SERIAL_NUMBER: item.SERIAL_NUMBER ?? '',
+                    MODEL_NAME: item.MODEL_NAME ?? '',
+                    GROUP_NAME: item.GROUP_NAME ?? '',
+                    TEST_TIME: item.TEST_TIME ?? '',
+                    ULT: item.ULT ?? '',
+                    STATION_NAME: item.STATION_NAME ?? '',
+                    TEST_ON: item.TEST_ON ?? '',
+                    TEST_OFF: item.TEST_OFF ?? '',
+                    TEST_RESULT: item.TEST_RESULT ?? ''
+                }));
+
                 applyViewAndRender();
-            } catch (err) {
-                alert(`Đã xảy ra lỗi: ${err.message}`);
+
+            } catch (error) {
+                alert(`Đã xảy ra lỗi: ${error.message}`);
             } finally {
-                overlay.remove();
+                document.body.removeChild(overlay);
             }
         }
 
-        // === Export ===
         function downloadExcel() {
-            if (!tableData || tableData.length === 0) {
+            if (!tableData.length) {
                 alert('Không có dữ liệu để xuất Excel.');
                 return;
             }
-            const ws = XLSX.utils.json_to_sheet(tableData);
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws, 'ULTData');
 
-            // Widths (tham khảo theo thứ tự cột)
-            ws['!cols'] = [
-                { wch: 22 }, // SERIAL_NUMBER
-                { wch: 15 }, // MODEL_NAME
-                { wch: 12 }, // GROUP_NAME
-                { wch: 20 }, // TEST_TIME
-                { wch: 20 }, // ULT
-                { wch: 30 }, // STATION_NAME
-                { wch: 12 }, // TEST_ON
-                { wch: 12 }, // TEST_OFF
-                { wch: 18 }  // TEST_RESULT
-            ];
-            XLSX.writeFile(wb, 'ULTData.xlsx');
+            const worksheet = XLSX.utils.json_to_sheet(tableData.map(row => ({
+                SERIAL_NUMBER: row.SERIAL_NUMBER,
+                MODEL_NAME: row.MODEL_NAME,
+                GROUP_NAME: row.GROUP_NAME,
+                TEST_TIME: row.TEST_TIME,
+                ULT: row.ULT,
+                STATION_NAME: row.STATION_NAME,
+                TEST_ON: row.TEST_ON,
+                TEST_OFF: row.TEST_OFF,
+                TEST_RESULT: row.TEST_RESULT
+            })));
+
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'ULT');
+            XLSX.writeFile(workbook, `ULT_${new Date().toISOString().split('T')[0]}.xlsx`);
         }
-
-        // === Init ===
-        $(document).ready(function () {
-            dataTable = $('#ULTDataTable').DataTable({
-                pageLength: 10,
-                scrollX: true,
-                responsive: true,
-                fixedHeader: true
-            });
-
-            // Thay đổi chế độ hiển thị -> render lại từ rawResults
-            $('#view-mode').on('change', applyViewAndRender);
-        });
     </script>
 }

--- a/PESystem/Areas/Allpart/Views/YRDCLC/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/YRDCLC/Index.cshtml
@@ -6,6 +6,7 @@
 }
 
 <link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
+<script src="~/lib/chart.umd.min.js"></script>
 
 <div class="allpart-interface nvidia-section">
     <div class="section-heading text-center text-lg-start">
@@ -92,18 +93,39 @@
 
 @section Scripts {
     <script>
+        const TOOLTIP_OFFSET_X = 10;
+        const TOOLTIP_OFFSET_Y = 10;
         let yrdcLcTable;
         let snDataCache = [];
 
+        function positionTooltip(evt, tooltip) {
+            const pageX = evt.pageX ?? (evt.clientX + window.scrollX);
+            const pageY = evt.pageY ?? (evt.clientY + window.scrollY);
+            tooltip.style.left = (pageX + TOOLTIP_OFFSET_X) + 'px';
+            tooltip.style.top = (pageY + TOOLTIP_OFFSET_Y) + 'px';
+        }
+
+        function htmlEscape(value) {
+            return String(value ?? '')
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;');
+        }
+
         function createTooltipCell(data) {
-            return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
+            const text = htmlEscape(data);
+            return `<span class="tooltip-trigger" data-tooltip="${text}">${text}</span>`;
         }
 
         function attachTooltipEvents() {
-            $(document).on('mouseover', '.tooltip-trigger', function (e) {
-                const $this = $(this);
-                const tooltipText = $this.data('tooltip');
-                if (tooltipText) {
+            $(document)
+                .off('.tooltipHover')
+                .on('mouseover.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltipText = $(this).data('tooltip');
+                    if (!tooltipText) return;
+
                     let tooltip = document.querySelector('.custom-tooltip');
                     if (!tooltip) {
                         tooltip = document.createElement('div');
@@ -112,21 +134,20 @@
                     }
                     tooltip.textContent = tooltipText;
                     tooltip.style.display = 'block';
-                    tooltip.style.left = (e.pageX + 10) + 'px';
-                    tooltip.style.top = (e.pageY - 20) + 'px';
-                }
-            }).on('mousemove', '.tooltip-trigger', function (e) {
-                const tooltip = document.querySelector('.custom-tooltip');
-                if (tooltip && tooltip.style.display === 'block') {
-                    tooltip.style.left = (e.pageX + 10) + 'px';
-                    tooltip.style.top = (e.pageY - 20) + 'px';
-                }
-            }).on('mouseout', '.tooltip-trigger', function () {
-                const tooltip = document.querySelector('.custom-tooltip');
-                if (tooltip) {
-                    tooltip.style.display = 'none';
-                }
-            });
+                    positionTooltip(e, tooltip);
+                })
+                .on('mousemove.tooltipHover', '.tooltip-trigger', function (e) {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip && tooltip.style.display === 'block') {
+                        positionTooltip(e, tooltip);
+                    }
+                })
+                .on('mouseout.tooltipHover', '.tooltip-trigger', function () {
+                    const tooltip = document.querySelector('.custom-tooltip');
+                    if (tooltip) {
+                        tooltip.style.display = 'none';
+                    }
+                });
         }
 
         function formatDateTime(dateTime) {
@@ -145,9 +166,10 @@
             yrdcLcTable = $('#yrdcLcTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
-                responsive: true,
+                responsive: false,
+                autoWidth: false,
                 columnDefs: [
-                    { targets: '_all', width: '150px' }
+                    { targets: '_all', width: '210px' }
                 ]
             });
 

--- a/PESystem/Areas/Allpart/Views/YRDCLC/Index.cshtml
+++ b/PESystem/Areas/Allpart/Views/YRDCLC/Index.cshtml
@@ -1,86 +1,104 @@
-﻿@{
+@{
     ViewData["Title"] = "YR follow DC-LC";
 }
 @{
     Layout = "~/Areas/Allpart/Views/Shared/layout_allpart.cshtml";
 }
 
-<link href="~/assets/css/yrdclc.css" rel="stylesheet" />
+<link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
 
-<div class="card shadow-sm">
-    <div class="card-header bg-nvidia-green text-white">
-        <h1 class="h4 mb-0 text-center">YR follow DC/LC</h1>
+<div class="allpart-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">YR follow DC/LC</h1>
+        <p>Theo dõi dữ liệu YR theo DC/LC với bộ lọc linh hoạt và bảng thống kê rõ ràng.</p>
     </div>
-    <div class="card-body">
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="date-time-range">
-                <label for="startDate">Bắt đầu:</label>
-                <input type="datetime-local" id="startDate" />
-                <label for="endDate">Kết thúc:</label>
-                <input type="datetime-local" id="endDate" />
-            </div>
-        </div>
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-2">
-                <input id="model" name="model" class="form-control" placeholder="Model Name" />
-            </div>
-            <div class="col-md-2">
-                <input id="PN" name="PN" class="form-control" placeholder="Mã Liệu" />
-            </div>
-            <div class="col-md-2">
-                <input id="location" name="location" class="form-control" placeholder="Vị trí" />
-            </div>
-            <div class="col-md-2">
-                <input id="station" name="station" class="form-control" placeholder="Trạm test" />
-            </div>
-            <div class="col-md-2">
-                <input id="error" name="error" class="form-control" placeholder="Mã lỗi" />
-            </div>
-        </div>
-        <div class="row g-3 mb-4 align-items-center">
-            <div class="col-md-2">
-                <button onclick="search()" class="btn btn-nvidia-green w-100">Tìm kiếm</button>
-            </div>
-            <div class="col-md-2">
-                <button onclick="downloadExcel()" class="btn btn-nvidia-green w-100">Load data</button>
+
+    <div class="row g-4 align-items-stretch">
+        <div class="col-12">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Bộ lọc tìm kiếm</h2>
+                    <span class="badge-nvidia">YR - DC/LC</span>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-4">
+                            <label class="form-label">Khoảng thời gian</label>
+                            <div class="d-flex flex-column flex-md-row gap-2">
+                                <input type="datetime-local" id="startDate" class="form-control" />
+                                <input type="datetime-local" id="endDate" class="form-control" />
+                            </div>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="model" class="form-label">Model Name</label>
+                            <input id="model" name="model" class="form-control" placeholder="Model Name" />
+                        </div>
+                        <div class="col-md-2">
+                            <label for="PN" class="form-label">Mã Liệu</label>
+                            <input id="PN" name="PN" class="form-control" placeholder="Mã Liệu" />
+                        </div>
+                        <div class="col-md-2">
+                            <label for="location" class="form-label">Vị trí</label>
+                            <input id="location" name="location" class="form-control" placeholder="Vị trí" />
+                        </div>
+                        <div class="col-md-2">
+                            <label for="station" class="form-label">Trạm test</label>
+                            <input id="station" name="station" class="form-control" placeholder="Trạm test" />
+                        </div>
+                        <div class="col-md-2">
+                            <label for="error" class="form-label">Mã lỗi</label>
+                            <input id="error" name="error" class="form-control" placeholder="Mã lỗi" />
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="search()" class="btn btn-ne w-100">Tìm kiếm</button>
+                        </div>
+                        <div class="col-md-2">
+                            <button onclick="downloadExcel()" class="btn btn-ne w-100">Load data</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="mt-5">
-            <div class="table-responsive align-items-center">
-                <table id="yrdcLcTable" class="display table table-bordered table-striped datatable-table" style="width:100%">
-                    <thead>
-                        <tr>
-                            <th>MODEL_NAME</th>
-                            <th>MÃ_LIỆU</th>
-                            <th>DATE_CODE</th>
-                            <th>LOT_CODE</th>
-                            <th>VENDOR_NAME</th>
-                            <th>INPUT_QTY</th>
-                            <th>FAIL_QTY</th>
-                            <th>PASS_QTY</th>
-                            <th>DFR</th>
-                        </tr>
-                    </thead>
-                    <tbody id="yrdcLcTableBody"></tbody>
-                </table>
+        <div class="col-12">
+            <div class="nvidia-card">
+                <div class="nvidia-card-header">
+                    <h2>Kết quả tổng hợp</h2>
+                </div>
+                <div class="nvidia-card-body">
+                    <div class="table-responsive">
+                        <table id="yrdcLcTable" class="display table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                            <thead>
+                                <tr>
+                                    <th>MODEL_NAME</th>
+                                    <th>MÃ_LIỆU</th>
+                                    <th>DATE_CODE</th>
+                                    <th>LOT_CODE</th>
+                                    <th>VENDOR_NAME</th>
+                                    <th>INPUT_QTY</th>
+                                    <th>FAIL_QTY</th>
+                                    <th>PASS_QTY</th>
+                                    <th>DFR</th>
+                                </tr>
+                            </thead>
+                            <tbody id="yrdcLcTableBody"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
 
 @section Scripts {
-
     <script>
         let yrdcLcTable;
-        let snDataCache = []; // Lưu dữ liệu BY-FAIL-SN để xuất Excel
+        let snDataCache = [];
 
-        // Hàm tạo nội dung cho ô với tooltip
         function createTooltipCell(data) {
             return `<span class="tooltip-trigger" data-tooltip="${data || ''}">${data || ''}</span>`;
         }
 
-        // Gắn sự kiện tooltip sử dụng event delegation
         function attachTooltipEvents() {
             $(document).on('mouseover', '.tooltip-trigger', function (e) {
                 const $this = $(this);
@@ -111,7 +129,6 @@
             });
         }
 
-        // Hàm định dạng ngày giờ từ datetime-local sang YYYY-MM-DD HH:MM:SS
         function formatDateTime(dateTime) {
             if (!dateTime) return '';
             const date = new Date(dateTime);
@@ -125,7 +142,6 @@
         }
 
         $(document).ready(function () {
-            // Khởi tạo DataTable
             yrdcLcTable = $('#yrdcLcTable').DataTable({
                 pageLength: 10,
                 scrollX: true,
@@ -135,7 +151,6 @@
                 ]
             });
 
-            // Gắn sự kiện tooltip
             attachTooltipEvents();
         });
 
@@ -148,30 +163,26 @@
             const startDate = document.getElementById('startDate').value;
             const endDate = document.getElementById('endDate').value;
 
-            // Kiểm tra đầu vào
             if (!model || !PN || !station || !error || !location || !startDate || !endDate) {
                 alert('Vui lòng nhập đầy đủ tất cả các trường!');
                 return;
             }
 
-            // Định dạng thời gian
             const formattedStartDate = formatDateTime(startDate);
             const formattedEndDate = formatDateTime(endDate);
 
-            // Hiển thị loading overlay
             const loadingOverlay = document.createElement('div');
             loadingOverlay.className = 'loading-overlay';
             loadingOverlay.innerHTML = `
                 <div class="spinner"></div>
                 <div>Đang tải dữ liệu, vui lòng chờ...</div>
             `;
+            loadingOverlay.style.display = 'flex';
             document.body.appendChild(loadingOverlay);
 
             try {
-                // Làm mới bảng trước khi tìm kiếm
                 yrdcLcTable.clear();
 
-                // Lần gọi API đầu tiên (BY-FAIL-TOTAL)
                 const totalResponse = await fetch('http://10.220.130.119:9090/api/RepairStatus/check-yr-by-dclc', {
                     method: 'POST',
                     headers: {
@@ -201,10 +212,9 @@
                     return;
                 }
 
-                // Hiển thị dữ liệu từ lần gọi đầu tiên vào bảng
                 totalData.result.forEach(item => {
                     yrdcLcTable.row.add([
-                        createTooltipCell(item.p_no),
+                        createTooltipCell(item.model_name),
                         createTooltipCell(item.kp_no),
                         createTooltipCell(item.date_code),
                         createTooltipCell(item.lot_code),
@@ -213,10 +223,10 @@
                         createTooltipCell(item.fail_qty),
                         createTooltipCell(item.pass_qty),
                         createTooltipCell(item.dfr)
-                    ]).draw();
+                    ]);
                 });
+                yrdcLcTable.draw();
 
-                // Lần gọi API thứ hai (BY-FAIL-SN)
                 const snResponse = await fetch('http://10.220.130.119:9090/api/RepairStatus/check-yr-by-dclc', {
                     method: 'POST',
                     headers: {
@@ -240,82 +250,26 @@
                 }
 
                 const snData = await snResponse.json();
-                if (!snData.result || snData.result.length === 0) {
-                    console.warn('Không có dữ liệu từ API BY-FAIL-SN.');
-                } else {
-                    // Lưu dữ liệu BY-FAIL-SN để xuất Excel
-                    snDataCache = snData.result;
-                }
+                snDataCache = snData.result || [];
 
-                // Gắn sự kiện tooltip
                 attachTooltipEvents();
-
             } catch (error) {
                 alert(`Đã xảy ra lỗi: ${error.message}`);
             } finally {
-                // Xóa loading overlay
-                if (document.body.contains(loadingOverlay)) {
-                    document.body.removeChild(loadingOverlay);
-                }
+                document.body.removeChild(loadingOverlay);
             }
         }
 
         function downloadExcel() {
-            if (!snDataCache.length && !yrdcLcTable.rows().data().toArray().length) {
-                alert('Không có dữ liệu để tải xuống Excel!');
+            if (!snDataCache.length) {
+                alert('Không có dữ liệu SN để tải.');
                 return;
             }
 
-            // Dữ liệu cho sheet 1 (từ bảng yrdcLcTable)
-            const totalData = [
-                ['MODEL_NAME', 'MÃ_LIỆU', 'DATE_CODE', 'LOT_CODE', 'VENDOR_NAME', 'INPUT_QTY', 'FAIL_QTY', 'PASS_QTY', 'DFR']
-            ];
-            yrdcLcTable.rows().data().toArray().forEach(row => {
-                const rowData = Array.from(row).map(cell => {
-                    const div = document.createElement('div');
-                    div.innerHTML = cell;
-                    return div.textContent || '';
-                });
-                totalData.push(rowData);
-            });
-
-            // Dữ liệu cho sheet 2 (từ snDataCache)
-            const snData = [
-                ['P_SN', 'WO', 'P_NO', 'TR_SN', 'KP_NO', 'MFR_KP_NO', 'DATE_CODE', 'LOT_CODE', 'MFR_NAME', 'PROCESS_FLAG', 'STATION', 'GROUP_NAME', 'WORK_TIME', 'REF_DES', 'TEST_CODE', 'TEST_GROUP']
-            ];
-            snDataCache.forEach(item => {
-                snData.push([
-                    item.p_sn,
-                    item.wo,
-                    item.p_no,
-                    item.tr_sn,
-                    item.kp_no,
-                    item.mfr_kp_no,
-                    item.date_code,
-                    item.lot_code,
-                    item.mfr_name,
-                    item.process_flag,
-                    item.station,
-                    item.group_name,
-                    item.work_time,
-                    item.ref_des,
-                    item.test_code,
-                    item.test_group
-                ]);
-            });
-
-            // Tạo worksheet cho sheet 1
-            const ws1 = XLSX.utils.aoa_to_sheet(totalData);
-            // Tạo worksheet cho sheet 2
-            const ws2 = XLSX.utils.aoa_to_sheet(snData);
-
-            // Tạo workbook và thêm các sheet
-            const wb = XLSX.utils.book_new();
-            XLSX.utils.book_append_sheet(wb, ws1, "Total_Data");
-            XLSX.utils.book_append_sheet(wb, ws2, "SN_Data");
-
-            // Xuất file Excel
-            XLSX.writeFile(wb, 'yrdc_lc_data_' + new Date().toISOString().slice(0, 10) + '.xlsx');
+            const worksheet = XLSX.utils.json_to_sheet(snDataCache);
+            const workbook = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(workbook, worksheet, 'YR-DC-LC');
+            XLSX.writeFile(workbook, `YR_DC_LC_${new Date().toISOString().split('T')[0]}.xlsx`);
         }
     </script>
 }

--- a/PESystem/Areas/Scrap/Views/Function/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function/Index.cshtml
@@ -142,8 +142,8 @@
 
         <div id="create-task-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">Danh sách Internal Task</h3>
-            <div class="table-responsive">
-                <table id="task-checkbox-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+            <div class="table-responsive table-container">
+                <table id="task-checkbox-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--compact">
                     <thead>
                         <tr>
                             <th class="checkbox-column"><input type="checkbox" id="select-all"></th>
@@ -170,8 +170,8 @@
 
         <div id="history-apply-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">Lịch sử gửi khách hàng</h3>
-            <div class="table-responsive">
-                <table id="history-task-checkbox-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+            <div class="table-responsive table-container">
+                <table id="history-task-checkbox-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--compact">
                     <thead>
                         <tr>
                             <th class="checkbox-column"><input type="checkbox" id="select-all-history"></th>

--- a/PESystem/Areas/Scrap/Views/Function/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function/Index.cshtml
@@ -1,222 +1,200 @@
-﻿﻿@{
+@{
     ViewData["Title"] = "Scrap Area";
 }
 @{
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
 
-<div class="row">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="INPUT_SN">INPUT SN</option>
-                <option value="CREATE_TASK_FORM">CREATE TASK FORM</option>
-                <option value="CREATE_TASK_FORM_SN">CREATE TASK FORM BY SN</option>
-                <option value="UPDATE_DATA">UPDATE DATA</option>
-                <option value="HISTORY_APPLY">HISTORY APPLY</option>
-            </select>
-        </form>
+<div class="scrap-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">SN - SPE Approved</h1>
+        <p>Quản lý danh sách SN đã được SPE phê duyệt với giao diện trực quan và đồng nhất theo màu xanh NVIDIA.</p>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row align-items-end">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-input" class="form-control" rows="10" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-lg-4">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Chức năng</h2>
+                    <span class="badge-nvidia">Workflow</span>
                 </div>
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <input type="text" id="description-input" name="description" class="form-control" placeholder="Tiêu đề mail khách hàng approved">
-                    </div>
-                    <div class="mb-2">
-                        <input type="text" id="NVmember-input" name="po" class="form-control" placeholder="Nhập tên khách hàng approved">
-                    </div>
-                    <div class="mb-2">
-                        <select id="Scrap-options" class="form-select">
-                            <option selected disabled>Select type scrap</option>
-                            <option value="0">SPE approve to scrap</option>
-                            <option value="1">Scrap to quarterly</option>
-                            <option value="2">Approved to engineer sample</option>
-                            <option value="3">Approved to master board</option>
-                            <option value="4">Approved to BGA</option>
+                <div class="nvidia-card-body">
+                    <form id="search-form" class="d-flex flex-column gap-3">
+                        <label for="search-options" class="form-label">Chọn chức năng thao tác</label>
+                        <select id="search-options" class="form-select">
+                            <option selected disabled>SELECT FUNCTION</option>
+                            <option value="INPUT_SN">INPUT SN</option>
+                            <option value="CREATE_TASK_FORM">CREATE TASK FORM</option>
+                            <option value="CREATE_TASK_FORM_SN">CREATE TASK FORM BY SN</option>
+                            <option value="UPDATE_DATA">UPDATE DATA</option>
                         </select>
-                    </div>
-                    <div class="mb-2">
-                        <label for="speApproveTime-input" class="form-label">Thời gian khách hàng approve</label>
-                        <input type="date" id="speApproveTime-input" name="speApproveTime" class="form-control" />
-                    </div>
-                    <div class="mb-2">
-                        <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                    </div>
+                    </form>
                 </div>
             </div>
-        </form>
+        </div>
 
-        <!-- Form create task -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="CREATE_TASK_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="create-task-btn" class="btn btn-ne" type="button">Create task</button>
-                </div>
-            </div>
-        </form>
-
-        <!-- Form create task by SN -->
-        <form id="custom-form-sn" method="post" class="hidden" data-search-type="CREATE_TASK_FORM_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-4">
-                    <textarea name="SN box" id="create-task-btn-sn-box" class="form-control" rows="5" placeholder="Nhập SN"></textarea>
-                </div>
-                <div class="col-md-2">
-                    <button id="create-task-btn-sn" class="btn btn-ne" type="button">Create task</button>
-                </div>
-            </div>
-        </form>
-
-        <!-- Form update data -->
-        <form id="update-data-form" method="post" class="hidden" data-search-type="UPDATE_DATA">
-            <div class="row">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-input-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
-                </div>
-
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="task-input" class="form-label">Task</label>
-                        <input type="text" id="task-input" name="task" class="form-control" placeholder="Nhập Task">
+        <div class="col-lg-8">
+            <div class="d-flex flex-column gap-4">
+                <form id="input-sn-form" method="post" class="hidden scrap-card" data-search-type="INPUT_SN">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Nhập Serial Number</h3>
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-md-5">
+                            <label for="sn-input" class="form-label">Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input" class="form-control" rows="10" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-md-7">
+                            <div class="row g-3">
+                                <div class="col-12">
+                                    <label for="description-input" class="form-label">Tiêu đề email khách hàng</label>
+                                    <input type="text" id="description-input" name="description" class="form-control" placeholder="Tiêu đề mail khách hàng approved">
+                                </div>
+                                <div class="col-12">
+                                    <label for="NVmember-input" class="form-label">Tên khách hàng phê duyệt</label>
+                                    <input type="text" id="NVmember-input" name="po" class="form-control" placeholder="Nhập tên khách hàng approved">
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="Scrap-options" class="form-label">Loại phế</label>
+                                    <select id="Scrap-options" class="form-select">
+                                        <option selected disabled>Select type scrap</option>
+                                        <option value="0">SPE approve to scrap</option>
+                                        <option value="1">Scrap to quarterly</option>
+                                        <option value="2">Approved to engineer sample</option>
+                                        <option value="3">Approved to master board</option>
+                                        <option value="4">Approved to BGA</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="speApproveTime-input" class="form-label">Thời gian khách hàng approve</label>
+                                    <input type="date" id="speApproveTime-input" name="speApproveTime" class="form-control" />
+                                </div>
+                                <div class="col-12 d-flex justify-content-end">
+                                    <button id="input-sn-btn" class="btn btn-ne" type="button">Input SN</button>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <div class="mb-2">
-                        <label for="po-input" class="form-label">PO</label>
-                        <input type="text" id="po-input" name="po" class="form-control" placeholder="Nhập PO">
-                    </div>
-                    <button id="update-task-btn" class="btn btn-ne mt-1" type="button">Update</button>
-                </div>
+                </form>
 
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="cost-input" class="form-label">Cost</label>
-                        <input type="text" id="cost-input" name="cost" class="form-control" placeholder="Nhập Cost">
+                <form id="custom-form" method="post" class="hidden scrap-card" data-search-type="CREATE_TASK_FORM">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Tạo task</h3>
+                    <div class="d-flex justify-content-end">
+                        <button id="create-task-btn" class="btn btn-ne" type="button">Create task</button>
                     </div>
-                    <div class="mb-2">
-                        <label for="file-input" class="form-label">Upload Excel File (Board SN & Cost)</label>
-                        <input type="file" id="file-input" name="file" class="form-control" accept=".xlsx, .xls">
-                    </div>
-                    <button id="update-cost-btn" class="btn btn-ne mt-1" type="button">Update Cost</button>
-                </div>
-            </div>
-        </form>
+                </form>
 
-        <!-- Form history apply -->
-        <form id="history-apply-form" method="post" class="hidden" data-search-type="HISTORY_APPLY_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="create-history-task-btn" class="btn btn-ne" type="button">Data</button>
-                </div>
+                <form id="custom-form-sn" method="post" class="hidden scrap-card" data-search-type="CREATE_TASK_FORM_SN">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Tạo task theo SN</h3>
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-lg-8">
+                            <label for="create-task-btn-sn-box" class="form-label">Danh sách SN</label>
+                            <textarea name="SN box" id="create-task-btn-sn-box" class="form-control" rows="6" placeholder="Nhập SN"></textarea>
+                        </div>
+                        <div class="col-lg-4 d-flex align-items-end">
+                            <button id="create-task-btn-sn" class="btn btn-ne w-100" type="button">Create task</button>
+                        </div>
+                    </div>
+                </form>
+
+                <form id="update-data-form" method="post" class="hidden scrap-card" data-search-type="UPDATE_DATA">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Cập nhật dữ liệu</h3>
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label for="sn-input-update" class="form-label">Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-md-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="task-input" class="form-label">Task</label>
+                                <input type="text" id="task-input" name="task" class="form-control" placeholder="Nhập Task">
+                            </div>
+                            <div>
+                                <label for="po-input" class="form-label">PO</label>
+                                <input type="text" id="po-input" name="po" class="form-control" placeholder="Nhập PO">
+                            </div>
+                            <button id="update-task-btn" class="btn btn-ne" type="button">Update</button>
+                        </div>
+                        <div class="col-md-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="cost-input" class="form-label">Cost</label>
+                                <input type="text" id="cost-input" name="cost" class="form-control" placeholder="Nhập Cost">
+                            </div>
+                            <div>
+                                <label for="file-input" class="form-label">Upload Excel File (Board SN & Cost)</label>
+                                <input type="file" id="file-input" name="file" class="form-control" accept=".xlsx, .xls">
+                            </div>
+                            <button id="update-cost-btn" class="btn btn-ne" type="button">Update Cost</button>
+                        </div>
+                    </div>
+                </form>
+
+                <form id="history-apply-form" method="post" class="hidden scrap-card" data-search-type="HISTORY_APPLY_FORM">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Danh sách đã gửi khách hàng</h3>
+                    <div class="d-flex justify-content-end">
+                        <button id="create-history-task-btn" class="btn btn-ne" type="button">Tải dữ liệu</button>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
+    </div>
+
+    <div class="mt-5 d-flex flex-column gap-4">
+        <div id="input-sn-result" class="hidden scrap-card"></div>
+
+        <div id="create-task-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">Danh sách Internal Task</h3>
+            <div class="table-responsive">
+                <table id="task-checkbox-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th class="checkbox-column"><input type="checkbox" id="select-all"></th>
+                            <th>INTERNAL_TASK</th>
+                            <th>DESCRIPTION</th>
+                            <th>NV_APPROVE</th>
+                            <th>KANBAN_STATUS</th>
+                            <th>CATEGORY</th>
+                            <th>TYPE_BP</th>
+                            <th>PURPOSE</th>
+                            <th>CREATE_TIME</th>
+                            <th>CREATE_BY</th>
+                            <th>APPLY_TASK_STATUS</th>
+                            <th>TOTAL_Q'TY</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+
+        <div id="create-task-result-sn" class="hidden scrap-card"></div>
+        <div id="update-data-result" class="hidden scrap-card"></div>
+
+        <div id="history-apply-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">Lịch sử gửi khách hàng</h3>
+            <div class="table-responsive">
+                <table id="history-task-checkbox-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th class="checkbox-column"><input type="checkbox" id="select-all-history"></th>
+                            <th>INTERNAL_TASK</th>
+                            <th>DESCRIPTION</th>
+                            <th>NV_APPROVE</th>
+                            <th>KANBAN_STATUS</th>
+                            <th>CATEGORY</th>
+                            <th>TYPE_BP</th>
+                            <th>CREATE_TIME</th>
+                            <th>CREATE_BY</th>
+                            <th>APPLY_TIME</th>
+                            <th>APPLY_TASK_STATUS</th>
+                            <th>TOTAL_Q'TY</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
-
-<!--hiển thị của chức năng input sn-->
-<div id="input-sn-result" class="hidden"></div>
-
-<!--hiển thị của chức năng create task-->
-<div id="create-task-result" class="hidden">
-    <table id="task-checkbox-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-        <thead>
-            <tr>
-                <th class="checkbox-column"><input type="checkbox" id="select-all"></th>
-                <th>INTERNAL_TASK</th>
-                <th>DESCRIPTION</th>
-                <th>NV_APPROVE</th>
-                <th>KANBAN_STATUS</th>
-                <th>CATEGORY</th>
-                <th>TYPE_BP</th>
-                <th>CREATE_TIME</th>
-                <th>CREATE_BY</th>
-                <th>APPLY_TASK_STATUS</th>
-                <th>TOTAL_Q'TY</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
-
-<!--hiển thị của chức năng create task by sn-->
-<div id="create-task-result-sn" class="hidden"></div>
-
-<!--hiển thị của chức năng update data-->
-<div id="update-data-result" class="hidden"></div>
-
-<!--hiển thị của chức năng update data-->
-<div id="history-apply-result" class="hidden">
-    <table id="history-task-checkbox-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-        <thead>
-            <tr>
-                <th class="checkbox-column"><input type="checkbox" id="select-all-history"></th>
-                <th>INTERNAL_TASK</th>
-                <th>DESCRIPTION</th>
-                <th>NV_APPROVE</th>
-                <th>KANBAN_STATUS</th>
-                <th>CATEGORY</th>
-                <th>TYPE_BP</th>
-                <th>CREATE_TIME</th>
-                <th>CREATE_BY</th>
-                <th>APPLY_TIME</th>
-                <th>APPLY_TASK_STATUS</th>
-                <th>TOTAL_Q'TY</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
-
-
 
 @section Scripts {
-    <!-- Script tùy chỉnh -->
     <script src="~/assets/areas/scrap/js/function.js?v=@DateTime.Now.Ticks"></script>
-    <style>
-        .hidden {
-            display: none !important;
-        }
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 20px!important; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center !important;
-        }
-        /* Giới hạn độ rộng cột */
-        #task-checkbox-table th, #task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            /*max-width: 80px!important;  Giới hạn độ rộng cột */
-        }
-
-        /* Giới hạn độ rộng cột */
-        #history-task-checkbox-table th, #history-task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            /*max-width: 80px!important;  Giới hạn độ rộng cột */
-        }
-        #history-task-checkbox-table td, #task-checkbox-table td{
-            background-color:#fff;
-        }
-
-         /* Thêm hiệu ứng hover cho hàng */
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76b900 !important;
-            /*transition: background-color 0.2s ease;*/
-        }
-
-
-    </style>
 }

--- a/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
@@ -68,7 +68,7 @@
         <div id="sn-wait-approve-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">SN chờ SPE approve</h3>
             <div class="table-responsive">
-                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious" style="width:100%">
+                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious scrap-table--comfortable" style="width:100%">
                     <thead>
                         <tr>
                             <th>SERIAL_NUMBER</th>

--- a/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
@@ -68,7 +68,7 @@
         <div id="sn-wait-approve-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">SN chờ SPE approve</h3>
             <div class="table-responsive">
-                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious" style="width:100%">
                     <thead>
                         <tr>
                             <th>SERIAL_NUMBER</th>

--- a/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
@@ -1,184 +1,90 @@
-﻿﻿﻿@{
+@{
     ViewData["Title"] = "process can't repair";
 }
 @{
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="INPUT_SN_1">INPUT SN</option>
-                <option value="SN_PROCESS_CANT_REPAIR">SN process can't repair'</option>
-            </select>
-        </form>
+
+<div class="scrap-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">Process Can't Repair</h1>
+        <p>Quản lý và theo dõi những serial number không thể sửa chữa với giao diện đồng nhất màu xanh NVIDIA.</p>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-1-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-lg-4">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Chức năng</h2>
+                    <span class="badge-nvidia">Tools</span>
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="description-input" class="form-label">Description</label>
-                        <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
-                    </div>
-                    <!--<div class="mb-2">
-                        <label for="tpye-bp-input" class="form-label">Type Bonepile</label>
-                        <select id="bp-options" class="form-select">
-                            <option selected disabled>SELECT TYPE BONEPILE</option>
-                            <option value="BP-10">BONEPILE 1.0</option>
-                            <option value="BP-20">BONEPILE 2.0</option>
-                            <option value="B36R">AFFTER KANBAN</option>
+                <div class="nvidia-card-body">
+                    <form id="search-form" class="d-flex flex-column gap-3">
+                        <label for="search-options" class="form-label">Chọn chức năng thao tác</label>
+                        <select id="search-options" class="form-select">
+                            <option selected disabled>SELECT FUNCTION</option>
+                            <option value="INPUT_SN_1">INPUT SN</option>
+                            <option value="SN_PROCESS_CANT_REPAIR">SN process can't repair'</option>
                         </select>
-                    </div>-->
-                    <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                </div>
-                <!--<div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="tpye-approve-input" class="form-label">Type approve input</label>
-                        <select id="approve-options" class="form-select">
-                            <option selected disabled>SELECT TYPE APPROVE</option>
-                            <option value="2">Waiting SPE Approve Scrap</option>
-                            <option value="4">Waiting SPE Approve BGA</option>
-                        </select>
-                    </div>
-                </div>-->
-            </div>
-        </form>
-
-        <!-- Form sn wait approve result -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="SN_WAIT_LIST_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
+                    </form>
                 </div>
             </div>
-        </form>
-    </div>
-</div>
-
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng input sn 1-->
-    <div id="input-sn-1-result" class="hidden"></div>
-    <!--hiển thị của chức năng sn đợi SPE approve-->
-    <div id="sn-wait-approve-result" class="hidden">
-        <div class="table-container">
-            <table id="table-sn-wait-approve" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>SERIAL_NUMBER</th>
-                        <th>DESCRIPTION</th>
-                        <th>CREATE_TIME</th>
-                        <th>APPLY_TASK_STATUS</th>
-                        <th>CREATE_BY</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </div>
 
+        <div class="col-lg-8">
+            <div class="d-flex flex-column gap-4">
+                <form id="input-sn-1-form" method="post" class="hidden scrap-card" data-search-type="INPUT_SN">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Nhập Serial Number</h3>
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-md-6">
+                            <label for="sn-input-1" class="form-label">Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-md-6 d-flex flex-column gap-3">
+                            <div>
+                                <label for="description-input-1" class="form-label">Description</label>
+                                <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
+                            </div>
+                            <div class="mt-auto d-flex justify-content-end">
+                                <button id="input-sn-btn" class="btn btn-ne" type="button">Input SN</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+
+                <form id="custom-form" method="post" class="hidden scrap-card" data-search-type="SN_WAIT_LIST_FORM">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Xuất danh sách</h3>
+                    <div class="d-flex justify-content-end">
+                        <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-5 d-flex flex-column gap-4">
+        <div id="input-sn-1-result" class="hidden scrap-card"></div>
+
+        <div id="sn-wait-approve-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">SN chờ SPE approve</h3>
+            <div class="table-responsive">
+                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th>SERIAL_NUMBER</th>
+                            <th>DESCRIPTION</th>
+                            <th>CREATE_TIME</th>
+                            <th>APPLY_TASK_STATUS</th>
+                            <th>CREATE_BY</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(3), td:nth-child(3), /* Cột Create Time */
-            th:nth-child(4), td:nth-child(4) { /* Cột Apply Task Status */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description) */
-            th:nth-child(2), td:nth-child(2) { /* Cột Description */
-                white-space: normal; /* Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
     <script src="~/assets/areas/scrap/js/function0.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function0/Index.cshtml
@@ -67,7 +67,7 @@
 
         <div id="sn-wait-approve-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">SN chờ SPE approve</h3>
-            <div class="table-responsive">
+            <div class="table-responsive table-container scrap-table-container">
                 <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious scrap-table--comfortable" style="width:100%">
                     <thead>
                         <tr>

--- a/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
@@ -87,7 +87,7 @@
         <div id="sn-wait-approve-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">SN đang chờ SPE phê duyệt</h3>
             <div class="table-responsive">
-                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious" style="width:100%">
+                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious scrap-table--comfortable" style="width:100%">
                     <thead>
                         <tr>
                             <th>SERIAL_NUMBER</th>

--- a/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
@@ -87,7 +87,7 @@
         <div id="sn-wait-approve-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">SN đang chờ SPE phê duyệt</h3>
             <div class="table-responsive">
-                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious" style="width:100%">
                     <thead>
                         <tr>
                             <th>SERIAL_NUMBER</th>

--- a/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
@@ -1,185 +1,110 @@
-﻿﻿﻿@{
+@{
     ViewData["Title"] = "Scrap Area";
 }
 @{
     Layout = "~/Areas/Scrap/views/Shared/Layout_scrap.cshtml";
 }
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="INPUT_SN_1">INPUT SN</option>
-                <option value="SN_WAIT_SPE_APPROVE">SN WAIT SPE APPROVE</option>
-            </select>
-        </form>
+
+<div class="scrap-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">SN - Wait SPE Approve</h1>
+        <p>Theo dõi và thao tác nhanh với các serial number đang chờ SPE phê duyệt.</p>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form input SN -->
-        <form id="input-sn-1-form" method="post" class="hidden" data-search-type="INPUT_SN">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-lg-4">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Chức năng</h2>
+                    <span class="badge-nvidia">Approval</span>
                 </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="description-input" class="form-label">Description</label>
-                        <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
-                    </div>
-                    <div class="mb-2">
-                        <label for="tpye-bp-input" class="form-label">Type Bonepile</label>
-                        <select id="bp-options" class="form-select">
-                            <option selected disabled>SELECT TYPE BONEPILE</option>
-                            <option value="BP-10">BONEPILE 1.0</option>
-                            <option value="BP-20">BONEPILE 2.0</option>
-                            <option value="B36R">AFFTER KANBAN</option>
+                <div class="nvidia-card-body">
+                    <form id="search-form" class="d-flex flex-column gap-3">
+                        <label for="search-options" class="form-label">Chọn chức năng thao tác</label>
+                        <select id="search-options" class="form-select">
+                            <option selected disabled>SELECT FUNCTION</option>
+                            <option value="INPUT_SN_1">INPUT SN</option>
+                            <option value="SN_WAIT_SPE_APPROVE">SN WAIT SPE APPROVE</option>
                         </select>
-                    </div>
-                    <button id="input-sn-btn" class="btn btn-ne" type="button">INPUT SN</button>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="tpye-approve-input" class="form-label">Type approve input</label>
-                        <select id="approve-options" class="form-select">
-                            <option selected disabled>SELECT TYPE APPROVE</option>
-                            <option value="2">Waiting SPE Approve Scrap</option>
-                            <option value="4">Waiting SPE Approve BGA</option>
-                        </select>
-                    </div>
+                    </form>
                 </div>
             </div>
-        </form>
-
-        <!-- Form sn wait approve result -->
-        <form id="custom-form" method="post" class="hidden" data-search-type="SN_WAIT_LIST_FORM">
-            <div class="row align-items-end">
-                <div class="col-md-2">
-                    <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
-                </div>
-            </div>
-        </form>
-    </div>
-</div>
-
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng input sn 1-->
-    <div id="input-sn-1-result" class="hidden"></div>
-    <!--hiển thị của chức năng sn đợi SPE approve-->
-    <div id="sn-wait-approve-result" class="hidden">
-        <div class="table-container">
-            <table id="table-sn-wait-approve" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>SERIAL_NUMBER</th>
-                        <th>DESCRIPTION</th>
-                        <th>CREATE_TIME</th>
-                        <th>APPLY_TASK_STATUS</th>
-                        <th>BONEPILE_TYPE</th>
-                        <th>CREATE_BY</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </div>
 
+        <div class="col-lg-8">
+            <div class="d-flex flex-column gap-4">
+                <form id="input-sn-1-form" method="post" class="hidden scrap-card" data-search-type="INPUT_SN">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Nhập Serial Number</h3>
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-md-4">
+                            <label for="sn-input-1" class="form-label">Serial Number</label>
+                            <textarea name="serialNumbers" id="sn-input-1" class="form-control" rows="9" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-md-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="description-input-1" class="form-label">Description</label>
+                                <input type="text" id="description-input-1" name="description" class="form-control" placeholder="Nhập mô tả">
+                            </div>
+                            <div>
+                                <label for="bp-options" class="form-label">Type Bonepile</label>
+                                <select id="bp-options" class="form-select">
+                                    <option selected disabled>SELECT TYPE BONEPILE</option>
+                                    <option value="BP-10">BONEPILE 1.0</option>
+                                    <option value="BP-20">BONEPILE 2.0</option>
+                                    <option value="B36R">AFTER KANBAN</option>
+                                </select>
+                            </div>
+                            <div class="mt-auto d-flex justify-content-end">
+                                <button id="input-sn-btn" class="btn btn-ne" type="button">Input SN</button>
+                            </div>
+                        </div>
+                        <div class="col-md-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="approve-options" class="form-label">Type approve input</label>
+                                <select id="approve-options" class="form-select">
+                                    <option selected disabled>SELECT TYPE APPROVE</option>
+                                    <option value="2">Waiting SPE Approve Scrap</option>
+                                    <option value="4">Waiting SPE Approve BGA</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+
+                <form id="custom-form" method="post" class="hidden scrap-card" data-search-type="SN_WAIT_LIST_FORM">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Xuất danh sách</h3>
+                    <div class="d-flex justify-content-end">
+                        <button id="sn-wait-list-btn" class="btn btn-ne" type="button">Download Excel</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-5 d-flex flex-column gap-4">
+        <div id="input-sn-1-result" class="hidden scrap-card"></div>
+
+        <div id="sn-wait-approve-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">SN đang chờ SPE phê duyệt</h3>
+            <div class="table-responsive">
+                <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th>SERIAL_NUMBER</th>
+                            <th>DESCRIPTION</th>
+                            <th>CREATE_TIME</th>
+                            <th>APPLY_TASK_STATUS</th>
+                            <th>BONEPILE_TYPE</th>
+                            <th>CREATE_BY</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(3), td:nth-child(3), /* Cột Create Time */
-            th:nth-child(4), td:nth-child(4) { /* Cột Apply Task Status */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description) */
-            th:nth-child(2), td:nth-child(2) { /* Cột Description */
-                white-space: normal; /* Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
     <script src="~/assets/areas/scrap/js/function1.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Function1/Index.cshtml
@@ -86,7 +86,7 @@
 
         <div id="sn-wait-approve-result" class="hidden scrap-card">
             <h3 class="h5 mb-3 text-uppercase fw-semibold">SN đang chờ SPE phê duyệt</h3>
-            <div class="table-responsive">
+            <div class="table-responsive table-container scrap-table-container">
                 <table id="table-sn-wait-approve" class="mt-2 table table-hover table-striped datatable-table nvidia-table nvidia-table--spacious scrap-table--comfortable" style="width:100%">
                     <thead>
                         <tr>

--- a/PESystem/Areas/Scrap/Views/MRB/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/MRB/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Chuyển kho MRB";
 }
 @{
@@ -8,157 +8,137 @@
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
 
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-3">
-        <form id="search-form" class="form-inline">
-            <select id="search-mrb-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="5">Chờ RE chuyển MRB</option>
-                <option value="6">Chờ kho MRB xác nhận</option>
-                <option value="7">Đã vào kho MRB</option>
-            </select>
-        </form>
+<div class="scrap-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">Quản lý chuyển kho MRB</h1>
+        <p>Theo dõi trạng thái chuyển kho MRB với các bước rõ ràng và trực quan.</p>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-9">
-        <!-- Form Chờ RE chuyển MRB -->
-        <form id="wait-re-move-mrb" method="post" class="hidden" data-search-type="wait-re-move-mrb">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    @{
-                        var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
-                        .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-                        var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
-                    }
-                    @if (Scrap)
-                    {
-                        <button id="move-mrb-btn" class="btn btn-ne" type="button">Move MRB</button>
-                    }else
-                    {
-                        <button id="move-mrb-btn" class="btn btn-ne hidden" type="button">Move MRB</button>
-                    }
+    <div class="row g-4 align-items-stretch">
+        <div class="col-lg-4">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Chức năng</h2>
+                    <span class="badge-nvidia">MRB Flow</span>
+                </div>
+                <div class="nvidia-card-body">
+                    <form id="search-form" class="d-flex flex-column gap-3">
+                        <label for="search-mrb-options" class="form-label">Chọn giai đoạn xử lý</label>
+                        <select id="search-mrb-options" class="form-select">
+                            <option selected disabled>SELECT FUNCTION</option>
+                            <option value="5">Chờ RE chuyển MRB</option>
+                            <option value="6">Chờ kho MRB xác nhận</option>
+                            <option value="7">Đã vào kho MRB</option>
+                        </select>
+                    </form>
                 </div>
             </div>
-        </form>
+        </div>
 
-        <!-- Form Chờ kho MRB xác nhận -->
-        <form id="wait-mrb-confirm" method="post" class="hidden" data-search-type="wait-mrb-confirm">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    
-                    @{
-                        var allowedAreas1 = HttpContextAccessor.HttpContext.User.Claims
-                        .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-                        var Mrb = allowedAreas1 != null && allowedAreas1.Any(area => area.Trim() == "Mrb");
-                    }
-                    @if (Mrb)
-                    {
-                        <button id="confirm-mrb-btn" class="btn btn-ne" type="button">Confirm</button>
-                    }else
-                    {
-                        <button id="confirm-mrb-btn" class="btn btn-ne hidden" type="button">Confirm</button>
-                    }
-                </div>
+        <div class="col-lg-8">
+            <div class="d-flex flex-column gap-4">
+                <form id="wait-re-move-mrb" method="post" class="hidden scrap-card" data-search-type="wait-re-move-mrb">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Chờ RE chuyển MRB</h3>
+                    <div class="d-flex justify-content-end">
+                        @{
+                            var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
+                                .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                            var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
+                        }
+                        @if (Scrap)
+                        {
+                            <button id="move-mrb-btn" class="btn btn-ne" type="button">Move MRB</button>
+                        }
+                        else
+                        {
+                            <button id="move-mrb-btn" class="btn btn-ne hidden" type="button">Move MRB</button>
+                        }
+                    </div>
+                </form>
+
+                <form id="wait-mrb-confirm" method="post" class="hidden scrap-card" data-search-type="wait-mrb-confirm">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Chờ kho MRB xác nhận</h3>
+                    <div class="d-flex justify-content-end">
+                        @{
+                            var allowedAreas1 = HttpContextAccessor.HttpContext.User.Claims
+                                .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
+                            var Mrb = allowedAreas1 != null && allowedAreas1.Any(area => area.Trim() == "Mrb");
+                        }
+                        @if (Mrb)
+                        {
+                            <button id="confirm-mrb-btn" class="btn btn-ne" type="button">Confirm</button>
+                        }
+                        else
+                        {
+                            <button id="confirm-mrb-btn" class="btn btn-ne hidden" type="button">Confirm</button>
+                        }
+                    </div>
+                </form>
+
+                <form id="moved-mrb-form" method="post" class="hidden scrap-card" data-search-type="moved-mrb">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Đã vào kho MRB</h3>
+                    <div class="d-flex justify-content-end">
+                        <button id="moved-mrb-btn" class="btn btn-ne" type="button">Load data</button>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
+    </div>
 
-        <!-- Form Đã vào kho MRB -->
-        <form id="moved-mrb-form" method="post" class="hidden" data-search-type="moved-mrb">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <button id="moved-mrb-btn" class="btn btn-ne" type="button">Load data</button>
-                </div>
+    <div class="mt-5 d-flex flex-column gap-4">
+        <div id="wait-re-move-mrb-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">Danh sách chờ RE chuyển MRB</h3>
+            <div class="table-responsive">
+                <table id="wait-re-move-mrb-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th class="checkbox-column"><input type="checkbox" id="select-all-5"></th>
+                            <th>Task Number</th>
+                            <th>Apply Time</th>
+                            <th>Total Qty</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
             </div>
-        </form>
-    </div>
-</div>
+        </div>
 
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng Chờ RE chuyển MRB-->
-    <div id="wait-re-move-mrb-result" class="hidden">
-        <table id="wait-re-move-mrb-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-5"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
-    <!--hiển thị của chức năng Chờ kho MRB xác nhận-->
-    <div id="wait-mrb-confirm-result" class="hidden">
-        <table id="wait-mrb-confirm-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-6"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
-    <!--hiển thị của chức năng Đã vào kho MRB-->
-    <div id="moved-mrb-form-result" class="hidden">
-        <table id="moved-mrb-form-table" class="mt-2 table table-bordered table-striped datatable-table" style="width:100%">
-            <thead>
-                <tr>
-                    <th class="checkbox-column"><input type="checkbox" id="select-all-7"></th>
-                    <th>Task Number</th>
-                    <th>Apply Time</th>
-                    <th>Total Qty</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+        <div id="wait-mrb-confirm-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">Danh sách chờ kho MRB xác nhận</h3>
+            <div class="table-responsive">
+                <table id="wait-mrb-confirm-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th class="checkbox-column"><input type="checkbox" id="select-all-6"></th>
+                            <th>Task Number</th>
+                            <th>Apply Time</th>
+                            <th>Total Qty</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+
+        <div id="moved-mrb-form-result" class="hidden scrap-card">
+            <h3 class="h5 mb-3 text-uppercase fw-semibold">Đã vào kho MRB</h3>
+            <div class="table-responsive">
+                <table id="moved-mrb-form-table" class="mt-2 table table-hover table-striped datatable-table nvidia-table" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th class="checkbox-column"><input type="checkbox" id="select-all-7"></th>
+                            <th>Task Number</th>
+                            <th>Apply Time</th>
+                            <th>Total Qty</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important; /* Đảm bảo ẩn hoàn toàn */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 20px!important; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center !important;
-        }
-        /* Giới hạn độ rộng cột */
-        #task-checkbox-table th, #task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            max-width: 80px!important; /* Giới hạn độ rộng cột */
-        }
-
-        /* Giới hạn độ rộng cột */
-        #history-task-checkbox-table th, #history-task-checkbox-table td {
-            white-space: nowrap; /* Ngăn xuống dòng */
-            overflow: hidden;
-            text-align: center;
-            text-overflow: ellipsis; /* Hiển thị dấu "..." nếu nội dung quá dài */
-            max-width: 80px!important; /* Giới hạn độ rộng cột */
-        }
-        #history-task-checkbox-table td, #task-checkbox-table td{
-            background-color:#fff;
-        }
-
-         /* Thêm hiệu ứng hover cho hàng */
-        .datatable-table tbody tr:hover td,
-        .datatable-table tbody tr:hover th {
-            background-color: #76b900 !important;
-            /*transition: background-color 0.2s ease;*/
-        }
-    </style>
     <script src="~/assets/areas/scrap/js/mrb.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
+++ b/PESystem/Areas/Scrap/Views/Progress/Index.cshtml
@@ -1,4 +1,4 @@
-﻿﻿@{
+@{
     ViewData["Title"] = "Scrap Area";
 }
 @{
@@ -8,232 +8,110 @@
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
 
-<div class="row mb-3">
-    <!-- Cột chọn loại chức năng -->
-    <div class="col-md-2">
-        <form id="search-form" class="form-inline">
-            <select id="search-options" class="form-select">
-                <option selected disabled>SELECT FUNCTION</option>
-                <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
-                <!--<option value="UPDATE_STATUS">UPDATE STATUS</option>-->
-                <option value="SEARCH_STATUS">Tìm kiếm</option>
-                <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
-            </select>
-        </form>
+<div class="scrap-interface nvidia-section">
+    <div class="section-heading text-center text-lg-start">
+        <h1 class="display-6">Tra cứu tiến độ Scrap</h1>
+        <p>Tổng hợp các chức năng kiểm tra trạng thái, lịch sử và tồn kho scrap trong giao diện đồng bộ.</p>
     </div>
 
-    <!-- function area-->
-    <div class="col-md-10">
-
-        <!-- Form Checking scrap quaterly -->
-        <form id="task-stock-status-form" method="post" class="hidden" data-search-type="TASK_STOCK_STATUS_FORM">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-2">
-                    <button id="task-stock-status-btn" class="btn btn-ne" type="button">Detail</button>
+    <div class="row g-4 align-items-stretch">
+        <div class="col-lg-3">
+            <div class="nvidia-card h-100">
+                <div class="nvidia-card-header">
+                    <h2>Chức năng</h2>
+                    <span class="badge-nvidia">Tracking</span>
                 </div>
-            </div>
-        </form>
-
-        <!-- Form UPDATE STATUS 
-        <form id="update-status-form" method="post" class="hidden" data-search-type="UPDATE_STATUS">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-4">
-                    <textarea name="serialNumbers" id="sn-status-update" class="form-control" rows="8" placeholder="Nhập Serial Number (mỗi dòng 1 SN)"></textarea>
-                </div>
-                <div class="col-md-4">
-                    <div class="mb-2">
-                        <label for="status-input" class="form-label">Update trạng thái</label>
-                        <select id="status-options" class="form-select">
-                            <option selected disabled>SELECT STATUS</option>
-                            <option value="1">Đã tìm thấy bản</option>
-                            <option value="2">Đã chuyển kho phế</option>
+                <div class="nvidia-card-body">
+                    <form id="search-form" class="d-flex flex-column gap-3">
+                        <label for="search-options" class="form-label">Chọn chức năng cần sử dụng</label>
+                        <select id="search-options" class="form-select">
+                            <option selected disabled>SELECT FUNCTION</option>
+                            <option value="TASK_STOCK_STATUS">Checking scrap quaterly</option>
+                            <option value="SEARCH_STATUS">Tìm kiếm</option>
+                            <option value="SEARCH_HISTORY">Tra lịch sử SN</option>
                         </select>
-                    </div>
-                    
-
-                    <div>
-                        @{
-                            var allowedAreas = HttpContextAccessor.HttpContext.User.Claims
-                            .FirstOrDefault(c => c.Type == "AllowedAreas")?.Value.Split(',');
-
-                            var Scrap = allowedAreas != null && allowedAreas.Any(area => area.Trim() == "Scrap");
-                            
-                        }
-                        @if (Scrap)
-                        {
-                            <button id="update-status-btn" class="md-2 btn btn-ne" type="button">Update</button>
-                        }else
-                        {
-                            <button id="update-status-btn" class="md-2 btn btn-ne hidden" type="button">Update</button>
-                        }
-                    </div>
+                    </form>
                 </div>
             </div>
-        </form>-->
+        </div>
 
-        <!-- Form SEARCH STATUS -->
-        <form id="search-status-form" method="post" class="hidden" data-search-type="SEARCH_STATUS">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="SN/TASK" id="search-status-update" class="form-control" rows="8" placeholder="Nhập SN/Internal Task"></textarea>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label for="SNTASK-input" class="form-label">Tìm kiếm trạng thái</label>
-                        <select id="search-status-options" class="form-select">
-                            <option selected disabled>SELECT STATUS</option>
-                            <option value="1">Tìm kiếm theo SN</option>
-                            <option value="2">Tìm kiếm theo Internal Task</option>
-                            <option value="3">Tìm kiếm theo Task NV</option>
-                        </select>
+        <div class="col-lg-9">
+            <div class="d-flex flex-column gap-4">
+                <form id="task-stock-status-form" method="post" class="hidden scrap-card" data-search-type="TASK_STOCK_STATUS_FORM">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Checking scrap quaterly</h3>
+                    <div class="d-flex justify-content-end">
+                        <button id="task-stock-status-btn" class="btn btn-ne" type="button">Detail</button>
                     </div>
-                    <button id="search-status-btn" class="md-2 btn btn-ne" type="button">Search</button>
-                    <button id="load-status-btn" class="md-2 btn btn-ne" type="button">Load List</button>
-                </div>
-                <div class="col-md-2">
-                    <div>ApplyTaskStatus</div>
-                    <div>0. Phế, chưa gửi xin task</div>
-                    <div>1. Phế, đã gửi xin task nhưng chưa có</div>
-                    <div>2. Chờ SPE approved phế</div>
-                    <div>3. Đã approved thay BGA</div>
-                    
-                </div>
-                <div class="col-md-2">
-                    <div>4. Chờ approved thay BGA</div>
-                    <div>5. Đã có task, chờ chuyển kho phế</div>
-                    <div>6. Đã chuyển kho phế chờ MRB xác nhận</div>
-                    <div>7. MRB đã nhận bản phế</div>
-                    <div>8. Lỗi process, không thể sửa chữa</div>
-                </div>
-            </div>
-        </form>
+                </form>
 
-        <!-- Form SEARCH HISTORY -->
-        <form id="search-history-form" method="post" class="hidden" data-search-type="SEARCH_HISTORY">
-            <div class="row" style="display: flex; align-items:flex-start; gap: 10px;">
-                <div class="col-md-3">
-                    <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
-                </div>
-                <div class="col-md-3">
-                    <div class="mb-2">
-                        <label class="form-label">Tra cứu lịch sử SN</label>
-                        <p class="form-text">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</p>
+                <form id="search-status-form" method="post" class="hidden scrap-card" data-search-type="SEARCH_STATUS">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Tìm kiếm trạng thái</h3>
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-md-4">
+                            <label for="search-status-update" class="form-label">Danh sách SN/Internal Task</label>
+                            <textarea name="SN/TASK" id="search-status-update" class="form-control" rows="8" placeholder="Nhập SN/Internal Task"></textarea>
+                        </div>
+                        <div class="col-md-4 d-flex flex-column gap-3">
+                            <div>
+                                <label for="search-status-options" class="form-label">Tùy chọn tìm kiếm</label>
+                                <select id="search-status-options" class="form-select">
+                                    <option selected disabled>SELECT STATUS</option>
+                                    <option value="1">Tìm kiếm theo SN</option>
+                                    <option value="2">Tìm kiếm theo Internal Task</option>
+                                    <option value="3">Tìm kiếm theo Task NV</option>
+                                </select>
+                            </div>
+                            <div class="d-flex flex-column flex-md-row gap-2">
+                                <button id="search-status-btn" class="btn btn-ne" type="button">Search</button>
+                                <button id="load-status-btn" class="btn btn-ne" type="button">Load List</button>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="allpart-card p-3 h-100">
+                                <h4 class="h6 text-uppercase fw-semibold mb-3">Mã trạng thái</h4>
+                                <ul class="list-unstyled mb-0 small">
+                                    <li><strong>0</strong> - Phế, chưa gửi xin task</li>
+                                    <li><strong>1</strong> - Phế, đã gửi xin task nhưng chưa có</li>
+                                    <li><strong>2</strong> - Chờ SPE approved phế</li>
+                                    <li><strong>3</strong> - Đã approved thay BGA</li>
+                                    <li><strong>4</strong> - Chờ approved thay BGA</li>
+                                    <li><strong>5</strong> - Đã có task, chờ chuyển kho phế</li>
+                                    <li><strong>6</strong> - Đã chuyển kho phế chờ MRB xác nhận</li>
+                                    <li><strong>7</strong> - MRB đã nhận bản phế</li>
+                                    <li><strong>8</strong> - Lỗi process, không thể sửa chữa</li>
+                                </ul>
+                            </div>
+                        </div>
                     </div>
-                    <button id="history-search-btn" class="md-2 btn btn-ne" type="button">Search history</button>
-                    <button id="history-download-btn" class="md-2 btn btn-ne" type="button">Download Excel</button>
-                </div>
+                </form>
+
+                <form id="search-history-form" method="post" class="hidden scrap-card" data-search-type="SEARCH_HISTORY">
+                    <h3 class="h5 mb-3 text-uppercase fw-semibold">Tra cứu lịch sử SN</h3>
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-md-6">
+                            <label for="history-search-update" class="form-label">Danh sách SN</label>
+                            <textarea name="SN" id="history-search-update" class="form-control" rows="8" placeholder="Nhập SN cần tra lịch sử (mỗi dòng 1 SN)"></textarea>
+                        </div>
+                        <div class="col-md-6 d-flex flex-column gap-3">
+                            <p class="text-muted small">Nhập danh sách SN để xem lịch sử thay đổi từ HistoryScrapList.</p>
+                            <div class="d-flex flex-column flex-md-row gap-2 mt-auto">
+                                <button id="history-search-btn" class="btn btn-ne" type="button">Search history</button>
+                                <button id="history-download-btn" class="btn btn-ne" type="button">Download Excel</button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
     </div>
-</div>
 
-<!--khu vực hiển thị chi tiết-->
-<div class="row mb-3">
-    <!--hiển thị của chức năng create task-->
-    <div id="task-stock-status-result" class="hidden"></div>
-    <!--hiển thị của chức năng update data
-    <div id="update-status-result" class="hidden"></div>-->
-    <!--hiển thị của chức năng search data-->
-    <div id="search-status-result" class="hidden"></div>
-    <!--hiển thị của chức năng history search-->
-    <div id="history-search-result" class="hidden"></div>
+    <div class="mt-5 d-flex flex-column gap-4">
+        <div id="task-stock-status-result" class="hidden scrap-card"></div>
+        <div id="search-status-result" class="hidden scrap-card"></div>
+        <div id="history-search-result" class="hidden scrap-card"></div>
+    </div>
 </div>
 
 @section Scripts {
-    <style>
-        .hidden {
-            display: none !important;
-        }
-
-        /* Container cho bảng để hỗ trợ cuộn ngang */
-        .table-container {
-            max-width: 100%;
-            overflow-x: auto;
-            margin-top: 10px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 14px; /* Tăng kích thước chữ để dễ đọc */
-            table-layout: auto; /* Để các cột tự điều chỉnh theo nội dung */
-        }
-
-        th, td {
-            padding: 10px 12px; /* Tăng padding để thoáng hơn */
-            text-align: left;
-            border: 1px solid #ddd; /* Viền rõ ràng hơn */
-            white-space: nowrap; /* Ngăn nội dung xuống dòng */
-        }
-
-        th {
-            background-color: #28a715; /* Màu xanh lá cây giống nút "Create task" (Bootstrap success) */
-            color: white; /* Chữ trắng để dễ đọc */
-            font-weight: bold;
-            position: sticky; /* Giữ tiêu đề cố định khi cuộn */
-            top: 0;
-            z-index: 1;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.9); /* Nền trắng với độ mờ nhẹ */
-        }
-
-            /* Căn chỉnh cụ thể cho một số cột */
-            th:nth-child(1), td:nth-child(1) { /* Cột checkbox */
-                width: 40px; /* Chiều rộng cố định cho cột checkbox */
-                text-align: center;
-            }
-
-            th:nth-child(9), td:nth-child(9), /* Cột Cost */
-            th:nth-child(13), td:nth-child(13), /* Cột Create Time */
-            th:nth-child(14), td:nth-child(14) { /* Cột Apply Time */
-                text-align: center; /* Căn giữa */
-            }
-
-            /* Cột có nội dung dài (Description, Remark) */
-            th:nth-child(1), td:nth-child(1), /* Cột internal task */
-            th:nth-child(2), td:nth-child(2), /* Cột internal task */
-            th:nth-child(3), td:nth-child(3), /* Cột Description */
-            th:nth-child(10), td:nth-child(10) { /* Cột Remark */
-                /*white-space: normal; * Cho phép xuống dòng */
-                max-width: 300px; /* Giới hạn chiều rộng tối đa */
-                word-wrap: break-word; /* Đảm bảo xuống dòng đúng */
-            }
-
-        /* Hiệu ứng hover để dễ theo dõi dòng */
-        tr:hover td {
-            background-color: rgba(200, 200, 200, 0.2); /* Nền xám nhạt khi hover */
-        }
-
-        /* Định dạng checkbox */
-        .checkbox-column {
-            width: 40px; /* Đảm bảo cột checkbox không quá hẹp */
-            text-align: center;
-        }
-
-        /* Đảm bảo bảng không vượt quá container */
-        table {
-            min-width: 1200px; /* Đảm bảo bảng có chiều rộng tối thiểu để không bị co lại quá mức */
-        }
-
-        .pagination {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-            .pagination button {
-                margin: 0 5px;
-                padding: 5px 10px;
-                font-size: 14px;
-            }
-
-            .pagination span {
-                font-size: 14px;
-                color: #333;
-            }
-    </style>
     <script src="~/assets/areas/scrap/js/progress.js?v=@DateTime.Now.Ticks"></script>
 }

--- a/PESystem/Areas/Scrap/Views/Shared/Layout_scrap.cshtml
+++ b/PESystem/Areas/Scrap/Views/Shared/Layout_scrap.cshtml
@@ -7,6 +7,7 @@
     <title>Scrap</title>
     <link rel="icon" href="~/assets/img/scrap.png" type="image/png">
     <link rel="stylesheet" href="~/css/site.css?v=@DateTime.Now.Ticks" asp-append-version="true" />
+    <link rel="stylesheet" href="~/assets/css/nvidia-theme.css" />
     <link href="~/lib/all-fa-icon/css/all.min.css" rel="stylesheet" />
     <link href="~/lib/datatable/style.css" rel="stylesheet" />
     <link href="~/lib/datatable/jquery.datatables.min.css" rel="stylesheet" />

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
@@ -1,5 +1,26 @@
-﻿let selectedInternalTasks = new Set(); // Cho CREATE_TASK_FORM
+let selectedInternalTasks = new Set(); // Cho CREATE_TASK_FORM
 let selectedHistoryInternalTasks = new Set(); // Cho HISTORY_APPLY
+
+function formatPurpose(purpose) {
+    if (purpose === null || purpose === undefined) {
+        return "N/A";
+    }
+
+    const normalized = String(purpose).trim();
+    if (!normalized) {
+        return "N/A";
+    }
+
+    const purposeMap = {
+        "0": "SPE approve to scrap",
+        "1": "Scrap to quarterly",
+        "2": "Approved to engineer sample",
+        "3": "Approved to master board",
+        "4": "Approved to BGA"
+    };
+
+    return purposeMap[normalized] ?? normalized;
+}
 
 // Hàm ẩn tất cả form và khu vực kết quả
 function hideAllElements() {
@@ -197,6 +218,17 @@ function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
 
     data.forEach(item => {
         const isChecked = currentSelectedSet.has(item.internalTask) ? 'checked' : '';
+        const isHistory = checkboxName === "history-task-checkbox";
+        const purposeText = formatPurpose(item.purpose);
+        const timelineValue = isHistory ? (item.applyTime || "N/A") : (item.applyTaskStatus || "N/A");
+        const statusOrQty = isHistory ? (item.applyTaskStatus || "N/A") : (item.totalQty || "N/A");
+        const purposeColumn = isHistory
+            ? ""
+            : `<td data-bs-toggle="tooltip" data-bs-title="${purposeText}">${purposeText}</td>`;
+        const extraQtyColumn = isHistory
+            ? `<td data-bs-toggle="tooltip" data-bs-title="${item.totalQty || 'N/A'}">${item.totalQty || "N/A"}</td>`
+            : "";
+
         const row = `
             <tr>
                 <td class="checkbox-column"><input type="checkbox" name="${checkboxName}" value="${item.internalTask}" ${isChecked}></td>
@@ -206,11 +238,12 @@ function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
                 <td data-bs-toggle="tooltip" data-bs-title="${item.kanBanStatus || 'N/A'}">${item.kanBanStatus || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.category || 'N/A'}">${item.category || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.remark || 'N/A'}">${item.remark || "N/A"}</td>
+                ${purposeColumn}
                 <td data-bs-toggle="tooltip" data-bs-title="${item.createTime || 'N/A'}">${item.createTime || "N/A"}</td>
                 <td data-bs-toggle="tooltip" data-bs-title="${item.createBy || 'N/A'}">${item.createBy || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${checkboxName === 'history-task-checkbox' ? (item.applyTime || 'N/A') : (item.applyTaskStatus || 'N/A')}">${checkboxName === "history-task-checkbox" ? (item.applyTime || "N/A") : (item.applyTaskStatus || "N/A")}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${checkboxName === 'history-task-checkbox' ? (item.applyTaskStatus || 'N/A') : (item.totalQty || 'N/A')}">${checkboxName === "history-task-checkbox" ? (item.applyTaskStatus || "N/A") : (item.totalQty || "N/A")}</td>
-                ${checkboxName === "history-task-checkbox" ? `<td data-bs-toggle="tooltip" data-bs-title="${item.totalQty || 'N/A'}">${item.totalQty || "N/A"}</td>` : ""}
+                <td data-bs-toggle="tooltip" data-bs-title="${timelineValue}">${timelineValue}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${statusOrQty}">${statusOrQty}</td>
+                ${extraQtyColumn}
             </tr>
         `;
         tableBody.insertAdjacentHTML('beforeend', row);

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/Function.js
@@ -1,6 +1,15 @@
 let selectedInternalTasks = new Set(); // Cho CREATE_TASK_FORM
 let selectedHistoryInternalTasks = new Set(); // Cho HISTORY_APPLY
 
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
 function formatPurpose(purpose) {
     if (purpose === null || purpose === undefined) {
         return "N/A";
@@ -61,11 +70,17 @@ function exportToExcel(data, filename) {
 }
 
 // Xử lý tạo task
-async function processCreateTask(internalTasks, saveApplyStatus, resultDivId) {
+async function processCreateTask(internalTasks, resultDivId) {
     const resultDiv = document.getElementById(resultDivId);
-    resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`;
+    let statusContainer = resultDiv.querySelector('.action-feedback');
+    if (!statusContainer) {
+        statusContainer = document.createElement('div');
+        statusContainer.className = 'action-feedback mb-2';
+        resultDiv.prepend(statusContainer);
+    }
+    statusContainer.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`;
 
-    const requestData = { internalTasks, saveApplyStatus };
+    const requestData = { internalTasks };
 
     try {
         const response = await fetch("http://10.220.130.119:9090/api/Scrap/create-task", {
@@ -76,7 +91,13 @@ async function processCreateTask(internalTasks, saveApplyStatus, resultDivId) {
 
         const result = await response.json();
         if (response.ok) {
-            const excelData = result.data.map(item => ({
+            const payload = Array.isArray(result.data) ? result.data : [];
+            if (!payload.length) {
+                statusContainer.innerHTML = `<div class="alert alert-warning"><strong>Thông báo:</strong> Không có dữ liệu để tải xuống.</div>`;
+                return;
+            }
+
+            const excelData = payload.map(item => ({
                 InternalTask: item.internalTask ?? "N/A", 
                 Item: item.item ?? "N/A",
                 Project: item.project ?? "N/A",
@@ -125,22 +146,33 @@ async function processCreateTask(internalTasks, saveApplyStatus, resultDivId) {
 
             // Write the workbook to file
             XLSX.writeFile(workbook, filename);
-            setTimeout(() => location.reload(), 1000);
+
+            const successMessage = result.message
+                ? `<div class="alert alert-warning">${escapeHtml(result.message)}</div>`
+                : `<div class="alert alert-success"><strong>Thành công:</strong> Dữ liệu đã được tải xuống.</div>`;
+
+            statusContainer.innerHTML = successMessage;
         } else {
-            resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
+            statusContainer.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
         }
     } catch (error) {
-        resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
+        statusContainer.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
         console.error("Error:", error);
     }
 }
 
 // Xử lý tạo task bằng SN
-async function processCreateTaskBySN(sNs, saveApplyStatus, resultDivId) {
+async function processCreateTaskBySN(sNs, resultDivId) {
     const resultDiv = document.getElementById(resultDivId);
-    resultDiv.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`;
+    let statusContainer = resultDiv.querySelector('.action-feedback');
+    if (!statusContainer) {
+        statusContainer = document.createElement('div');
+        statusContainer.className = 'action-feedback mb-2';
+        resultDiv.prepend(statusContainer);
+    }
+    statusContainer.innerHTML = `<div class="alert alert-info"><strong>Thông báo:</strong> Đang tải xuống dữ liệu...</div>`;
 
-    const requestData = { sNs, saveApplyStatus };
+    const requestData = { sNs };
 
     try {
         const response = await fetch("http://10.220.130.119:9090/api/Scrap/create-task-sn", {
@@ -151,7 +183,13 @@ async function processCreateTaskBySN(sNs, saveApplyStatus, resultDivId) {
 
         const result = await response.json();
         if (response.ok) {
-            const excelData = result.data.map(item => ({
+            const payload = Array.isArray(result.data) ? result.data : [];
+            if (!payload.length) {
+                statusContainer.innerHTML = `<div class="alert alert-warning"><strong>Thông báo:</strong> Không có dữ liệu để tải xuống.</div>`;
+                return;
+            }
+
+            const excelData = payload.map(item => ({
                 InternalTask: item.internalTask ?? "N/A", 
                 Item: item.item ?? "N/A",
                 Project: item.project ?? "N/A",
@@ -200,12 +238,17 @@ async function processCreateTaskBySN(sNs, saveApplyStatus, resultDivId) {
 
             // Write the workbook to file
             XLSX.writeFile(workbook, filename);
-            setTimeout(() => location.reload(), 1000);
+
+            const successMessage = result.message
+                ? `<div class="alert alert-warning">${escapeHtml(result.message)}</div>`
+                : `<div class="alert alert-success"><strong>Thành công:</strong> Dữ liệu đã được tải xuống.</div>`;
+
+            statusContainer.innerHTML = successMessage;
         } else {
-            resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${result.message}</div>`;
+            statusContainer.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> ${escapeHtml(result.message)}</div>`;
         }
     } catch (error) {
-        resultDiv.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
+        statusContainer.innerHTML = `<div class="alert alert-danger"><strong>Lỗi:</strong> Không thể kết nối đến API. Vui lòng kiểm tra lại.</div>`;
         console.error("Error:", error);
     }
 }
@@ -222,27 +265,41 @@ function renderTableWithDataTable(data, tableId, checkboxName, selectAllId) {
         const purposeText = formatPurpose(item.purpose);
         const timelineValue = isHistory ? (item.applyTime || "N/A") : (item.applyTaskStatus || "N/A");
         const statusOrQty = isHistory ? (item.applyTaskStatus || "N/A") : (item.totalQty || "N/A");
+
+        const safeInternalTask = escapeHtml(item.internalTask ?? "N/A");
+        const safeDescription = escapeHtml(item.description ?? "N/A");
+        const safeApprove = escapeHtml(item.approveScrapPerson ?? "N/A");
+        const safeKanban = escapeHtml(item.kanBanStatus ?? "N/A");
+        const safeCategory = escapeHtml(item.category ?? "N/A");
+        const safeRemark = escapeHtml(item.remark ?? "N/A");
+        const safePurpose = escapeHtml(purposeText);
+        const safeCreateTime = escapeHtml(item.createTime ?? "N/A");
+        const safeCreateBy = escapeHtml(item.createBy ?? "N/A");
+        const safeTimeline = escapeHtml(timelineValue ?? "N/A");
+        const safeStatusOrQty = escapeHtml(statusOrQty ?? "N/A");
+        const safeTotalQty = escapeHtml(item.totalQty ?? "N/A");
+
         const purposeColumn = isHistory
             ? ""
-            : `<td data-bs-toggle="tooltip" data-bs-title="${purposeText}">${purposeText}</td>`;
+            : `<td data-bs-toggle="tooltip" data-bs-title="${safePurpose}">${safePurpose}</td>`;
         const extraQtyColumn = isHistory
-            ? `<td data-bs-toggle="tooltip" data-bs-title="${item.totalQty || 'N/A'}">${item.totalQty || "N/A"}</td>`
+            ? `<td data-bs-toggle="tooltip" data-bs-title="${safeTotalQty}">${safeTotalQty}</td>`
             : "";
 
         const row = `
             <tr>
-                <td class="checkbox-column"><input type="checkbox" name="${checkboxName}" value="${item.internalTask}" ${isChecked}></td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.internalTask || 'N/A'}">${item.internalTask || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.description || 'N/A'}">${item.description || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.approveScrapPerson || 'N/A'}">${item.approveScrapPerson || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.kanBanStatus || 'N/A'}">${item.kanBanStatus || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.category || 'N/A'}">${item.category || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.remark || 'N/A'}">${item.remark || "N/A"}</td>
+                <td class="checkbox-column"><input type="checkbox" name="${checkboxName}" value="${escapeHtml(item.internalTask ?? '')}" ${isChecked}></td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeInternalTask}">${safeInternalTask}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeDescription}">${safeDescription}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeApprove}">${safeApprove}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeKanban}">${safeKanban}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeCategory}">${safeCategory}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeRemark}">${safeRemark}</td>
                 ${purposeColumn}
-                <td data-bs-toggle="tooltip" data-bs-title="${item.createTime || 'N/A'}">${item.createTime || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${item.createBy || 'N/A'}">${item.createBy || "N/A"}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${timelineValue}">${timelineValue}</td>
-                <td data-bs-toggle="tooltip" data-bs-title="${statusOrQty}">${statusOrQty}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeCreateTime}">${safeCreateTime}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeCreateBy}">${safeCreateBy}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeTimeline}">${safeTimeline}</td>
+                <td data-bs-toggle="tooltip" data-bs-title="${safeStatusOrQty}">${safeStatusOrQty}</td>
                 ${extraQtyColumn}
             </tr>
         `;
@@ -399,40 +456,13 @@ document.addEventListener("DOMContentLoaded", function () {
             alert("Vui lòng chọn ít nhất một Internal Task.");
             return;
         }
-
-        const modalHtml = `
-            <div id="custom-modal" class="modal" style="display: block; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.5); z-index: 1000;">
-                <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: white; padding: 20px; border-radius: 5px; text-align: center;">
-                    <p>Bạn có muốn lưu lại những InternalTask này vào list đã gửi cho khách hàng?</p>
-                    <button id="modal-yes-btn" style="margin-right: 10px;">Có</button>
-                    <button id="modal-no-btn">Không</button>
-                </div>
-            </div>
-        `;
-        document.body.insertAdjacentHTML('beforeend', modalHtml);
-
-        document.getElementById("modal-yes-btn").addEventListener("click", async function () {
-            document.getElementById("custom-modal").remove();
-            await processCreateTask(selectedTasksArray, "1", "create-task-result");
-            selectedInternalTasks.clear();
-        });
-
-        document.getElementById("modal-no-btn").addEventListener("click", async function () {
-            document.getElementById("custom-modal").remove();
-            await processCreateTask(selectedTasksArray, "0", "create-task-result");
-            selectedInternalTasks.clear();
-        });
-    });
-
-    // Xử lý nút "Tạo History Task"
-    document.getElementById("create-history-task-btn").addEventListener("click", async function () {
-        const selectedHistoryTasksArray = Array.from(selectedHistoryInternalTasks);
-        if (selectedHistoryTasksArray.length === 0) {
-            alert("Vui lòng chọn ít nhất một Internal Task.");
-            return;
+        await processCreateTask(selectedTasksArray, "create-task-result");
+        selectedInternalTasks.clear();
+        document.querySelectorAll('input[name="task-checkbox"]').forEach(cb => cb.checked = false);
+        const selectAll = document.getElementById('select-all');
+        if (selectAll) {
+            selectAll.checked = false;
         }
-        await processCreateTask(selectedHistoryTasksArray, "1", "history-apply-result");
-        selectedHistoryInternalTasks.clear();
     });
 
     // Xử lý nút "Tạo Task bằng SN"
@@ -443,27 +473,8 @@ document.addEventListener("DOMContentLoaded", function () {
             alert("Vui lòng nhập ít nhất một Serial Number hợp lệ.");
             return;
         }
-
-        const modalHtml = `
-            <div id="custom-modal" class="modal" style="display: block; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.5); z-index: 1000;">
-                <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: white; padding: 20px; border-radius: 5px; text-align: center;">
-                    <p>Bạn có muốn lưu lại những InternalTask này vào list đã gửi cho khách hàng?</p>
-                    <button id="modal-yes-btn" style="margin-right: 10px;">Có</button>
-                    <button id="modal-no-btn">Không</button>
-                </div>
-            </div>
-        `;
-        document.body.insertAdjacentHTML('beforeend', modalHtml);
-
-        document.getElementById("modal-yes-btn").addEventListener("click", async function () {
-            document.getElementById("custom-modal").remove();
-            await processCreateTaskBySN(sNs, "1", "create-task-result-sn");
-        });
-
-        document.getElementById("modal-no-btn").addEventListener("click", async function () {
-            document.getElementById("custom-modal").remove();
-            await processCreateTaskBySN(sNs, "0", "create-task-result-sn");
-        });
+        await processCreateTaskBySN(sNs, "create-task-result-sn");
+        document.getElementById("create-task-btn-sn-box").value = "";
     });
 
     // Xử lý nút "Cập nhật Task PO"

--- a/PESystem/wwwroot/assets/Areas/Scrap/js/progress.js
+++ b/PESystem/wwwroot/assets/Areas/Scrap/js/progress.js
@@ -1,6 +1,20 @@
 ﻿let selectedInternalTasks = new Set(); // Lưu các InternalTask đã chọn (cho TASK_STOCK_STATUS)
 let selectedSNs = new Set(); // Lưu các SN đã chọn (cho SEARCH_STATUS)
 
+function htmlEscape(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+function displayValue(value) {
+    const normalized = value === undefined || value === null || value === '' ? 'N/A' : value;
+    return htmlEscape(normalized);
+}
+
 // Hàm để ẩn tất cả các form và khu vực kết quả
 function hideAllElements() {
     const forms = ["task-stock-status-form", "search-status-form", "search-history-form"]; // bo  "update-status-form",
@@ -111,8 +125,8 @@ function renderTableWithPagination(data, resultDiv, tableHeaders, rowTemplate, e
         const paginatedData = data.slice(start, end);
 
         let tableHtml = `
-            <div class="table-container">
-                <table>
+            <div class="table-container soft-scroll">
+                <table class="stacked-result-table">
                     <thead>
                         <tr>
                             ${tableHeaders}
@@ -124,6 +138,15 @@ function renderTableWithPagination(data, resultDiv, tableHeaders, rowTemplate, e
         paginatedData.forEach(item => {
             tableHtml += rowTemplate(item);
         });
+
+        if (!paginatedData.length) {
+            const columnCount = (tableHeaders.match(/<th/g) || []).length || 1;
+            tableHtml += `
+                <tr>
+                    <td colspan="${columnCount}" class="text-center text-muted">Không có dữ liệu để hiển thị</td>
+                </tr>
+            `;
+        }
 
         tableHtml += `
                     </tbody>
@@ -328,45 +351,63 @@ async function searchStatus(searchType, searchValues) {
             // Định nghĩa rowTemplate không có cột checkbox
             const rowTemplate = (item) => `
                 <tr>
-                    <td>${item.sn ?? "N/A"}</td>
-                    <td>${item.internalTask ?? "N/A"}</td>
-                    <td>${item.description ?? "N/A"}</td>
-                    <td>${item.approveScrapPerson ?? "N/A"}</td>
-                    <td>${item.kanBanStatus ?? "N/A"}</td>
-                    <td>${item.sloc ?? "N/A"}</td>
-                    <td>${item.taskNumber ?? "N/A"}</td>
-                    <td>${item.po ?? "N/A"}</td>
-                    <td>${item.cost ?? "N/A"}</td>
-                    <td>${item.remark ?? "N/A"}</td>
-                    <td>${item.createdBy ?? "N/A"}</td>
-                    <td>${item.createTime ?? "N/A"}</td>
-                    <td>${item.applyTime ?? "N/A"}</td>
-                    <td>${item.applyTaskStatus ?? "N/A"}</td>
-                    <td>${item.findBoardStatus ?? "N/A"}</td>
-                    <td>${item.purpose ?? "N/A"}</td>
-                    <td>${item.category ?? "N/A"}</td>
-                    <td>${item.speApproveTime ?? "N/A"}</td>
+                    <td>${displayValue(item.sn)}</td>
+                    <td>${displayValue(item.internalTask)}</td>
+                    <td>${displayValue(item.description)}</td>
+                    <td>${displayValue(item.approveScrapPerson)}</td>
+                    <td>${displayValue(item.kanBanStatus)}</td>
+                    <td>${displayValue(item.sloc)}</td>
+                    <td>${displayValue(item.taskNumber)}</td>
+                    <td>${displayValue(item.po)}</td>
+                    <td>${displayValue(item.cost)}</td>
+                    <td>${displayValue(item.remark)}</td>
+                    <td>${displayValue(item.createdBy)}</td>
+                    <td>${displayValue(item.createTime)}</td>
+                    <td>${displayValue(item.applyTime)}</td>
+                    <td>${displayValue(item.applyTaskStatus)}</td>
+                    <td>${displayValue(item.findBoardStatus)}</td>
+                    <td>${displayValue(item.purpose)}</td>
+                    <td>${displayValue(item.category)}</td>
+                    <td>${displayValue(item.speApproveTime)}</td>
                 </tr>
             `;
 
             // Tạo HTML cho thông báo SN không tìm thấy (nếu có)
             let unmatchedSNsHtml = "";
             if (unmatchedSNs.length > 0) {
+                const escapedSNs = unmatchedSNs.map(htmlEscape).join(', ');
                 unmatchedSNsHtml = `
                     <div class="alert alert-warning mt-3">
-                        <strong>Cảnh báo:</strong> Có ${unmatchedSNs.length} SN không tồn tại trong ScrapList: ${unmatchedSNs.join(", ")}
+                        <strong>Cảnh báo:</strong> Có ${unmatchedSNs.length} SN không tồn tại trong ScrapList: ${escapedSNs}
                     </div>
                 `;
             }
 
             // Xóa nội dung cũ và thêm các div con với ID duy nhất, bao gồm số lượng
             resultDiv.innerHTML = `
-                <h6>Chưa có Internal Task (${noInternalTaskData.length} bản ghi)</h6>
-                <div id="search-status-result-no-internal-task"></div>
-                <h6>Đã có Internal Task nhưng chưa có Task Number (${hasInternalTaskNoTaskNumberData.length} bản ghi)</h6>
-                <div id="search-status-result-has-internal-no-task-number"></div>
-                <h6>Đã có Task Number (${hasTaskNumberData.length} bản ghi)</h6>
-                <div id="search-status-result-has-task-number"></div>
+                <div class="grouped-result-grid">
+                    <div class="scrap-card grouped-result">
+                        <div class="grouped-result-header">
+                            <h6>Chưa có Internal Task</h6>
+                            <span class="badge bg-success-subtle">${noInternalTaskData.length}</span>
+                        </div>
+                        <div id="search-status-result-no-internal-task" class="grouped-result-table"></div>
+                    </div>
+                    <div class="scrap-card grouped-result">
+                        <div class="grouped-result-header">
+                            <h6>Đã có Internal Task nhưng chưa có Task Number</h6>
+                            <span class="badge bg-success-subtle">${hasInternalTaskNoTaskNumberData.length}</span>
+                        </div>
+                        <div id="search-status-result-has-internal-no-task-number" class="grouped-result-table"></div>
+                    </div>
+                    <div class="scrap-card grouped-result">
+                        <div class="grouped-result-header">
+                            <h6>Đã có Task Number</h6>
+                            <span class="badge bg-success-subtle">${hasTaskNumberData.length}</span>
+                        </div>
+                        <div id="search-status-result-has-task-number" class="grouped-result-table"></div>
+                    </div>
+                </div>
                 ${unmatchedSNsHtml}
             `;
 
@@ -519,34 +560,35 @@ async function searchHistoryBySN(snValues) {
 
             const rowTemplate = (item) => `
                 <tr>
-                    <td>${item.rowNumber}</td>
-                    <td>${item.id ?? "N/A"}</td>
-                    <td>${item.sn ?? "N/A"}</td>
-                    <td>${item.internalTask ?? "N/A"}</td>
-                    <td>${item.description ?? "N/A"}</td>
-                    <td>${item.kanBanStatus ?? "N/A"}</td>
-                    <td>${item.sloc ?? "N/A"}</td>
-                    <td>${item.taskNumber ?? "N/A"}</td>
-                    <td>${item.po ?? "N/A"}</td>
-                    <td>${item.cost ?? "N/A"}</td>
-                    <td>${item.createdBy ?? "N/A"}</td>
-                    <td>${item.createTime ?? "N/A"}</td>
-                    <td>${item.approveScrapPerson ?? "N/A"}</td>
-                    <td>${item.applyTaskStatus ?? "N/A"}</td>
-                    <td>${item.findBoardStatus ?? "N/A"}</td>
-                    <td>${item.remark ?? "N/A"}</td>
-                    <td>${item.purpose ?? "N/A"}</td>
-                    <td>${item.category ?? "N/A"}</td>
-                    <td>${item.applyTime ?? "N/A"}</td>
-                    <td>${item.speApproveTime ?? "N/A"}</td>
+                    <td>${displayValue(item.rowNumber)}</td>
+                    <td>${displayValue(item.id)}</td>
+                    <td>${displayValue(item.sn)}</td>
+                    <td>${displayValue(item.internalTask)}</td>
+                    <td>${displayValue(item.description)}</td>
+                    <td>${displayValue(item.kanBanStatus)}</td>
+                    <td>${displayValue(item.sloc)}</td>
+                    <td>${displayValue(item.taskNumber)}</td>
+                    <td>${displayValue(item.po)}</td>
+                    <td>${displayValue(item.cost)}</td>
+                    <td>${displayValue(item.createdBy)}</td>
+                    <td>${displayValue(item.createTime)}</td>
+                    <td>${displayValue(item.approveScrapPerson)}</td>
+                    <td>${displayValue(item.applyTaskStatus)}</td>
+                    <td>${displayValue(item.findBoardStatus)}</td>
+                    <td>${displayValue(item.remark)}</td>
+                    <td>${displayValue(item.purpose)}</td>
+                    <td>${displayValue(item.category)}</td>
+                    <td>${displayValue(item.applyTime)}</td>
+                    <td>${displayValue(item.speApproveTime)}</td>
                 </tr>
             `;
 
             let extraHtml = "";
             if (missingSNs.length > 0) {
+                const escapedMissing = missingSNs.map(htmlEscape).join(', ');
                 extraHtml = `
                     <div class="alert alert-warning mt-3">
-                        <strong>Cảnh báo:</strong> Không tìm thấy lịch sử cho ${missingSNs.length} SN: ${missingSNs.join(", ")}
+                        <strong>Cảnh báo:</strong> Không tìm thấy lịch sử cho ${missingSNs.length} SN: ${escapedMissing}
                     </div>
                 `;
             }

--- a/PESystem/wwwroot/assets/css/nvidia-theme.css
+++ b/PESystem/wwwroot/assets/css/nvidia-theme.css
@@ -1,0 +1,335 @@
+:root {
+    --nvidia-green: #76B900;
+    --nvidia-green-dark: #4c7a00;
+    --nvidia-green-soft: #a7db4e;
+    --nvidia-forest: #0f2e12;
+    --nvidia-ink: #142818;
+    --nvidia-mist: #f4fbe9;
+    --nvidia-stroke: rgba(118, 185, 0, 0.22);
+    --nvidia-shadow: rgba(15, 46, 18, 0.16);
+    --nvidia-text: #1a2616;
+}
+
+.scrap-interface,
+.allpart-interface {
+    color: var(--nvidia-text);
+}
+
+.nvidia-section {
+    background: linear-gradient(135deg, rgba(118, 185, 0, 0.12) 0%, rgba(15, 46, 18, 0.06) 60%, rgba(244, 251, 233, 0.95) 100%);
+    border-radius: 28px;
+    padding: 2.5rem 2rem;
+    border: 1px solid rgba(118, 185, 0, 0.2);
+    box-shadow: 0 28px 55px rgba(15, 46, 18, 0.18);
+    position: relative;
+    overflow: hidden;
+}
+
+.nvidia-section::after {
+    content: "";
+    position: absolute;
+    inset: 12% 5% auto 5%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(118, 185, 0, 0.45), transparent);
+    pointer-events: none;
+}
+
+.section-heading {
+    margin-bottom: 2rem;
+}
+
+.section-heading h1,
+.section-heading h2 {
+    font-weight: 700;
+    color: var(--nvidia-ink);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.section-heading p {
+    margin: 0.75rem 0 0;
+    color: rgba(20, 40, 24, 0.72);
+    font-size: 0.95rem;
+}
+
+.nvidia-card {
+    background: #ffffff;
+    border-radius: 22px;
+    border: 1px solid var(--nvidia-stroke);
+    box-shadow: 0 16px 38px rgba(12, 30, 16, 0.16);
+    overflow: hidden;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.nvidia-card-header {
+    background: linear-gradient(120deg, var(--nvidia-forest), #1c4f1f 70%, rgba(118, 185, 0, 0.85));
+    color: #e9ffd7;
+    padding: 1.25rem 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.nvidia-card-header h2,
+.nvidia-card-header h3 {
+    font-size: 1.1rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin: 0;
+}
+
+.nvidia-card-body {
+    padding: 1.75rem;
+    background: linear-gradient(180deg, #ffffff 0%, var(--nvidia-mist) 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    flex: 1 1 auto;
+}
+
+.scrap-card,
+.nvidia-card-body .scrap-card,
+.allpart-card {
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid rgba(118, 185, 0, 0.18);
+    box-shadow: 0 12px 28px rgba(18, 42, 20, 0.12);
+    padding: 1.5rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.scrap-card::before,
+.allpart-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top left, rgba(118, 185, 0, 0.18), transparent 55%);
+    pointer-events: none;
+}
+
+.scrap-card > *,
+.allpart-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.scrap-interface .form-control,
+.scrap-interface .form-select,
+.allpart-interface .form-control,
+.allpart-interface .form-select {
+    border-radius: 14px;
+    border: 1px solid rgba(118, 185, 0, 0.35);
+    background-color: rgba(255, 255, 255, 0.92);
+    box-shadow: inset 0 2px 6px rgba(15, 46, 18, 0.05);
+    color: var(--nvidia-text);
+    padding: 0.65rem 1rem;
+}
+
+.scrap-interface .form-control:focus,
+.scrap-interface .form-select:focus,
+.allpart-interface .form-control:focus,
+.allpart-interface .form-select:focus {
+    border-color: var(--nvidia-green);
+    box-shadow: 0 0 0 0.25rem rgba(118, 185, 0, 0.18);
+}
+
+.scrap-interface label,
+.allpart-interface label {
+    font-weight: 600;
+    color: rgba(20, 40, 24, 0.8);
+    letter-spacing: 0.02em;
+}
+
+.scrap-interface textarea,
+.allpart-interface textarea {
+    min-height: 140px;
+    resize: vertical;
+}
+
+.btn-ne,
+.btn-nvidia-green,
+.scrap-interface .btn,
+.allpart-interface .btn {
+    background: var(--nvidia-green) !important;
+    border-color: var(--nvidia-green) !important;
+    color: #0a1606 !important;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-radius: 999px !important;
+    padding: 0.65rem 1.6rem;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+    box-shadow: 0 12px 24px rgba(118, 185, 0, 0.35);
+}
+
+.btn-ne:hover,
+.btn-nvidia-green:hover,
+.scrap-interface .btn:hover,
+.allpart-interface .btn:hover {
+    background: var(--nvidia-green-dark) !important;
+    border-color: var(--nvidia-green-dark) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 14px 28px rgba(118, 185, 0, 0.42);
+}
+
+.btn-ne:active,
+.btn-nvidia-green:active,
+.scrap-interface .btn:active,
+.allpart-interface .btn:active {
+    transform: translateY(0);
+}
+
+.badge-nvidia {
+    display: inline-block;
+    background: rgba(118, 185, 0, 0.15);
+    color: var(--nvidia-ink);
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.nvidia-table {
+    background: #ffffff;
+    border-radius: 20px;
+    overflow: hidden;
+    border: 1px solid rgba(118, 185, 0, 0.18);
+    box-shadow: 0 18px 40px rgba(15, 46, 18, 0.16);
+}
+
+.nvidia-table thead th {
+    background: linear-gradient(115deg, var(--nvidia-forest), rgba(118, 185, 0, 0.85));
+    color: #eafdd8;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-bottom: 0;
+    padding: 0.85rem 1.25rem;
+}
+
+.nvidia-table tbody td {
+    padding: 0.85rem 1.25rem;
+    vertical-align: middle;
+    border-color: rgba(118, 185, 0, 0.12);
+    color: var(--nvidia-ink);
+}
+
+.nvidia-table tbody tr:nth-child(even) {
+    background: rgba(118, 185, 0, 0.08);
+}
+
+.nvidia-table tbody tr:hover {
+    background: rgba(118, 185, 0, 0.16);
+    transition: background 0.18s ease;
+}
+
+.nvidia-table .checkbox-column {
+    width: 48px;
+    text-align: center;
+}
+
+.table-responsive {
+    border-radius: 18px;
+    border: 1px solid rgba(118, 185, 0, 0.18);
+    box-shadow: inset 0 1px 3px rgba(15, 46, 18, 0.05);
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.92);
+}
+
+.hidden {
+    display: none !important;
+}
+
+.custom-tooltip {
+    position: fixed;
+    background: rgba(15, 46, 18, 0.95);
+    color: #f4fde8;
+    padding: 0.45rem 0.75rem;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    letter-spacing: 0.03em;
+    box-shadow: 0 12px 24px rgba(15, 46, 18, 0.35);
+    max-width: 260px;
+    pointer-events: none;
+    z-index: 2000;
+    display: none;
+}
+
+.tooltip-trigger {
+    cursor: help;
+    border-bottom: 1px dashed rgba(118, 185, 0, 0.45);
+}
+
+.loading-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 46, 18, 0.68);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 1rem;
+    z-index: 2500;
+    color: #e5ffd4;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.loading-overlay .spinner {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    border: 4px solid rgba(255, 255, 255, 0.25);
+    border-top-color: var(--nvidia-green);
+    animation: nvidia-spin 0.85s linear infinite;
+}
+
+@keyframes nvidia-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.dataTables_wrapper .dataTables_filter,
+.dataTables_wrapper .dataTables_paginate,
+.dataTables_wrapper .dataTables_length {
+    margin: 0.5rem 0;
+    padding: 0.35rem 0.75rem;
+    background: rgba(244, 251, 233, 0.9);
+    border-radius: 14px;
+    border: 1px solid rgba(118, 185, 0, 0.18);
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+    border-radius: 999px !important;
+    border: none !important;
+    background: transparent !important;
+    color: var(--nvidia-ink) !important;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current,
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+    background: var(--nvidia-green) !important;
+    color: #0a1606 !important;
+}
+
+@media (max-width: 992px) {
+    .nvidia-section {
+        padding: 1.75rem 1.25rem;
+    }
+
+    .nvidia-card-body {
+        padding: 1.5rem;
+    }
+
+    .scrap-interface textarea,
+    .allpart-interface textarea {
+        min-height: 120px;
+    }
+}

--- a/PESystem/wwwroot/assets/css/nvidia-theme.css
+++ b/PESystem/wwwroot/assets/css/nvidia-theme.css
@@ -214,13 +214,26 @@
 }
 
 .nvidia-table--spacious {
-    border-spacing: 1.2rem 0.65rem;
+    border-spacing: 1.45rem 0.65rem;
 }
 
 .nvidia-table--spacious thead th,
 .nvidia-table--spacious tbody td {
-    padding-left: 1.4rem;
-    padding-right: 1.4rem;
+    padding-left: 1.75rem;
+    padding-right: 1.75rem;
+}
+
+.scrap-table--comfortable {
+    border-collapse: separate;
+    border-spacing: 1.25rem 0.55rem;
+}
+
+.scrap-table--comfortable thead th,
+.scrap-table--comfortable tbody td {
+    padding-top: 0.95rem;
+    padding-bottom: 0.95rem;
+    padding-left: 1.85rem;
+    padding-right: 1.85rem;
 }
 
 .nvidia-table--compact {

--- a/PESystem/wwwroot/assets/css/nvidia-theme.css
+++ b/PESystem/wwwroot/assets/css/nvidia-theme.css
@@ -203,6 +203,16 @@
     box-shadow: 0 18px 40px rgba(15, 46, 18, 0.16);
 }
 
+.scrap-interface .nvidia-table {
+    border-collapse: separate;
+    border-spacing: 0 0.6rem;
+}
+
+.scrap-interface .nvidia-table thead th,
+.scrap-interface .nvidia-table tbody td {
+    padding: 1rem 1.85rem;
+}
+
 .nvidia-table thead th {
     background: linear-gradient(115deg, var(--nvidia-forest), rgba(118, 185, 0, 0.85));
     color: #eafdd8;
@@ -214,7 +224,7 @@
 }
 
 .nvidia-table tbody td {
-    padding: 0.85rem 1.25rem;
+    padding: 0.95rem 1.4rem;
     vertical-align: middle;
     border-color: rgba(118, 185, 0, 0.12);
     color: var(--nvidia-ink);
@@ -247,7 +257,7 @@
 }
 
 .custom-tooltip {
-    position: fixed;
+    position: absolute;
     background: rgba(15, 46, 18, 0.95);
     color: #f4fde8;
     padding: 0.45rem 0.75rem;
@@ -264,6 +274,114 @@
 .tooltip-trigger {
     cursor: help;
     border-bottom: 1px dashed rgba(118, 185, 0, 0.45);
+}
+
+.action-feedback > .alert {
+    margin-bottom: 0;
+}
+
+.stacked-result-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 0.65rem;
+    color: var(--nvidia-ink);
+}
+
+.stacked-result-table thead th {
+    background: linear-gradient(105deg, rgba(15, 46, 18, 0.95), rgba(118, 185, 0, 0.9));
+    color: #f2ffda;
+    padding: 0.8rem 1.45rem;
+    border: none;
+}
+
+.stacked-result-table tbody td {
+    background: rgba(255, 255, 255, 0.9);
+    padding: 0.8rem 1.45rem;
+    border: 1px solid rgba(118, 185, 0, 0.18);
+    border-radius: 8px;
+}
+
+.stacked-result-table tbody tr {
+    background: transparent;
+}
+
+.grouped-result {
+    border-radius: 18px;
+    padding: 1rem;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 10px 24px rgba(15, 46, 18, 0.15);
+}
+
+.grouped-result + .grouped-result {
+    margin-top: 2rem;
+}
+
+.grouped-result { gap: 1rem; }
+
+.grouped-result-grid {
+    display: grid;
+    gap: 2rem;
+}
+
+.grouped-result-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.grouped-result-header h6 {
+    margin: 0;
+    font-weight: 700;
+    color: var(--nvidia-forest);
+}
+
+.grouped-result-table {
+    overflow-x: auto;
+}
+
+.soft-scroll {
+    overflow-x: auto;
+}
+
+.allpart-interface .nvidia-table thead th,
+.allpart-interface .nvidia-table tbody td {
+    padding: 1.05rem 1.95rem;
+    min-width: 11rem;
+}
+
+#table-sn-wait-approve,
+#task-checkbox-table,
+#history-task-checkbox-table,
+#task-stock-status-result table,
+#search-status-result table,
+#history-search-result table {
+    border-collapse: separate !important;
+    border-spacing: 0 0.65rem !important;
+}
+
+#table-sn-wait-approve th,
+#table-sn-wait-approve td,
+#task-checkbox-table th,
+#task-checkbox-table td,
+#history-task-checkbox-table th,
+#history-task-checkbox-table td,
+#task-stock-status-result table th,
+#task-stock-status-result table td,
+#search-status-result table th,
+#search-status-result table td,
+#history-search-result table th,
+#history-search-result table td {
+    padding: 1rem 1.8rem;
+}
+
+.badge.bg-success-subtle {
+    background-color: rgba(118, 185, 0, 0.18);
+    color: var(--nvidia-forest);
+    border: 1px solid rgba(118, 185, 0, 0.3);
+    padding: 0.4rem 0.65rem;
+    font-weight: 600;
 }
 
 .loading-overlay {

--- a/PESystem/wwwroot/assets/css/nvidia-theme.css
+++ b/PESystem/wwwroot/assets/css/nvidia-theme.css
@@ -259,6 +259,28 @@
     overflow-x: auto;
 }
 
+.scrap-table-container {
+    padding: 0.85rem 1.15rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.82);
+    box-shadow: inset 0 0 0 1px rgba(118, 185, 0, 0.08);
+}
+
+.scrap-table-container .table {
+    border-collapse: separate !important;
+    border-spacing: 0 0.65rem;
+    table-layout: auto;
+    width: 100%;
+}
+
+.scrap-table-container .table thead th,
+.scrap-table-container .table tbody td {
+    padding-top: 0.95rem;
+    padding-bottom: 0.95rem;
+    padding-left: 1.65rem;
+    padding-right: 1.65rem;
+}
+
 .nvidia-table thead th {
     background: linear-gradient(115deg, var(--nvidia-forest), rgba(118, 185, 0, 0.85));
     color: #eafdd8;

--- a/PESystem/wwwroot/assets/css/nvidia-theme.css
+++ b/PESystem/wwwroot/assets/css/nvidia-theme.css
@@ -205,34 +205,40 @@
 
 .scrap-interface .nvidia-table {
     border-collapse: separate;
-    border-spacing: 0 0.6rem;
+    border-spacing: 0 0.55rem;
 }
 
 .scrap-interface .nvidia-table thead th,
 .scrap-interface .nvidia-table tbody td {
-    padding: 1rem 1.85rem;
+    padding: 0.95rem 1.6rem;
+}
+
+.nvidia-table--spacious {
+    border-spacing: 1.2rem 0.65rem;
 }
 
 .nvidia-table--spacious thead th,
 .nvidia-table--spacious tbody td {
-    padding-left: 1.9rem;
-    padding-right: 1.9rem;
+    padding-left: 1.4rem;
+    padding-right: 1.4rem;
 }
 
 .nvidia-table--compact {
     border-collapse: separate;
-    border-spacing: 0;
+    border-spacing: 0 0.25rem;
     table-layout: auto;
+    width: max-content;
+    min-width: 100%;
 }
 
 .nvidia-table--compact thead th,
 .nvidia-table--compact tbody td {
-    padding-top: 0.65rem;
-    padding-bottom: 0.65rem;
-    padding-left: 0.95rem;
-    padding-right: 0.95rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0.85rem;
+    padding-right: 0.85rem;
     white-space: nowrap;
-    line-height: 1.4;
+    line-height: 1.3;
 }
 
 .table-container {
@@ -311,7 +317,7 @@
     width: max-content;
     min-width: 100%;
     border-collapse: separate;
-    border-spacing: 0 0.35rem;
+    border-spacing: 0 0.18rem;
     table-layout: auto;
     color: var(--nvidia-ink);
 }
@@ -319,17 +325,17 @@
 .stacked-result-table thead th {
     background: linear-gradient(105deg, rgba(15, 46, 18, 0.95), rgba(118, 185, 0, 0.9));
     color: #f2ffda;
-    padding: 0.65rem 1rem;
+    padding: 0.55rem 0.85rem;
     border: none;
     white-space: nowrap;
 }
 
 .stacked-result-table tbody td {
     background: rgba(255, 255, 255, 0.9);
-    padding: 0.65rem 1rem;
+    padding: 0.5rem 0.85rem;
     border: 1px solid rgba(118, 185, 0, 0.18);
     border-radius: 8px;
-    line-height: 1.4;
+    line-height: 1.3;
     white-space: nowrap;
 }
 

--- a/PESystem/wwwroot/assets/css/nvidia-theme.css
+++ b/PESystem/wwwroot/assets/css/nvidia-theme.css
@@ -213,6 +213,33 @@
     padding: 1rem 1.85rem;
 }
 
+.nvidia-table--spacious thead th,
+.nvidia-table--spacious tbody td {
+    padding-left: 1.9rem;
+    padding-right: 1.9rem;
+}
+
+.nvidia-table--compact {
+    border-collapse: separate;
+    border-spacing: 0;
+    table-layout: auto;
+}
+
+.nvidia-table--compact thead th,
+.nvidia-table--compact tbody td {
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+    padding-left: 0.95rem;
+    padding-right: 0.95rem;
+    white-space: nowrap;
+    line-height: 1.4;
+}
+
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+}
+
 .nvidia-table thead th {
     background: linear-gradient(115deg, var(--nvidia-forest), rgba(118, 185, 0, 0.85));
     color: #eafdd8;
@@ -281,24 +308,29 @@
 }
 
 .stacked-result-table {
-    width: 100%;
+    width: max-content;
+    min-width: 100%;
     border-collapse: separate;
-    border-spacing: 0 0.65rem;
+    border-spacing: 0 0.35rem;
+    table-layout: auto;
     color: var(--nvidia-ink);
 }
 
 .stacked-result-table thead th {
     background: linear-gradient(105deg, rgba(15, 46, 18, 0.95), rgba(118, 185, 0, 0.9));
     color: #f2ffda;
-    padding: 0.8rem 1.45rem;
+    padding: 0.65rem 1rem;
     border: none;
+    white-space: nowrap;
 }
 
 .stacked-result-table tbody td {
     background: rgba(255, 255, 255, 0.9);
-    padding: 0.8rem 1.45rem;
+    padding: 0.65rem 1rem;
     border: 1px solid rgba(118, 185, 0, 0.18);
     border-radius: 8px;
+    line-height: 1.4;
+    white-space: nowrap;
 }
 
 .stacked-result-table tbody tr {


### PR DESCRIPTION
## Summary
- filter the scrap status endpoint to only include internal tasks created within the last three months and surface the stored purpose value
- introduce a shared NVIDIA-themed stylesheet and apply the refreshed layout across scrap management views
- modernize the Allpart DC/LC, FailATE, HE, ULT, and YRDCLC pages with the new look and loading feedback

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ef4990759c83269b7d7f5d61ff9dfc