### PR TITLE
Add NPI document management area

### DIFF
--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Logging;
+using PESystem.Areas.NPI.Models.ViewModels;
+using PESystem.Areas.NPI.Services;
+
+namespace PESystem.Areas.NPI.Controllers
+{
+    [Area("NPI")]
+    [Authorize(Policy = "NpiAccess")]
+    public class HomeController : Controller
+    {
+        private readonly NpiDocumentService _documentService;
+        private readonly ILogger<HomeController> _logger;
+
+        public HomeController(NpiDocumentService documentService, ILogger<HomeController> logger)
+        {
+            _documentService = documentService;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(string? projectKey = null, string? path = null)
+        {
+            var projects = await _documentService.GetProjectsAsync();
+            NpiProjectDetailViewModel? detail = null;
+
+            if (!string.IsNullOrWhiteSpace(projectKey))
+            {
+                detail = await _documentService.GetProjectDetailAsync(projectKey, path);
+                if (detail == null)
+                {
+                    TempData["ErrorMessage"] = "Không tìm thấy project đã chọn.";
+                    return RedirectToAction(nameof(Index));
+                }
+            }
+
+            var viewModel = new NpiIndexViewModel
+            {
+                Projects = projects,
+                SelectedProject = detail
+            };
+
+            if (TempData.TryGetValue("ErrorMessage", out var error))
+            {
+                ViewData["ErrorMessage"] = error;
+            }
+
+            if (TempData.TryGetValue("SuccessMessage", out var success))
+            {
+                ViewData["SuccessMessage"] = success;
+            }
+
+            return View(viewModel);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreateProject(CreateProjectViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                var projects = await _documentService.GetProjectsAsync();
+                var vm = new NpiIndexViewModel
+                {
+                    Projects = projects,
+                    SelectedProject = null,
+                    CreateProject = model
+                };
+                ViewBag.ShowCreateModal = true;
+                return View("Index", vm);
+            }
+
+            try
+            {
+                var project = await _documentService.CreateProjectAsync(model.Name!, model.Owner!);
+                TempData["SuccessMessage"] = $"Project '{project.Name}' đã được tạo.";
+                return RedirectToAction(nameof(Index), new { projectKey = project.ProjectKey });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create NPI project");
+                ModelState.AddModelError(string.Empty, ex.Message);
+                var projects = await _documentService.GetProjectsAsync();
+                var vm = new NpiIndexViewModel
+                {
+                    Projects = projects,
+                    SelectedProject = null,
+                    CreateProject = model
+                };
+                ViewBag.ShowCreateModal = true;
+                return View("Index", vm);
+            }
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> UploadDocument(string projectKey, string? path, IFormFile? file)
+        {
+            if (string.IsNullOrWhiteSpace(projectKey))
+            {
+                TempData["ErrorMessage"] = "Thiếu thông tin project.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            if (file == null || file.Length == 0)
+            {
+                TempData["ErrorMessage"] = "Vui lòng chọn tài liệu hợp lệ.";
+                return RedirectToAction(nameof(Index), new { projectKey, path });
+            }
+
+            try
+            {
+                await _documentService.UploadDocumentAsync(projectKey, path, file);
+                TempData["SuccessMessage"] = $"Đã tải lên '{file.FileName}'.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to upload NPI document");
+                TempData["ErrorMessage"] = ex.Message;
+            }
+
+            return RedirectToAction(nameof(Index), new { projectKey, path });
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> DownloadDocument(string projectKey, string documentId, string? path)
+        {
+            if (string.IsNullOrWhiteSpace(projectKey) || string.IsNullOrWhiteSpace(documentId))
+            {
+                TempData["ErrorMessage"] = "Không tìm thấy tài liệu.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            var document = await _documentService.GetDocumentAsync(projectKey, documentId, path);
+            if (document == null)
+            {
+                TempData["ErrorMessage"] = "Không tìm thấy tài liệu.";
+                return RedirectToAction(nameof(Index), new { projectKey, path });
+            }
+
+            var provider = new FileExtensionContentTypeProvider();
+            if (!provider.TryGetContentType(document.Metadata.StoredFileName, out var contentType))
+            {
+                contentType = "application/octet-stream";
+            }
+
+            var originalName = Path.GetFileNameWithoutExtension(document.Metadata.OriginalName);
+            var extension = Path.GetExtension(document.Metadata.OriginalName);
+            var downloadName = $"{originalName}_v{document.Metadata.Version:000}{extension}";
+            return PhysicalFile(document.PhysicalPath, contentType, downloadName);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteDocument(string projectKey, string documentId, string? path)
+        {
+            if (string.IsNullOrWhiteSpace(projectKey) || string.IsNullOrWhiteSpace(documentId))
+            {
+                TempData["ErrorMessage"] = "Không tìm thấy tài liệu.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            try
+            {
+                var deleted = await _documentService.DeleteDocumentAsync(projectKey, documentId, path);
+                TempData[deleted ? "SuccessMessage" : "ErrorMessage"] = deleted ? "Đã xoá tài liệu." : "Không tìm thấy tài liệu.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete NPI document");
+                TempData["ErrorMessage"] = ex.Message;
+            }
+
+            return RedirectToAction(nameof(Index), new { projectKey, path });
+        }
+    }
+}

--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -137,23 +137,25 @@ namespace PESystem.Areas.NPI.Controllers
                 return RedirectToAction(nameof(Index));
             }
 
-            var document = await _documentService.GetDocumentAsync(projectKey, documentId, path);
-            if (document == null)
+            var documentResult = await _documentService.GetDocumentAsync(projectKey, documentId, path);
+            if (documentResult == null)
             {
                 TempData["ErrorMessage"] = "Không tìm thấy tài liệu.";
                 return RedirectToAction(nameof(Index), new { projectKey, path });
             }
 
+            var (metadata, physicalPath) = documentResult.Value;
+
             var provider = new FileExtensionContentTypeProvider();
-            if (!provider.TryGetContentType(document.Metadata.StoredFileName, out var contentType))
+            if (!provider.TryGetContentType(metadata.StoredFileName, out var contentType))
             {
                 contentType = "application/octet-stream";
             }
 
-            var originalName = Path.GetFileNameWithoutExtension(document.Metadata.OriginalName);
-            var extension = Path.GetExtension(document.Metadata.OriginalName);
-            var downloadName = $"{originalName}_v{document.Metadata.Version:000}{extension}";
-            return PhysicalFile(document.PhysicalPath, contentType, downloadName);
+            var originalName = Path.GetFileNameWithoutExtension(metadata.OriginalName);
+            var extension = Path.GetExtension(metadata.OriginalName);
+            var downloadName = $"{originalName}_v{metadata.Version:000}{extension}";
+            return PhysicalFile(physicalPath, contentType, downloadName);
         }
 
         [HttpPost]

--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -63,8 +65,20 @@ namespace PESystem.Areas.NPI.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> CreateProject(CreateProjectViewModel model)
         {
+            var isAjax = HttpContext.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+
             if (!ModelState.IsValid)
             {
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return Json(new
+                    {
+                        success = false,
+                        errors = ExtractModelErrors()
+                    });
+                }
+
                 var projects = await _documentService.GetProjectsAsync();
                 var vm = new NpiIndexViewModel
                 {
@@ -79,12 +93,32 @@ namespace PESystem.Areas.NPI.Controllers
             try
             {
                 var project = await _documentService.CreateProjectAsync(model.Name!, model.Owner!);
+                if (isAjax)
+                {
+                    return Json(new
+                    {
+                        success = true,
+                        redirectUrl = Url.Action(nameof(Index), new { projectKey = project.ProjectKey }),
+                        message = $"Project '{project.Name}' đã được tạo."
+                    });
+                }
+
                 TempData["SuccessMessage"] = $"Project '{project.Name}' đã được tạo.";
                 return RedirectToAction(nameof(Index), new { projectKey = project.ProjectKey });
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to create NPI project");
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status500InternalServerError;
+                    return Json(new
+                    {
+                        success = false,
+                        error = ex.Message
+                    });
+                }
+
                 ModelState.AddModelError(string.Empty, ex.Message);
                 var projects = await _documentService.GetProjectsAsync();
                 var vm = new NpiIndexViewModel
@@ -102,14 +136,28 @@ namespace PESystem.Areas.NPI.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> UploadDocument(string projectKey, string? path, IFormFile? file)
         {
+            var isAjax = HttpContext.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+
             if (string.IsNullOrWhiteSpace(projectKey))
             {
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return Json(new { success = false, error = "Thiếu thông tin project." });
+                }
+
                 TempData["ErrorMessage"] = "Thiếu thông tin project.";
                 return RedirectToAction(nameof(Index));
             }
 
             if (file == null || file.Length == 0)
             {
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return Json(new { success = false, error = "Vui lòng chọn tài liệu hợp lệ." });
+                }
+
                 TempData["ErrorMessage"] = "Vui lòng chọn tài liệu hợp lệ.";
                 return RedirectToAction(nameof(Index), new { projectKey, path });
             }
@@ -117,11 +165,27 @@ namespace PESystem.Areas.NPI.Controllers
             try
             {
                 await _documentService.UploadDocumentAsync(projectKey, path, file);
+                if (isAjax)
+                {
+                    return Json(new
+                    {
+                        success = true,
+                        redirectUrl = Url.Action(nameof(Index), new { projectKey, path }),
+                        message = $"Đã tải lên '{file.FileName}'."
+                    });
+                }
+
                 TempData["SuccessMessage"] = $"Đã tải lên '{file.FileName}'.";
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to upload NPI document");
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status500InternalServerError;
+                    return Json(new { success = false, error = ex.Message });
+                }
+
                 TempData["ErrorMessage"] = ex.Message;
             }
 
@@ -162,8 +226,16 @@ namespace PESystem.Areas.NPI.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteDocument(string projectKey, string documentId, string? path)
         {
+            var isAjax = HttpContext.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+
             if (string.IsNullOrWhiteSpace(projectKey) || string.IsNullOrWhiteSpace(documentId))
             {
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return Json(new { success = false, error = "Không tìm thấy tài liệu." });
+                }
+
                 TempData["ErrorMessage"] = "Không tìm thấy tài liệu.";
                 return RedirectToAction(nameof(Index));
             }
@@ -171,15 +243,46 @@ namespace PESystem.Areas.NPI.Controllers
             try
             {
                 var deleted = await _documentService.DeleteDocumentAsync(projectKey, documentId, path);
+                if (isAjax)
+                {
+                    if (!deleted)
+                    {
+                        Response.StatusCode = StatusCodes.Status404NotFound;
+                        return Json(new { success = false, error = "Không tìm thấy tài liệu." });
+                    }
+
+                    return Json(new
+                    {
+                        success = true,
+                        redirectUrl = Url.Action(nameof(Index), new { projectKey, path }),
+                        message = "Đã xoá tài liệu."
+                    });
+                }
+
                 TempData[deleted ? "SuccessMessage" : "ErrorMessage"] = deleted ? "Đã xoá tài liệu." : "Không tìm thấy tài liệu.";
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to delete NPI document");
+                if (isAjax)
+                {
+                    Response.StatusCode = StatusCodes.Status500InternalServerError;
+                    return Json(new { success = false, error = ex.Message });
+                }
+
                 TempData["ErrorMessage"] = ex.Message;
             }
 
             return RedirectToAction(nameof(Index), new { projectKey, path });
+        }
+
+        private Dictionary<string, string[]> ExtractModelErrors()
+        {
+            return ModelState
+                .Where(kvp => kvp.Value?.Errors.Count > 0)
+                .ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value!.Errors.Select(e => e.ErrorMessage).ToArray());
         }
     }
 }

