### PR TITLE
Add NPI document management area

### DIFF
--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PESystem.Areas.NPI.Models;
+using PESystem.Areas.NPI.Services;
+
+namespace PESystem.Areas.NPI.Controllers;
+
+[Area("NPI")]
+[Authorize(Policy = "NpiAccess")]
+public class HomeController : Controller
+{
+    private readonly INpiDocumentService _documentService;
+
+    public HomeController(INpiDocumentService documentService)
+    {
+        _documentService = documentService;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var model = new NpiProjectIndexViewModel
+        {
+            Projects = await _documentService.GetProjectsAsync(),
+            NewProject = new NpiProjectInputModel(),
+            StatusMessage = TempData["StatusMessage"] as string,
+            ErrorMessage = TempData["ErrorMessage"] as string
+        };
+
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(NpiProjectInputModel input)
+    {
+        if (!ModelState.IsValid)
+        {
+            var model = new NpiProjectIndexViewModel
+            {
+                Projects = await _documentService.GetProjectsAsync(),
+                NewProject = input,
+                StatusMessage = TempData["StatusMessage"] as string,
+                ErrorMessage = TempData["ErrorMessage"] as string
+            };
+
+            return View("Index", model);
+        }
+
+        try
+        {
+            var project = await _documentService.CreateProjectAsync(input.Name, input.Owner);
+            TempData["StatusMessage"] = $"Project '{project.Name}' created successfully.";
+            return RedirectToAction(nameof(Details), new { id = project.Id });
+        }
+        catch (Exception ex)
+        {
+            TempData["ErrorMessage"] = ex.Message;
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    public async Task<IActionResult> Details(Guid id)
+    {
+        var project = await _documentService.GetProjectAsync(id);
+        if (project == null)
+        {
+            return NotFound();
+        }
+
+        var documents = await _documentService.GetDocumentsAsync(id);
+        var structure = _documentService.GetStructure();
+
+        var categories = structure
+            .Select(category => new NpiCategoryViewModel
+            {
+                Name = category.Name,
+                Items = category.Items
+                    .Select(item => new NpiItemViewModel
+                    {
+                        Name = item,
+                        Documents = documents
+                            .Where(d => string.Equals(d.Category, category.Name, StringComparison.OrdinalIgnoreCase)
+                                        && string.Equals(d.Item, item, StringComparison.OrdinalIgnoreCase))
+                            .OrderByDescending(d => d.UploadedAt)
+                            .ThenByDescending(d => d.Version)
+                            .ToList()
+                    })
+                    .ToList()
+            })
+            .ToList();
+
+        var model = new NpiProjectDetailViewModel
+        {
+            Project = project,
+            Categories = categories,
+            Upload = new NpiUploadInputModel
+            {
+                ProjectId = id,
+                UploadedBy = User?.Identity?.Name ?? string.Empty
+            },
+            StatusMessage = TempData["StatusMessage"] as string,
+            ErrorMessage = TempData["ErrorMessage"] as string
+        };
+
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Upload(NpiUploadInputModel input)
+    {
+        if (!ModelState.IsValid)
+        {
+            TempData["ErrorMessage"] = "Please provide all required information for the upload.";
+            return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+        }
+
+        if (input.File == null || input.File.Length == 0)
+        {
+            TempData["ErrorMessage"] = "The selected file is empty.";
+            return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+        }
+
+        try
+        {
+            await _documentService.UploadDocumentAsync(input.ProjectId, input.Category, input.Item, input.File, input.UploadedBy);
+            TempData["StatusMessage"] = $"Document '{input.File.FileName}' uploaded successfully.";
+        }
+        catch (Exception ex)
+        {
+            TempData["ErrorMessage"] = ex.Message;
+        }
+
+        return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteDocument(Guid projectId, Guid documentId)
+    {
+        var deleted = await _documentService.DeleteDocumentAsync(projectId, documentId);
+        TempData[deleted ? "StatusMessage" : "ErrorMessage"] = deleted
+            ? "Document deleted successfully."
+            : "Unable to delete the selected document.";
+
+        return RedirectToAction(nameof(Details), new { id = projectId });
+    }
+
+    public async Task<IActionResult> Download(Guid projectId, Guid documentId)
+    {
+        var (record, filePath) = await _documentService.GetDocumentFileAsync(projectId, documentId);
+        if (record == null || string.IsNullOrEmpty(filePath) || !System.IO.File.Exists(filePath))
+        {
+            return NotFound();
+        }
+
+        var contentType = GetContentType(record.OriginalFileName);
+        return PhysicalFile(filePath, contentType, record.OriginalFileName);
+    }
+
+    private static string GetContentType(string fileName)
+    {
+        var extension = System.IO.Path.GetExtension(fileName)?.ToLowerInvariant();
+        return extension switch
+        {
+            ".pdf" => "application/pdf",
+            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".xls" => "application/vnd.ms-excel",
+            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ".doc" => "application/msword",
+            ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ".ppt" => "application/vnd.ms-powerpoint",
+            ".txt" => "text/plain",
+            ".csv" => "text/csv",
+            _ => "application/octet-stream"
+        };
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiCategoryDefinition.cs
+++ b/PESystem/Areas/NPI/Models/NpiCategoryDefinition.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiCategoryDefinition
+{
+    public string Name { get; init; } = string.Empty;
+    public IReadOnlyList<string> Items { get; init; } = new List<string>();
+}

--- a/PESystem/Areas/NPI/Models/NpiDocumentRecord.cs
+++ b/PESystem/Areas/NPI/Models/NpiDocumentRecord.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiDocumentRecord
+{
+    public Guid Id { get; set; }
+    public string OriginalFileName { get; set; } = string.Empty;
+    public string StoredFileName { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Item { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string UploadedBy { get; set; } = string.Empty;
+    public DateTime UploadedAt { get; set; }
+}

--- a/PESystem/Areas/NPI/Models/NpiProject.cs
+++ b/PESystem/Areas/NPI/Models/NpiProject.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiProject
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Owner { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectDetailViewModel.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectDetailViewModel.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiProjectDetailViewModel
+{
+    public NpiProject Project { get; set; } = new();
+    public IReadOnlyList<NpiCategoryViewModel> Categories { get; set; } = new List<NpiCategoryViewModel>();
+    public NpiUploadInputModel Upload { get; set; } = new();
+    public string? StatusMessage { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+public class NpiCategoryViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public IReadOnlyList<NpiItemViewModel> Items { get; set; } = new List<NpiItemViewModel>();
+}
+
+public class NpiItemViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public IReadOnlyList<NpiDocumentRecord> Documents { get; set; } = new List<NpiDocumentRecord>();
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectIndexViewModel.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectIndexViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiProjectIndexViewModel
+{
+    public IReadOnlyList<NpiProject> Projects { get; set; } = new List<NpiProject>();
+    public NpiProjectInputModel NewProject { get; set; } = new();
+    public string? StatusMessage { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectInputModel.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectInputModel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiProjectInputModel
+{
+    [Required]
+    [StringLength(150)]
+    [Display(Name = "Project name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(150)]
+    [Display(Name = "Owner")]
+    public string Owner { get; set; } = string.Empty;
+}

--- a/PESystem/Areas/NPI/Models/NpiUploadInputModel.cs
+++ b/PESystem/Areas/NPI/Models/NpiUploadInputModel.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+
+namespace PESystem.Areas.NPI.Models;
+
+public class NpiUploadInputModel
+{
+    [Required]
+    public Guid ProjectId { get; set; }
+
+    [Required]
+    public string Category { get; set; } = string.Empty;
+
+    [Required]
+    public string Item { get; set; } = string.Empty;
+
+    [Required]
+    [Display(Name = "Document")]
+    public IFormFile? File { get; set; }
+
+    [Required]
+    [StringLength(150)]
+    [Display(Name = "Updated by")]
+    public string UploadedBy { get; set; } = string.Empty;
+}

--- a/PESystem/Areas/NPI/Services/INpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/INpiDocumentService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using PESystem.Areas.NPI.Models;
+
+namespace PESystem.Areas.NPI.Services;
+
+public interface INpiDocumentService
+{
+    IReadOnlyList<NpiCategoryDefinition> GetStructure();
+    Task<IReadOnlyList<NpiProject>> GetProjectsAsync();
+    Task<NpiProject?> GetProjectAsync(Guid projectId);
+    Task<NpiProject> CreateProjectAsync(string name, string owner);
+    Task<IReadOnlyList<NpiDocumentRecord>> GetDocumentsAsync(Guid projectId);
+    Task<NpiDocumentRecord?> GetDocumentAsync(Guid projectId, Guid documentId);
+    Task<(NpiDocumentRecord? Record, string? FilePath)> GetDocumentFileAsync(Guid projectId, Guid documentId);
+    Task<NpiDocumentRecord> UploadDocumentAsync(Guid projectId, string category, string item, IFormFile file, string uploadedBy);
+    Task<bool> DeleteDocumentAsync(Guid projectId, Guid documentId);
+}

--- a/PESystem/Areas/NPI/Services/NpiDocumentOptions.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentOptions.cs
@@ -1,0 +1,6 @@
+namespace PESystem.Areas.NPI.Services;
+
+public class NpiDocumentOptions
+{
+    public string RootPath { get; set; } = @"D:\\NpiDocument";
+}

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -1,0 +1,456 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using PESystem.Areas.NPI.Models;
+
+namespace PESystem.Areas.NPI.Services;
+
+public class NpiDocumentService : INpiDocumentService
+{
+    private const string ProjectMetadataFile = "project.json";
+    private const string DocumentMetadataFile = "documents.json";
+
+    private readonly NpiDocumentOptions _options;
+    private readonly string _rootPath;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+    private readonly IReadOnlyList<NpiCategoryDefinition> _structure;
+    private readonly SemaphoreSlim _sync = new(1, 1);
+
+    public NpiDocumentService(IOptions<NpiDocumentOptions> options)
+    {
+        _options = options.Value;
+        _rootPath = ResolveRootPath(_options.RootPath);
+        Directory.CreateDirectory(_rootPath);
+        _structure = BuildStructure();
+    }
+
+    public IReadOnlyList<NpiCategoryDefinition> GetStructure() => _structure;
+
+    public async Task<IReadOnlyList<NpiProject>> GetProjectsAsync()
+    {
+        var result = new List<NpiProject>();
+        foreach (var directory in Directory.Exists(_rootPath)
+            ? Directory.EnumerateDirectories(_rootPath)
+            : Enumerable.Empty<string>())
+        {
+            var projectPath = Path.Combine(directory, ProjectMetadataFile);
+            if (!File.Exists(projectPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                await using var stream = File.OpenRead(projectPath);
+                var project = await JsonSerializer.DeserializeAsync<NpiProject>(stream, _jsonOptions);
+                if (project != null)
+                {
+                    result.Add(project);
+                }
+            }
+            catch
+            {
+                // Ignore corrupted project metadata but keep iterating.
+            }
+        }
+
+        return result
+            .OrderByDescending(p => p.CreatedAt)
+            .ThenBy(p => p.Name)
+            .ToList();
+    }
+
+    public async Task<NpiProject?> GetProjectAsync(Guid projectId)
+    {
+        var (project, _) = await GetProjectInternalAsync(projectId);
+        return project;
+    }
+
+    public async Task<NpiProject> CreateProjectAsync(string name, string owner)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Project name is required", nameof(name));
+        }
+
+        if (string.IsNullOrWhiteSpace(owner))
+        {
+            throw new ArgumentException("Owner is required", nameof(owner));
+        }
+
+        await _sync.WaitAsync();
+        try
+        {
+            var project = new NpiProject
+            {
+                Id = Guid.NewGuid(),
+                Name = name.Trim(),
+                Owner = owner.Trim(),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var existing = await GetProjectsAsync();
+            if (existing.Any(p => string.Equals(p.Name, project.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException($"A project named '{project.Name}' already exists.");
+            }
+
+            var directoryName = $"{DateTime.UtcNow:yyyyMMddHHmmss}_{SanitizePathSegment(project.Name)}_{project.Id}";
+            var projectDirectory = Path.Combine(_rootPath, directoryName);
+            Directory.CreateDirectory(projectDirectory);
+
+            foreach (var category in _structure)
+            {
+                var categoryPath = Path.Combine(projectDirectory, SanitizePathSegment(category.Name));
+                Directory.CreateDirectory(categoryPath);
+
+                foreach (var item in category.Items)
+                {
+                    var itemPath = Path.Combine(categoryPath, SanitizePathSegment(item));
+                    Directory.CreateDirectory(itemPath);
+                }
+            }
+
+            var projectMetadataPath = Path.Combine(projectDirectory, ProjectMetadataFile);
+            await using (var stream = File.Create(projectMetadataPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, project, _jsonOptions);
+            }
+
+            var documentsPath = Path.Combine(projectDirectory, DocumentMetadataFile);
+            await using (var stream = File.Create(documentsPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, new List<NpiDocumentRecord>(), _jsonOptions);
+            }
+
+            return project;
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<NpiDocumentRecord>> GetDocumentsAsync(Guid projectId)
+    {
+        var (_, projectDirectory) = await GetProjectInternalAsync(projectId);
+        if (projectDirectory == null)
+        {
+            return Array.Empty<NpiDocumentRecord>();
+        }
+
+        return await ReadDocumentsAsync(projectDirectory);
+    }
+
+    public async Task<NpiDocumentRecord?> GetDocumentAsync(Guid projectId, Guid documentId)
+    {
+        var documents = await GetDocumentsAsync(projectId);
+        return documents.FirstOrDefault(d => d.Id == documentId);
+    }
+
+    public async Task<(NpiDocumentRecord? Record, string? FilePath)> GetDocumentFileAsync(Guid projectId, Guid documentId)
+    {
+        var (_, projectDirectory) = await GetProjectInternalAsync(projectId);
+        if (projectDirectory == null)
+        {
+            return (null, null);
+        }
+
+        var documents = await ReadDocumentsAsync(projectDirectory);
+        var record = documents.FirstOrDefault(d => d.Id == documentId);
+        if (record == null)
+        {
+            return (null, null);
+        }
+
+        var safeCategory = SanitizePathSegment(record.Category);
+        var safeItem = SanitizePathSegment(record.Item);
+        var filePath = Path.Combine(projectDirectory, safeCategory, safeItem, record.StoredFileName);
+        return (record, filePath);
+    }
+
+    public async Task<NpiDocumentRecord> UploadDocumentAsync(Guid projectId, string category, string item, IFormFile file, string uploadedBy)
+    {
+        if (file == null)
+        {
+            throw new ArgumentNullException(nameof(file));
+        }
+
+        if (string.IsNullOrWhiteSpace(category))
+        {
+            throw new ArgumentException("Category is required", nameof(category));
+        }
+
+        if (string.IsNullOrWhiteSpace(item))
+        {
+            throw new ArgumentException("Item is required", nameof(item));
+        }
+
+        if (string.IsNullOrWhiteSpace(uploadedBy))
+        {
+            throw new ArgumentException("Uploader is required", nameof(uploadedBy));
+        }
+
+        var (project, projectDirectory) = await GetProjectInternalAsync(projectId);
+        if (project == null || projectDirectory == null)
+        {
+            throw new InvalidOperationException("Project not found");
+        }
+
+        var safeCategory = SanitizePathSegment(category);
+        var safeItem = SanitizePathSegment(item);
+        var destinationDirectory = Path.Combine(projectDirectory, safeCategory, safeItem);
+        Directory.CreateDirectory(destinationDirectory);
+
+        var documents = await ReadDocumentsAsync(projectDirectory);
+        var originalName = Path.GetFileName(file.FileName);
+        var relatedDocuments = documents
+            .Where(d => string.Equals(d.Category, category, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(d.Item, item, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(d.OriginalFileName, originalName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var version = relatedDocuments.Any() ? relatedDocuments.Max(d => d.Version) + 1 : 1;
+        var record = new NpiDocumentRecord
+        {
+            Id = Guid.NewGuid(),
+            Category = category.Trim(),
+            Item = item.Trim(),
+            OriginalFileName = originalName,
+            StoredFileName = $"{Guid.NewGuid()}{Path.GetExtension(originalName)}",
+            UploadedBy = uploadedBy.Trim(),
+            UploadedAt = DateTime.UtcNow,
+            Version = version
+        };
+
+        var destinationFilePath = Path.Combine(destinationDirectory, record.StoredFileName);
+        await using (var destinationStream = File.Create(destinationFilePath))
+        {
+            await file.CopyToAsync(destinationStream);
+        }
+
+        documents.Add(record);
+        await WriteDocumentsAsync(projectDirectory, documents);
+
+        return record;
+    }
+
+    public async Task<bool> DeleteDocumentAsync(Guid projectId, Guid documentId)
+    {
+        var (_, projectDirectory) = await GetProjectInternalAsync(projectId);
+        if (projectDirectory == null)
+        {
+            return false;
+        }
+
+        var documents = await ReadDocumentsAsync(projectDirectory);
+        var record = documents.FirstOrDefault(d => d.Id == documentId);
+        if (record == null)
+        {
+            return false;
+        }
+
+        var safeCategory = SanitizePathSegment(record.Category);
+        var safeItem = SanitizePathSegment(record.Item);
+        var filePath = Path.Combine(projectDirectory, safeCategory, safeItem, record.StoredFileName);
+
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+
+        documents.Remove(record);
+        await WriteDocumentsAsync(projectDirectory, documents);
+
+        return true;
+    }
+
+    private async Task<(NpiProject? Project, string? Directory)> GetProjectInternalAsync(Guid projectId)
+    {
+        foreach (var directory in Directory.Exists(_rootPath)
+            ? Directory.EnumerateDirectories(_rootPath)
+            : Enumerable.Empty<string>())
+        {
+            var projectPath = Path.Combine(directory, ProjectMetadataFile);
+            if (!File.Exists(projectPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                await using var stream = File.OpenRead(projectPath);
+                var project = await JsonSerializer.DeserializeAsync<NpiProject>(stream, _jsonOptions);
+                if (project != null && project.Id == projectId)
+                {
+                    return (project, directory);
+                }
+            }
+            catch
+            {
+                // ignore malformed metadata
+            }
+        }
+
+        return (null, null);
+    }
+
+    private async Task<List<NpiDocumentRecord>> ReadDocumentsAsync(string projectDirectory)
+    {
+        var documentsPath = Path.Combine(projectDirectory, DocumentMetadataFile);
+        if (!File.Exists(documentsPath))
+        {
+            return new List<NpiDocumentRecord>();
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(documentsPath);
+            var documents = await JsonSerializer.DeserializeAsync<List<NpiDocumentRecord>>(stream, _jsonOptions);
+            return documents ?? new List<NpiDocumentRecord>();
+        }
+        catch
+        {
+            return new List<NpiDocumentRecord>();
+        }
+    }
+
+    private async Task WriteDocumentsAsync(string projectDirectory, List<NpiDocumentRecord> documents)
+    {
+        var documentsPath = Path.Combine(projectDirectory, DocumentMetadataFile);
+        await using var stream = File.Create(documentsPath);
+        await JsonSerializer.SerializeAsync(stream, documents, _jsonOptions);
+    }
+
+    private static string SanitizePathSegment(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "General";
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string(value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
+        return cleaned.Trim().Length == 0 ? "General" : cleaned.Trim();
+    }
+
+    private static string ResolveRootPath(string? configuredPath)
+    {
+        var path = string.IsNullOrWhiteSpace(configuredPath) ? @"D:\\NpiDocument" : configuredPath;
+        return Path.GetFullPath(path);
+    }
+
+    private static IReadOnlyList<NpiCategoryDefinition> BuildStructure()
+        => new List<NpiCategoryDefinition>
+        {
+            new()
+            {
+                Name = "BOM",
+                Items = new List<string>
+                {
+                    "NPI BOM",
+                    "BOM Map",
+                    "PCB layout"
+                }
+            },
+            new()
+            {
+                Name = "Document instruction",
+                Items = new List<string>
+                {
+                    "ASSY + Packing instruction",
+                    "Label instruction"
+                }
+            },
+            new()
+            {
+                Name = "Manufacturing process",
+                Items = new List<string>
+                {
+                    "Route from NV",
+                    "Sampling in foxconn + SFC",
+                    "SOP route NV",
+                    "OPV data"
+                }
+            },
+            new()
+            {
+                Name = "Key component",
+                Items = new List<string>
+                {
+                    "OPV data"
+                }
+            },
+            new()
+            {
+                Name = "SOP NPI",
+                Items = new List<string>
+                {
+                    "SOP polarity",
+                    "EPAD location",
+                    "ESD location"
+                }
+            },
+            new()
+            {
+                Name = "Config NPI",
+                Items = new List<string>
+                {
+                    "Config 27 for BI process",
+                    "LCR config",
+                    "PMP"
+                }
+            },
+            new()
+            {
+                Name = "DFX",
+                Items = new List<string>
+                {
+                    "PFMEA",
+                    "PMP"
+                }
+            },
+            new()
+            {
+                Name = "Production plan",
+                Items = new List<string>
+                {
+                    "DEV + status",
+                    "YR everyday (tracker)",
+                    "YR report",
+                    "YR report for each build (engineer report)"
+                }
+            },
+            new()
+            {
+                Name = "Cook book",
+                Items = new List<string>
+                {
+                    "Cook book",
+                    "Picture SFG + FG",
+                    "Picture AOI",
+                    "Picture SMT",
+                    "Profile SMT",
+                    "Profile SFG"
+                }
+            },
+            new()
+            {
+                Name = "YR 1st MP",
+                Items = new List<string>
+                {
+                    "Only test station (engineer report)"
+                }
+            }
+        };
+}

--- a/PESystem/Areas/NPI/Views/Home/Details.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Details.cshtml
@@ -1,0 +1,116 @@
+@model NpiProjectDetailViewModel
+@{
+    ViewData["Title"] = Model.Project.Name;
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h2 class="mb-1">@Model.Project.Name</h2>
+            <p class="text-muted mb-0">Owner: <strong>@Model.Project.Owner</strong> · Created: @Model.Project.CreatedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</p>
+        </div>
+        <a asp-action="Index" class="btn btn-outline-secondary">Back to projects</a>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+    {
+        <div class="alert alert-success" role="alert">@Model.StatusMessage</div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+    }
+
+    <div class="accordion" id="documentAccordion">
+        @for (var categoryIndex = 0; categoryIndex < Model.Categories.Count; categoryIndex++)
+        {
+            var category = Model.Categories[categoryIndex];
+            var collapseId = $"category-{categoryIndex}";
+            <div class="accordion-item mb-3">
+                <h2 class="accordion-header" id="heading-@collapseId">
+                    <button class="accordion-button @((categoryIndex == 0 ? "" : "collapsed"))" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-@collapseId" aria-expanded="@(categoryIndex == 0)" aria-controls="collapse-@collapseId">
+                        @category.Name
+                    </button>
+                </h2>
+                <div id="collapse-@collapseId" class="accordion-collapse collapse @(categoryIndex == 0 ? "show" : string.Empty)" aria-labelledby="heading-@collapseId" data-bs-parent="#documentAccordion">
+                    <div class="accordion-body">
+                        @for (var itemIndex = 0; itemIndex < category.Items.Count; itemIndex++)
+                        {
+                            var item = category.Items[itemIndex];
+                            var controlId = $"cat{categoryIndex}-item{itemIndex}";
+                            <div class="card mb-4 shadow-sm">
+                                <div class="card-header d-flex justify-content-between align-items-center">
+                                    <h5 class="mb-0">@item.Name</h5>
+                                </div>
+                                <div class="card-body">
+                                    <form asp-action="Upload" method="post" enctype="multipart/form-data" class="row gy-2 gx-3 align-items-end mb-3">
+                                        <input type="hidden" name="ProjectId" value="@Model.Project.Id" />
+                                        <input type="hidden" name="Category" value="@category.Name" />
+                                        <input type="hidden" name="Item" value="@item.Name" />
+                                        <div class="col-md-5">
+                                            <label class="form-label" for="file-@controlId">Upload document</label>
+                                            <input type="file" class="form-control" id="file-@controlId" name="File" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label class="form-label" for="uploadedBy-@controlId">Updated by</label>
+                                            <input class="form-control" id="uploadedBy-@controlId" name="UploadedBy" value="@Model.Upload.UploadedBy" />
+                                        </div>
+                                        <div class="col-md-3 d-grid">
+                                            <button type="submit" class="btn btn-primary">Upload</button>
+                                        </div>
+                                    </form>
+
+                                    @if (item.Documents.Count > 0)
+                                    {
+                                        <div class="table-responsive">
+                                            <table class="table table-hover mb-0">
+                                                <thead class="table-light">
+                                                    <tr>
+                                                        <th scope="col">Document</th>
+                                                        <th scope="col">Version</th>
+                                                        <th scope="col">Updated at</th>
+                                                        <th scope="col">Updated by</th>
+                                                        <th scope="col" class="text-end">Actions</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                @foreach (var document in item.Documents)
+                                                {
+                                                    <tr>
+                                                        <td>@document.OriginalFileName</td>
+                                                        <td>v@document.Version</td>
+                                                        <td>@document.UploadedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                                        <td>@document.UploadedBy</td>
+                                                        <td class="text-end">
+                                                            <a asp-action="Download" asp-route-projectId="@Model.Project.Id" asp-route-documentId="@document.Id" class="btn btn-sm btn-outline-primary me-2">Download</a>
+                                                            <form asp-action="DeleteDocument" method="post" class="d-inline">
+                                                                <input type="hidden" name="projectId" value="@Model.Project.Id" />
+                                                                <input type="hidden" name="documentId" value="@document.Id" />
+                                                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this document?');">Delete</button>
+                                                            </form>
+                                                        </td>
+                                                    </tr>
+                                                }
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <p class="text-muted mb-0">No documents uploaded yet.</p>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,0 +1,94 @@
+@model NpiProjectIndexViewModel
+@{
+    ViewData["Title"] = "NPI Document";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h2 class="mb-0">NPI Document Projects</h2>
+            <p class="text-muted mb-0">Manage all NPI document repositories from a single place.</p>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+    {
+        <div class="alert alert-success" role="alert">@Model.StatusMessage</div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+    }
+
+    <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
+            <strong>Create a new NPI project</strong>
+        </div>
+        <div class="card-body">
+            <form asp-action="Create" method="post" class="row g-3">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="col-md-6">
+                    <label asp-for="NewProject.Name" class="form-label"></label>
+                    <input asp-for="NewProject.Name" class="form-control" placeholder="Project name" />
+                    <span asp-validation-for="NewProject.Name" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="NewProject.Owner" class="form-label"></label>
+                    <input asp-for="NewProject.Owner" class="form-control" placeholder="Owner" />
+                    <span asp-validation-for="NewProject.Owner" class="text-danger"></span>
+                </div>
+                <div class="col-12 d-flex justify-content-end">
+                    <button type="submit" class="btn btn-primary">Create project</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header bg-light">
+            <strong>Existing projects</strong>
+        </div>
+        <div class="card-body p-0">
+            @if (Model.Projects.Count > 0)
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Name</th>
+                                <th scope="col">Owner</th>
+                                <th scope="col">Created</th>
+                                <th scope="col" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var project in Model.Projects)
+                        {
+                            <tr>
+                                <td>@project.Name</td>
+                                <td>@project.Owner</td>
+                                <td>@project.CreatedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                <td class="text-end">
+                                    <a asp-action="Details" asp-route-id="@project.Id" class="btn btn-sm btn-outline-primary">Open</a>
+                                </td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="p-4">
+                    <p class="mb-0 text-muted">No projects have been created yet. Use the form above to create the first one.</p>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/PESystem/Areas/NPI/Views/_ViewImports.cshtml
+++ b/PESystem/Areas/NPI/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using PESystem.Areas.NPI.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/PESystem/Program.cs
+++ b/PESystem/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using PESystem.Areas.NPI.Services;
 using PESystem.Models;
 using PESystem.Policies;
 
@@ -15,6 +16,8 @@ var configuration = new ConfigurationBuilder()
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllersWithViews();
+builder.Services.Configure<NpiDocumentOptions>(configuration.GetSection("NpiDocument"));
+builder.Services.AddScoped<INpiDocumentService, NpiDocumentService>();
 
 // ---- HttpClient: gộp làm 1, vừa có BaseAddress vừa bypass proxy ----
 builder.Services.AddHttpClient("ApiClient", client =>

--- a/PESystem/mvc_appsettings.Development.json
+++ b/PESystem/mvc_appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ApiBaseUrl": "http://10.220.130.119:9090"
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }

--- a/PESystem/mvc_appsettings.json
+++ b/PESystem/mvc_appsettings.json
@@ -8,6 +8,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  ,"ApiBaseUrl": "http://10.220.130.119:9090"
+  "AllowedHosts": "*",
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }


### PR DESCRIPTION
## Summary
- add an NPI area with controllers, views, and models to manage project creation and document lifecycles
- implement a filesystem-backed document service that provisions the required folder structure and tracks versions/metadata
- expose configuration for the NPI document root path and wire the service into the application startup

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68f5f8daafc483269d86cb5df061d2ad