--- a/PESystem/Areas/NPI/Models/NpiDocumentMetadata.cs
+++ b/PESystem/Areas/NPI/Models/NpiDocumentMetadata.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiDocumentMetadata
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+        [JsonPropertyName("name")]
+        public string OriginalName { get; set; } = string.Empty;
+
+        [JsonPropertyName("stored")]
+        public string StoredFileName { get; set; } = string.Empty;
+
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+        [JsonPropertyName("uploadedAt")]
+        public DateTime UploadedAt { get; set; }
+
+        [JsonPropertyName("uploadedBy")]
+        public string UploadedBy { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectMetadata.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectMetadata.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiProjectMetadata
+    {
+        [JsonPropertyName("key")]
+        public string ProjectKey { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("owner")]
+        public string Owner { get; set; } = string.Empty;
+
+        [JsonPropertyName("createdAt")]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/PESystem/Areas/NPI/Models/ViewModels/NpiIndexViewModel.cs
+++ b/PESystem/Areas/NPI/Models/ViewModels/NpiIndexViewModel.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace PESystem.Areas.NPI.Models.ViewModels
+{
+    public class NpiIndexViewModel
+    {
+        public IReadOnlyList<NpiProjectMetadata> Projects { get; set; } = Array.Empty<NpiProjectMetadata>();
+
+        public NpiProjectDetailViewModel? SelectedProject { get; set; }
+
+        public CreateProjectViewModel CreateProject { get; set; } = new();
+    }
+
+    public class NpiProjectDetailViewModel
+    {
+        public NpiProjectMetadata Project { get; set; } = null!;
+
+        public string RelativePath { get; set; } = string.Empty;
+
+        public IReadOnlyList<NpiBreadcrumbItem> Breadcrumbs { get; set; } = Array.Empty<NpiBreadcrumbItem>();
+
+        public IReadOnlyList<NpiFolderViewModel> Folders { get; set; } = Array.Empty<NpiFolderViewModel>();
+
+        public IReadOnlyList<NpiDocumentViewModel> Documents { get; set; } = Array.Empty<NpiDocumentViewModel>();
+    }
+
+    public class NpiFolderViewModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public string RelativePath { get; set; } = string.Empty;
+    }
+
+    public class NpiDocumentViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string StoredFileName { get; set; } = string.Empty;
+        public int Version { get; set; }
+        public DateTime UploadedAt { get; set; }
+        public string UploadedBy { get; set; } = string.Empty;
+        public string RelativePath { get; set; } = string.Empty;
+    }
+
+    public class NpiBreadcrumbItem
+    {
+        public string Title { get; set; } = string.Empty;
+        public string RelativePath { get; set; } = string.Empty;
+    }
+
+    public class CreateProjectViewModel
+    {
+        [Required]
+        [Display(Name = "Project name")]
+        [StringLength(200, ErrorMessage = "{0} không được vượt quá {1} ký tự.")]
+        public string? Name { get; set; }
+
+        [Required]
+        [Display(Name = "Owner")]
+        [StringLength(200, ErrorMessage = "{0} không được vượt quá {1} ký tự.")]
+        public string? Owner { get; set; }
+    }
+}

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -1,0 +1,523 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using PESystem.Areas.NPI.Models;
+using PESystem.Areas.NPI.Models.ViewModels;
+
+namespace PESystem.Areas.NPI.Services
+{
+    public class NpiDocumentService
+    {
+        private const string ProjectsMetadataFileName = ".projects.json";
+        private const string DocumentMetadataFileName = ".documents.json";
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true
+        };
+
+        private static readonly SemaphoreSlim ProjectsLock = new(1, 1);
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> FolderLocks = new();
+
+        private readonly ILogger<NpiDocumentService> _logger;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        private readonly string _rootPath;
+
+        private static readonly IReadOnlyDictionary<string, string[]> TemplateFolders = new Dictionary<string, string[]>
+        {
+            ["BOM"] = new[] { "NPI BOM", "MP BOM" },
+            ["Document instruction"] = new[] { "BOM map", "PCB layout", "ASSY + Packing instruction" },
+            ["Manufacturing process"] = new[] { "Route from NV", "Manufacturing in foxconn + SFC", "SOP route NV" },
+            ["Key component"] = new[] { "OPV data", "SOP NPI", "EPAD location" },
+            ["Config NPI"] = new[] { "Config 27 for BI process", "LCR config" },
+            ["DFX"] = new[] { "PFMEA", "PMP" },
+            ["Production plan"] = new[] { "DEV + status" },
+            ["YR report for each build"] = new[] { "YR everyday (tracker)", "YR report (engineer report)" },
+            ["Cook book"] = new[] { "Picture SFG + FG", "Picture AOI", "Profile SMT" },
+            ["YR 1st MP"] = new[] { "Only test station (engineer report)" },
+            ["Bone pile report"] = Array.Empty<string>()
+        };
+
+        public NpiDocumentService(IConfiguration configuration, ILogger<NpiDocumentService> logger, IHttpContextAccessor httpContextAccessor)
+        {
+            var configuredPath = configuration.GetSection("NpiDocument")?.GetValue<string>("RootPath");
+            _rootPath = string.IsNullOrWhiteSpace(configuredPath) ? @"D:\\NpiDocument" : configuredPath!;
+            _logger = logger;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<IReadOnlyList<NpiProjectMetadata>> GetProjectsAsync()
+        {
+            await EnsureRootExistsAsync();
+            await ProjectsLock.WaitAsync();
+            try
+            {
+                var metadataPath = GetProjectsMetadataPath();
+                if (!File.Exists(metadataPath))
+                {
+                    return Array.Empty<NpiProjectMetadata>();
+                }
+
+                await using var stream = File.OpenRead(metadataPath);
+                var projects = await JsonSerializer.DeserializeAsync<List<NpiProjectMetadata>>(stream, JsonOptions) ?? new List<NpiProjectMetadata>();
+                return projects
+                    .Where(p => Directory.Exists(GetProjectFolderPath(p.ProjectKey, ensureExists: false)))
+                    .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to read NPI project metadata");
+                return Array.Empty<NpiProjectMetadata>();
+            }
+            finally
+            {
+                ProjectsLock.Release();
+            }
+        }
+
+        public async Task<NpiProjectMetadata?> CreateProjectAsync(string name, string owner)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Tên project không hợp lệ.", nameof(name));
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentException("Owner không hợp lệ.", nameof(owner));
+            }
+
+            name = name.Trim();
+            owner = owner.Trim();
+
+            await EnsureRootExistsAsync();
+
+            await ProjectsLock.WaitAsync();
+            try
+            {
+                var projects = await ReadProjectsInternalAsync();
+                if (projects.Any(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new InvalidOperationException($"Project '{name}' đã tồn tại.");
+                }
+
+                var projectKey = GenerateUniqueProjectKey(name, projects);
+                var project = new NpiProjectMetadata
+                {
+                    ProjectKey = projectKey,
+                    Name = name,
+                    Owner = owner,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                projects.Add(project);
+                await WriteProjectsInternalAsync(projects);
+
+                var projectPath = GetProjectFolderPath(project.ProjectKey);
+                Directory.CreateDirectory(projectPath);
+
+                foreach (var group in TemplateFolders)
+                {
+                    var groupPath = Path.Combine(projectPath, group.Key);
+                    Directory.CreateDirectory(groupPath);
+                    foreach (var child in group.Value)
+                    {
+                        Directory.CreateDirectory(Path.Combine(groupPath, child));
+                    }
+                }
+
+                return project;
+            }
+            finally
+            {
+                ProjectsLock.Release();
+            }
+        }
+
+        public async Task<NpiProjectMetadata?> GetProjectAsync(string projectKey)
+        {
+            if (string.IsNullOrWhiteSpace(projectKey))
+            {
+                return null;
+            }
+
+            await ProjectsLock.WaitAsync();
+            try
+            {
+                var projects = await ReadProjectsInternalAsync();
+                return projects.FirstOrDefault(p => string.Equals(p.ProjectKey, projectKey, StringComparison.OrdinalIgnoreCase));
+            }
+            finally
+            {
+                ProjectsLock.Release();
+            }
+        }
+
+        public async Task<NpiProjectDetailViewModel?> GetProjectDetailAsync(string projectKey, string? relativePath)
+        {
+            var project = await GetProjectAsync(projectKey);
+            if (project == null)
+            {
+                return null;
+            }
+
+            var normalizedPath = NormalizeRelativePath(relativePath);
+            var folderPath = GetProjectFolderPath(project.ProjectKey);
+            var currentPath = string.IsNullOrEmpty(normalizedPath) ? folderPath : Path.Combine(folderPath, normalizedPath);
+            currentPath = EnsurePathWithinProject(project, currentPath);
+
+            if (!Directory.Exists(currentPath))
+            {
+                Directory.CreateDirectory(currentPath);
+            }
+
+            var breadcrumbItems = BuildBreadcrumbs(project, normalizedPath);
+
+            var directories = Directory.GetDirectories(currentPath)
+                .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+                .Select(d => new NpiFolderViewModel
+                {
+                    Name = Path.GetFileName(d),
+                    RelativePath = CombineRelativePaths(ToRoutePath(normalizedPath), Path.GetFileName(d))
+                })
+                .ToList();
+
+            var documents = await LoadDocumentsAsync(currentPath, ToRoutePath(normalizedPath));
+
+            return new NpiProjectDetailViewModel
+            {
+                Project = project,
+                RelativePath = ToRoutePath(normalizedPath),
+                Breadcrumbs = breadcrumbItems,
+                Folders = directories,
+                Documents = documents
+            };
+        }
+
+        public async Task UploadDocumentAsync(string projectKey, string? relativePath, IFormFile file, CancellationToken cancellationToken = default)
+        {
+            if (file == null || file.Length == 0)
+            {
+                throw new InvalidOperationException("Tệp tải lên không hợp lệ.");
+            }
+
+            var project = await GetProjectAsync(projectKey) ?? throw new InvalidOperationException("Project không tồn tại.");
+            var normalizedPath = NormalizeRelativePath(relativePath);
+            var folderPath = EnsurePathWithinProject(project, Path.Combine(GetProjectFolderPath(project.ProjectKey), normalizedPath));
+            Directory.CreateDirectory(folderPath);
+
+            var metadataPath = Path.Combine(folderPath, DocumentMetadataFileName);
+            var folderLock = FolderLocks.GetOrAdd(metadataPath, _ => new SemaphoreSlim(1, 1));
+            await folderLock.WaitAsync(cancellationToken);
+            try
+            {
+                var documents = await ReadDocumentsInternalAsync(metadataPath);
+                var existingVersions = documents
+                    .Where(d => string.Equals(d.OriginalName, file.FileName, StringComparison.OrdinalIgnoreCase))
+                    .Select(d => d.Version);
+                var nextVersion = existingVersions.Any() ? existingVersions.Max() + 1 : 1;
+
+                var baseName = Path.GetFileNameWithoutExtension(file.FileName);
+                var extension = Path.GetExtension(file.FileName);
+                var storedName = $"{SanitizeFileName(baseName)}_v{nextVersion:000}{extension}";
+                var storedPath = Path.Combine(folderPath, storedName);
+
+                await using (var stream = File.Create(storedPath))
+                {
+                    await file.CopyToAsync(stream, cancellationToken);
+                }
+
+                var uploader = _httpContextAccessor.HttpContext?.User?.Identity?.Name;
+                if (string.IsNullOrWhiteSpace(uploader))
+                {
+                    uploader = "Unknown";
+                }
+
+                documents.Add(new NpiDocumentMetadata
+                {
+                    Id = Guid.NewGuid().ToString("N"),
+                    OriginalName = file.FileName,
+                    StoredFileName = storedName,
+                    UploadedAt = DateTime.UtcNow,
+                    UploadedBy = uploader,
+                    Version = nextVersion
+                });
+
+                await WriteDocumentsInternalAsync(metadataPath, documents);
+            }
+            finally
+            {
+                folderLock.Release();
+            }
+        }
+
+        public async Task<(NpiDocumentMetadata Metadata, string PhysicalPath)?> GetDocumentAsync(string projectKey, string documentId, string? relativePath)
+        {
+            var project = await GetProjectAsync(projectKey);
+            if (project == null)
+            {
+                return null;
+            }
+
+            var normalizedPath = NormalizeRelativePath(relativePath);
+            var folderPath = EnsurePathWithinProject(project, Path.Combine(GetProjectFolderPath(project.ProjectKey), normalizedPath));
+            var metadataPath = Path.Combine(folderPath, DocumentMetadataFileName);
+            var documents = await ReadDocumentsInternalAsync(metadataPath);
+            var document = documents.FirstOrDefault(d => d.Id == documentId);
+            if (document == null)
+            {
+                return null;
+            }
+
+            var filePath = Path.Combine(folderPath, document.StoredFileName);
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            return (document, filePath);
+        }
+
+        public async Task<bool> DeleteDocumentAsync(string projectKey, string documentId, string? relativePath)
+        {
+            var project = await GetProjectAsync(projectKey);
+            if (project == null)
+            {
+                return false;
+            }
+
+            var normalizedPath = NormalizeRelativePath(relativePath);
+            var folderPath = EnsurePathWithinProject(project, Path.Combine(GetProjectFolderPath(project.ProjectKey), normalizedPath));
+            var metadataPath = Path.Combine(folderPath, DocumentMetadataFileName);
+            var folderLock = FolderLocks.GetOrAdd(metadataPath, _ => new SemaphoreSlim(1, 1));
+            await folderLock.WaitAsync();
+            try
+            {
+                var documents = await ReadDocumentsInternalAsync(metadataPath);
+                var index = documents.FindIndex(d => d.Id == documentId);
+                if (index < 0)
+                {
+                    return false;
+                }
+
+                var document = documents[index];
+                var filePath = Path.Combine(folderPath, document.StoredFileName);
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+
+                documents.RemoveAt(index);
+                await WriteDocumentsInternalAsync(metadataPath, documents);
+                return true;
+            }
+            finally
+            {
+                folderLock.Release();
+            }
+        }
+
+        private async Task EnsureRootExistsAsync()
+        {
+            if (!Directory.Exists(_rootPath))
+            {
+                Directory.CreateDirectory(_rootPath);
+            }
+
+            var metadataPath = GetProjectsMetadataPath();
+            if (!File.Exists(metadataPath))
+            {
+                await using var stream = File.Create(metadataPath);
+                await JsonSerializer.SerializeAsync(stream, new List<NpiProjectMetadata>(), JsonOptions);
+            }
+        }
+
+        private string GetProjectsMetadataPath() => Path.Combine(_rootPath, ProjectsMetadataFileName);
+
+        private string GetProjectFolderPath(string projectKey, bool ensureExists = true)
+        {
+            var projectPath = Path.Combine(_rootPath, projectKey);
+            if (ensureExists && !Directory.Exists(projectPath))
+            {
+                Directory.CreateDirectory(projectPath);
+            }
+
+            return projectPath;
+        }
+
+        private async Task<List<NpiProjectMetadata>> ReadProjectsInternalAsync()
+        {
+            var metadataPath = GetProjectsMetadataPath();
+            if (!File.Exists(metadataPath))
+            {
+                return new List<NpiProjectMetadata>();
+            }
+
+            await using var stream = File.OpenRead(metadataPath);
+            return await JsonSerializer.DeserializeAsync<List<NpiProjectMetadata>>(stream, JsonOptions) ?? new List<NpiProjectMetadata>();
+        }
+
+        private async Task WriteProjectsInternalAsync(List<NpiProjectMetadata> projects)
+        {
+            var metadataPath = GetProjectsMetadataPath();
+            await using var stream = File.Create(metadataPath);
+            await JsonSerializer.SerializeAsync(stream, projects, JsonOptions);
+        }
+
+        private string GenerateUniqueProjectKey(string projectName, IEnumerable<NpiProjectMetadata> existing)
+        {
+            var safeName = SanitizeFileName(projectName);
+            if (string.IsNullOrWhiteSpace(safeName))
+            {
+                safeName = "Project";
+            }
+
+            var key = safeName;
+            var suffix = 1;
+            var existingKeys = new HashSet<string>(existing.Select(p => p.ProjectKey), StringComparer.OrdinalIgnoreCase);
+            while (existingKeys.Contains(key) || Directory.Exists(Path.Combine(_rootPath, key)))
+            {
+                key = $"{safeName}_{suffix++}";
+            }
+
+            return key;
+        }
+
+        private static string ToRoutePath(string normalizedPath)
+        {
+            return string.IsNullOrWhiteSpace(normalizedPath)
+                ? string.Empty
+                : normalizedPath.Replace('\\', '/');
+        }
+
+        private static string SanitizeFileName(string input)
+        {
+            var invalidChars = Regex.Escape(new string(Path.GetInvalidFileNameChars()));
+            var invalidRegex = new Regex($"[{invalidChars}]", RegexOptions.Compiled);
+            var sanitized = invalidRegex.Replace(input, "_");
+            sanitized = Regex.Replace(sanitized, "\\s+", "_");
+            sanitized = sanitized.Trim('_');
+            return string.IsNullOrWhiteSpace(sanitized) ? "item" : sanitized;
+        }
+
+        private static string NormalizeRelativePath(string? relativePath)
+        {
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                return string.Empty;
+            }
+
+            var parts = relativePath
+                .Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .Where(part => !string.IsNullOrWhiteSpace(part))
+                .Select(Path.GetFileName);
+
+            return Path.Combine(parts.ToArray());
+        }
+
+        private string EnsurePathWithinProject(NpiProjectMetadata project, string targetPath)
+        {
+            var projectRoot = Path.GetFullPath(GetProjectFolderPath(project.ProjectKey));
+            var fullPath = Path.GetFullPath(targetPath);
+            if (!fullPath.StartsWith(projectRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Đường dẫn không hợp lệ.");
+            }
+
+            return fullPath;
+        }
+
+        private static string CombineRelativePaths(string basePath, string? append)
+        {
+            if (string.IsNullOrEmpty(basePath))
+            {
+                return append ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(append))
+            {
+                return basePath;
+            }
+
+            return $"{basePath.TrimEnd('/')}/{append.TrimStart('/')}";
+        }
+
+        private IReadOnlyList<NpiBreadcrumbItem> BuildBreadcrumbs(NpiProjectMetadata project, string relativePath)
+        {
+            var breadcrumbs = new List<NpiBreadcrumbItem>
+            {
+                new() { Title = project.Name, RelativePath = string.Empty }
+            };
+
+            if (string.IsNullOrEmpty(relativePath))
+            {
+                return breadcrumbs;
+            }
+
+            var parts = relativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            var current = string.Empty;
+            foreach (var part in parts)
+            {
+                current = CombineRelativePaths(current, part);
+                breadcrumbs.Add(new NpiBreadcrumbItem
+                {
+                    Title = part,
+                    RelativePath = current
+                });
+            }
+
+            return breadcrumbs;
+        }
+
+        private async Task<IReadOnlyList<NpiDocumentViewModel>> LoadDocumentsAsync(string folderPath, string relativePath)
+        {
+            var metadataPath = Path.Combine(folderPath, DocumentMetadataFileName);
+            var documents = await ReadDocumentsInternalAsync(metadataPath);
+
+            return documents
+                .OrderBy(d => d.OriginalName, StringComparer.OrdinalIgnoreCase)
+                .ThenByDescending(d => d.Version)
+                .Select(d => new NpiDocumentViewModel
+                {
+                    Id = d.Id,
+                    DisplayName = d.OriginalName,
+                    Version = d.Version,
+                    UploadedAt = d.UploadedAt,
+                    UploadedBy = d.UploadedBy,
+                    StoredFileName = d.StoredFileName,
+                    RelativePath = relativePath
+                })
+                .ToList();
+        }
+
+        private static async Task<List<NpiDocumentMetadata>> ReadDocumentsInternalAsync(string metadataPath)
+        {
+            if (!File.Exists(metadataPath))
+            {
+                return new List<NpiDocumentMetadata>();
+            }
+
+            await using var stream = File.OpenRead(metadataPath);
+            return await JsonSerializer.DeserializeAsync<List<NpiDocumentMetadata>>(stream, JsonOptions) ?? new List<NpiDocumentMetadata>();
+        }
+
+        private static async Task WriteDocumentsInternalAsync(string metadataPath, List<NpiDocumentMetadata> documents)
+        {
+            await using var stream = File.Create(metadataPath);
+            await JsonSerializer.SerializeAsync(stream, documents, JsonOptions);
+        }
+    }
+}

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -8,7 +8,7 @@
 <div class="container-fluid py-4">
     <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
         <h2 class="mb-0">NPI Document</h2>
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal" data-npi-trigger="open-create-modal">
             Tạo project mới
         </button>
     </div>
@@ -36,7 +36,7 @@
                     <span class="fw-semibold">Danh sách project</span>
                     <span class="badge bg-secondary">@Model.Projects.Count</span>
                 </div>
-                <div class="list-group list-group-flush">
+                <div class="list-group list-group-flush" data-npi-project-list>
                     @if (!Model.Projects.Any())
                     {
                         <div class="list-group-item text-muted">Chưa có project nào.</div>
@@ -48,7 +48,8 @@
                             var isActive = Model.SelectedProject?.Project.ProjectKey == project.ProjectKey;
                             <a class="list-group-item list-group-item-action @(isActive ? "active" : string.Empty)"
                                asp-action="Index"
-                               asp-route-projectKey="@project.ProjectKey">
+                               asp-route-projectKey="@project.ProjectKey"
+                               data-npi-link="project">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
                                         <div class="fw-semibold">@project.Name</div>
@@ -97,7 +98,11 @@
                 <div class="card shadow-sm mb-4">
                     <div class="card-header fw-semibold">Tải tài liệu lên</div>
                     <div class="card-body">
-                        <form asp-action="UploadDocument" method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
+                        <form asp-action="UploadDocument"
+                              method="post"
+                              enctype="multipart/form-data"
+                              class="row g-3 align-items-end"
+                              data-npi-form="upload-document">
                             @Html.AntiForgeryToken()
                             <input type="hidden" name="projectKey" value="@projectDetail.Project.ProjectKey" />
                             <input type="hidden" name="path" value="@projectDetail.RelativePath" />
@@ -129,7 +134,8 @@
                                 <a class="list-group-item list-group-item-action"
                                    asp-action="Index"
                                    asp-route-projectKey="@projectDetail.Project.ProjectKey"
-                                   asp-route-path="@folder.RelativePath">
+                                   asp-route-path="@folder.RelativePath"
+                                   data-npi-link="folder">
                                     <span class="me-2">📁</span>@folder.Name
                                 </a>
                             }
@@ -175,8 +181,11 @@
                                                        asp-route-path="@document.RelativePath">
                                                         Tải xuống
                                                     </a>
-                                                    <form asp-action="DeleteDocument" method="post" class="d-inline"
-                                                          onsubmit="return confirm('Bạn có chắc chắn muốn xoá tài liệu này?');">
+                                                    <form asp-action="DeleteDocument"
+                                                          method="post"
+                                                          class="d-inline"
+                                                          data-npi-form="delete-document"
+                                                          data-confirm-message="Bạn có chắc chắn muốn xoá tài liệu này?">
                                                         @Html.AntiForgeryToken()
                                                         <input type="hidden" name="projectKey" value="@projectDetail.Project.ProjectKey" />
                                                         <input type="hidden" name="documentId" value="@document.Id" />
@@ -215,7 +224,7 @@
                 <h5 class="modal-title" id="createProjectLabel">Tạo project mới</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
             </div>
-            <form asp-action="CreateProject" method="post">
+            <form asp-action="CreateProject" method="post" data-npi-form="create-project">
                 @Html.AntiForgeryToken()
                 <div class="modal-body">
                     <div class="mb-3">
@@ -241,6 +250,7 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/assets/Areas/NPI/js/npi.js" asp-append-version="true"></script>
     @if (ViewBag.ShowCreateModal == true)
     {
         <script>

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,0 +1,256 @@
+@model NpiIndexViewModel
+@using System.Linq
+@{
+    ViewData["Title"] = "NPI Document";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container-fluid py-4">
+    <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+        <h2 class="mb-0">NPI Document</h2>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+            Tạo project mới
+        </button>
+    </div>
+
+    @if (ViewData["ErrorMessage"] is string errorMessage)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @errorMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (ViewData["SuccessMessage"] is string successMessage)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @successMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <div class="row g-4">
+        <div class="col-lg-4 col-xl-3">
+            <div class="card h-100 shadow-sm">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold">Danh sách project</span>
+                    <span class="badge bg-secondary">@Model.Projects.Count</span>
+                </div>
+                <div class="list-group list-group-flush">
+                    @if (!Model.Projects.Any())
+                    {
+                        <div class="list-group-item text-muted">Chưa có project nào.</div>
+                    }
+                    else
+                    {
+                        foreach (var project in Model.Projects)
+                        {
+                            var isActive = Model.SelectedProject?.Project.ProjectKey == project.ProjectKey;
+                            <a class="list-group-item list-group-item-action @(isActive ? "active" : string.Empty)"
+                               asp-action="Index"
+                               asp-route-projectKey="@project.ProjectKey">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <div class="fw-semibold">@project.Name</div>
+                                        <div class="small text-muted">Owner: @project.Owner</div>
+                                    </div>
+                                    <span class="text-muted">›</span>
+                                </div>
+                            </a>
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8 col-xl-9">
+            @if (Model.SelectedProject is { } projectDetail)
+            {
+                <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+                    <div>
+                        <nav aria-label="breadcrumb">
+                            <ol class="breadcrumb mb-0">
+                                @foreach (var crumb in projectDetail.Breadcrumbs)
+                                {
+                                    var isLast = crumb == projectDetail.Breadcrumbs.Last();
+                                    if (isLast)
+                                    {
+                                        <li class="breadcrumb-item active" aria-current="page">@crumb.Title</li>
+                                    }
+                                    else
+                                    {
+                                        <li class="breadcrumb-item">
+                                            <a asp-action="Index"
+                                               asp-route-projectKey="@projectDetail.Project.ProjectKey"
+                                               asp-route-path="@crumb.RelativePath">@crumb.Title</a>
+                                        </li>
+                                    }
+                                }
+                            </ol>
+                        </nav>
+                        <div class="text-muted small mt-1">
+                            Owner: <strong>@projectDetail.Project.Owner</strong> ·
+                            Tạo ngày: @projectDetail.Project.CreatedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card shadow-sm mb-4">
+                    <div class="card-header fw-semibold">Tải tài liệu lên</div>
+                    <div class="card-body">
+                        <form asp-action="UploadDocument" method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="projectKey" value="@projectDetail.Project.ProjectKey" />
+                            <input type="hidden" name="path" value="@projectDetail.RelativePath" />
+                            <div class="col-md-8">
+                                <label for="file" class="form-label">Chọn tài liệu</label>
+                                <input class="form-control" type="file" id="file" name="file" required />
+                            </div>
+                            <div class="col-md-4 text-md-end">
+                                <button type="submit" class="btn btn-success w-100">
+                                    Tải lên
+                                </button>
+                            </div>
+                        </form>
+                        <div class="form-text mt-2">Hệ thống tự động đánh version dựa trên số lần cập nhật.</div>
+                    </div>
+                </div>
+
+                <div class="card shadow-sm mb-4">
+                    <div class="card-header fw-semibold">Thư mục</div>
+                    <div class="list-group list-group-flush">
+                        @if (!projectDetail.Folders.Any())
+                        {
+                            <div class="list-group-item text-muted">Không có thư mục con.</div>
+                        }
+                        else
+                        {
+                            foreach (var folder in projectDetail.Folders)
+                            {
+                                <a class="list-group-item list-group-item-action"
+                                   asp-action="Index"
+                                   asp-route-projectKey="@projectDetail.Project.ProjectKey"
+                                   asp-route-path="@folder.RelativePath">
+                                    <span class="me-2">📁</span>@folder.Name
+                                </a>
+                            }
+                        }
+                    </div>
+                </div>
+
+                <div class="card shadow-sm">
+                    <div class="card-header fw-semibold">Tài liệu</div>
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0 align-middle">
+                            <thead class="table-light">
+                                <tr>
+                                    <th scope="col">Tên tài liệu</th>
+                                    <th scope="col" class="text-center">Version</th>
+                                    <th scope="col">Người cập nhật</th>
+                                    <th scope="col">Ngày cập nhật</th>
+                                    <th scope="col" class="text-end">Thao tác</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @if (!projectDetail.Documents.Any())
+                                {
+                                    <tr>
+                                        <td colspan="5" class="text-center text-muted py-4">Chưa có tài liệu nào trong thư mục này.</td>
+                                    </tr>
+                                }
+                                else
+                                {
+                                    foreach (var document in projectDetail.Documents)
+                                    {
+                                        <tr>
+                                            <td>@document.DisplayName</td>
+                                            <td class="text-center">v@document.Version.ToString("000")</td>
+                                            <td>@document.UploadedBy</td>
+                                            <td>@document.UploadedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                            <td class="text-end">
+                                                <div class="btn-group" role="group">
+                                                    <a class="btn btn-outline-primary btn-sm"
+                                                       asp-action="DownloadDocument"
+                                                       asp-route-projectKey="@projectDetail.Project.ProjectKey"
+                                                       asp-route-documentId="@document.Id"
+                                                       asp-route-path="@document.RelativePath">
+                                                        Tải xuống
+                                                    </a>
+                                                    <form asp-action="DeleteDocument" method="post" class="d-inline"
+                                                          onsubmit="return confirm('Bạn có chắc chắn muốn xoá tài liệu này?');">
+                                                        @Html.AntiForgeryToken()
+                                                        <input type="hidden" name="projectKey" value="@projectDetail.Project.ProjectKey" />
+                                                        <input type="hidden" name="documentId" value="@document.Id" />
+                                                        <input type="hidden" name="path" value="@document.RelativePath" />
+                                                        <button type="submit" class="btn btn-outline-danger btn-sm">
+                                                            Xoá
+                                                        </button>
+                                                    </form>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    }
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="card shadow-sm h-100">
+                    <div class="card-body d-flex flex-column justify-content-center align-items-center text-center text-muted">
+                        <div class="display-4 mb-3">📂</div>
+                        <p class="mb-0">Hãy chọn một project ở bên trái để xem và quản lý tài liệu.</p>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="createProjectModal" tabindex="-1" aria-labelledby="createProjectLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="createProjectLabel">Tạo project mới</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+            </div>
+            <form asp-action="CreateProject" method="post">
+                @Html.AntiForgeryToken()
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label asp-for="CreateProject.Name" class="form-label"></label>
+                        <input asp-for="CreateProject.Name" class="form-control" />
+                        <span asp-validation-for="CreateProject.Name" class="text-danger"></span>
+                    </div>
+                    <div class="mb-3">
+                        <label asp-for="CreateProject.Owner" class="form-label"></label>
+                        <input asp-for="CreateProject.Owner" class="form-control" />
+                        <span asp-validation-for="CreateProject.Owner" class="text-danger"></span>
+                    </div>
+                    <div class="form-text">Sau khi tạo, hệ thống tự động sinh các thư mục chuẩn cho project.</div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Huỷ</button>
+                    <button type="submit" class="btn btn-primary">Tạo project</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    @if (ViewBag.ShowCreateModal == true)
+    {
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var modalEl = document.getElementById('createProjectModal');
+                if (modalEl) {
+                    var modal = new bootstrap.Modal(modalEl);
+                    modal.show();
+                }
+            });
+        </script>
+    }
+}

--- a/PESystem/Areas/NPI/Views/_ViewImports.cshtml
+++ b/PESystem/Areas/NPI/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using PESystem.Areas.NPI.Models
+@using PESystem.Areas.NPI.Models.ViewModels
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/PESystem/Program.cs
+++ b/PESystem/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using PESystem.Areas.NPI.Services;
 using PESystem.Models;
 using PESystem.Policies;
 
@@ -31,6 +32,8 @@ builder.Services.AddHttpClient("ApiClient", client =>
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(configuration.GetConnectionString("cnn")));
 
+builder.Services.AddSingleton<NpiDocumentService>();
+
 // ---- Authorization theo Area ----
 builder.Services.AddSingleton<IAuthorizationHandler, AreaAccessHandler>();
 builder.Services.AddAuthorization(options =>
@@ -44,7 +47,7 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("CheckListAccess", p => p.Requirements.Add(new AreaAccessRequirement("CheckList")));
     options.AddPolicy("ScrapAccess", p => p.Requirements.Add(new AreaAccessRequirement("Scrap")));
     options.AddPolicy("MaterialSystemAccess", p => p.Requirements.Add(new AreaAccessRequirement("MaterialSystem")));
-    options.AddPolicy("NpiAccess", p => p.Requirements.Add(new AreaAccessRequirement("Npi")));
+    options.AddPolicy("NpiAccess", p => p.Requirements.Add(new AreaAccessRequirement("NPI")));
 });
 
 builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();

--- a/PESystem/Views/Shared/_Layout.cshtml
+++ b/PESystem/Views/Shared/_Layout.cshtml
@@ -90,6 +90,7 @@
         </main>
     </div>
 
+    <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/js/site.min.js?v=@DateTime.Now.Ticks"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/lib/all-fa-icon/js/all.min.js"></script>

--- a/PESystem/mvc_appsettings.Development.json
+++ b/PESystem/mvc_appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ApiBaseUrl": "http://10.220.130.119:9090"
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }

--- a/PESystem/mvc_appsettings.json
+++ b/PESystem/mvc_appsettings.json
@@ -8,6 +8,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  ,"ApiBaseUrl": "http://10.220.130.119:9090"
+  "AllowedHosts": "*",
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }

--- a/PESystem/wwwroot/assets/Areas/NPI/js/npi.js
+++ b/PESystem/wwwroot/assets/Areas/NPI/js/npi.js
@@ -1,0 +1,235 @@
+(function () {
+    const SELECTORS = {
+        ajaxForm: '[data-npi-form]',
+        createForm: '[data-npi-form="create-project"]',
+        uploadForm: '[data-npi-form="upload-document"]',
+        deleteForm: '[data-npi-form="delete-document"]',
+        navLinks: '[data-npi-link]'
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        setupAjaxForms();
+        setupNavigationFeedback();
+    });
+
+    function setupAjaxForms() {
+        const forms = document.querySelectorAll(SELECTORS.ajaxForm);
+        forms.forEach(form => {
+            if (form.dataset.npiAjaxBound === 'true') {
+                return;
+            }
+
+            const type = form.dataset.npiForm;
+            const options = buildOptions(type, form);
+
+            if (!options) {
+                return;
+            }
+
+            form.addEventListener('submit', event => handleSubmit(event, form, options));
+            form.dataset.npiAjaxBound = 'true';
+        });
+    }
+
+    function buildOptions(type, form) {
+        switch (type) {
+            case 'create-project':
+                return {
+                    onSuccess: data => redirectOrReload(data),
+                    onValidation: errors => ensureModalVisible('createProjectModal'),
+                    errorMessage: 'Không thể tạo project. Vui lòng thử lại.',
+                    busyText: 'Đang tạo...'
+                };
+            case 'upload-document':
+                return {
+                    onSuccess: data => redirectOrReload(data),
+                    onValidation: () => { /* nothing */ },
+                    errorMessage: 'Không thể tải tài liệu lên. Vui lòng thử lại.',
+                    busyText: 'Đang tải...'
+                };
+            case 'delete-document':
+                return {
+                    beforeSubmit: () => confirmDeletion(form),
+                    onSuccess: data => redirectOrReload(data),
+                    errorMessage: 'Không thể xoá tài liệu. Vui lòng thử lại.',
+                    busyText: 'Đang xoá...'
+                };
+            default:
+                return null;
+        }
+    }
+
+    async function handleSubmit(event, form, options) {
+        if (form.dataset.npiAjaxDisabled === 'true') {
+            return;
+        }
+
+        if (options.beforeSubmit && options.beforeSubmit() === false) {
+            event.preventDefault();
+            return;
+        }
+
+        event.preventDefault();
+        clearValidationErrors(form);
+        toggleSubmitState(form, true, options.busyText);
+        showSpinnerSafe();
+
+        try {
+            const response = await fetch(form.action, {
+                method: (form.method || 'post').toUpperCase(),
+                body: new FormData(form),
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            });
+
+            const data = await parseJsonSafe(response);
+
+            if (response.ok) {
+                if (options.onSuccess) {
+                    options.onSuccess(data);
+                }
+                return;
+            }
+
+            if (response.status === 400 && data && data.errors) {
+                applyValidationErrors(form, data.errors);
+                if (options.onValidation) {
+                    options.onValidation(data.errors);
+                }
+                return;
+            }
+
+            handleErrorResponse(data, options.errorMessage);
+        } catch (error) {
+            console.error('NPI AJAX submission failed. Falling back to standard post.', error);
+            form.dataset.npiAjaxDisabled = 'true';
+            setTimeout(() => form.submit(), 0);
+        } finally {
+            hideSpinnerSafe();
+            toggleSubmitState(form, false);
+        }
+    }
+
+    function confirmDeletion(form) {
+        const message = form.dataset.confirmMessage || 'Bạn có chắc chắn muốn xoá tài liệu này?';
+        return window.confirm(message);
+    }
+
+    function redirectOrReload(payload) {
+        if (payload && payload.redirectUrl) {
+            window.location.href = payload.redirectUrl;
+        } else {
+            window.location.reload();
+        }
+    }
+
+    function parseJsonSafe(response) {
+        const contentType = response.headers.get('content-type');
+        if (contentType && contentType.includes('application/json')) {
+            return response.json();
+        }
+        return Promise.resolve({});
+    }
+
+    function applyValidationErrors(form, errors) {
+        Object.keys(errors).forEach(key => {
+            const messages = errors[key];
+            if (!Array.isArray(messages) || messages.length === 0) {
+                return;
+            }
+
+            const field = findField(form, key);
+            const message = messages[0];
+
+            if (field) {
+                field.classList.add('is-invalid');
+            }
+
+            const span = form.querySelector(`[data-valmsg-for="${CSS.escape(key)}"]`);
+            if (span) {
+                span.classList.remove('field-validation-valid');
+                span.classList.add('field-validation-error');
+                span.textContent = message;
+            }
+        });
+    }
+
+    function clearValidationErrors(form) {
+        const invalidInputs = form.querySelectorAll('.is-invalid');
+        invalidInputs.forEach(input => input.classList.remove('is-invalid'));
+
+        const validationSpans = form.querySelectorAll('[data-valmsg-for]');
+        validationSpans.forEach(span => {
+            span.classList.add('field-validation-valid');
+            span.classList.remove('field-validation-error');
+            span.textContent = '';
+        });
+    }
+
+    function findField(form, key) {
+        const name = key.replace(/^CreateProject\./, '').replace(/^model\./i, '');
+        return form.querySelector(`[name="${CSS.escape(name)}"]`);
+    }
+
+    function toggleSubmitState(form, isBusy, busyText) {
+        const submit = form.querySelector('[type="submit"]');
+        if (!submit) {
+            return;
+        }
+
+        if (isBusy) {
+            submit.disabled = true;
+            submit.dataset.originalText = submit.textContent;
+            if (busyText) {
+                submit.textContent = busyText;
+            }
+        } else {
+            submit.disabled = false;
+            if (submit.dataset.originalText) {
+                submit.textContent = submit.dataset.originalText;
+                delete submit.dataset.originalText;
+            }
+        }
+    }
+
+    function ensureModalVisible(modalId) {
+        const modalElement = document.getElementById(modalId);
+        if (!modalElement) {
+            return;
+        }
+
+        const modalInstance = bootstrap.Modal.getOrCreateInstance(modalElement);
+        modalInstance.show();
+    }
+
+    function handleErrorResponse(data, fallbackMessage) {
+        const message = (data && (data.error || data.message)) || fallbackMessage || 'Đã xảy ra lỗi không xác định.';
+        if (typeof showError === 'function') {
+            showError(message);
+        } else {
+            alert(message);
+        }
+    }
+
+    function setupNavigationFeedback() {
+        const links = document.querySelectorAll(SELECTORS.navLinks);
+        links.forEach(link => {
+            link.addEventListener('click', () => {
+                showSpinnerSafe();
+            });
+        });
+    }
+
+    function showSpinnerSafe() {
+        if (typeof showSpinner === 'function') {
+            showSpinner();
+        }
+    }
+
+    function hideSpinnerSafe() {
+        if (typeof hideSpinner === 'function') {
+            hideSpinner();
+        }
+    }
+})();


### PR DESCRIPTION
## Summary
- add a dedicated NPI area with controllers, views, and view models to manage project-specific documents
- implement a document service that provisions the required folder structure, tracks metadata, and handles upload, download, and delete actions with versioning
- configure the NPI document root path and register the new service and authorization policy updates in the application startup

## Testing
- dotnet build *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68f0f10896d88326b58190cbeaa0c745