### PR TITLE
Add NPI document management area

### DIFF
--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,0 +1,201 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PESystem.Areas.NPI.Models;
+using PESystem.Services;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PESystem.Areas.NPI.Controllers
+{
+    [Area("NPI")]
+    [Authorize(Policy = "NPIAccess")]
+    public class HomeController : Controller
+    {
+        private readonly INpiDocumentService _documentService;
+        private readonly ILogger<HomeController> _logger;
+
+        public HomeController(INpiDocumentService documentService, ILogger<HomeController> logger)
+        {
+            _documentService = documentService;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(CancellationToken cancellationToken)
+        {
+            var projects = await _documentService.GetProjectsAsync(cancellationToken);
+            var viewModel = new NpiHomeIndexViewModel
+            {
+                Projects = projects.ToList(),
+                NewProject = new CreateNpiProjectViewModel()
+            };
+
+            return View(viewModel);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreateProject(CreateNpiProjectViewModel model, CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+            {
+                var projects = await _documentService.GetProjectsAsync(cancellationToken);
+                var vm = new NpiHomeIndexViewModel { Projects = projects.ToList(), NewProject = model };
+                return View("Index", vm);
+            }
+
+            try
+            {
+                var project = await _documentService.CreateProjectAsync(model.Name, model.Owner, cancellationToken);
+                TempData["Success"] = $"Project '{project.Name}' was created successfully.";
+                return RedirectToAction(nameof(Details), new { id = project.Id });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create NPI project {Name}", model.Name);
+                ModelState.AddModelError(string.Empty, "Không thể tạo project mới. Vui lòng thử lại sau.");
+                var projects = await _documentService.GetProjectsAsync(cancellationToken);
+                var vm = new NpiHomeIndexViewModel { Projects = projects.ToList(), NewProject = model };
+                return View("Index", vm);
+            }
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Details(Guid id, CancellationToken cancellationToken)
+        {
+            var detail = await _documentService.GetProjectDetailAsync(id, cancellationToken);
+            if (detail == null)
+            {
+                return NotFound();
+            }
+
+            var defaultCategory = _documentService.FolderTemplates.FirstOrDefault();
+            var defaultItem = defaultCategory?.Items.FirstOrDefault();
+
+            var viewModel = new NpiProjectDetailsViewModel
+            {
+                Project = detail.Project,
+                Documents = detail.Documents,
+                UploadModel = new UploadNpiDocumentViewModel
+                {
+                    ProjectId = detail.Project.Id,
+                    Category = defaultCategory?.Category ?? string.Empty,
+                    Item = defaultItem?.Name ?? string.Empty,
+                    DocumentName = string.Empty
+                },
+                Structure = _documentService.FolderTemplates
+            };
+
+            if (TempData.TryGetValue("Error", out var errorMessage))
+            {
+                ViewData["Error"] = errorMessage;
+            }
+
+            if (TempData.TryGetValue("Success", out var successMessage))
+            {
+                ViewData["Success"] = successMessage;
+            }
+
+            return View(viewModel);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> UploadDocument(UploadNpiDocumentViewModel model, CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+            {
+                TempData["Error"] = "Vui lòng kiểm tra lại thông tin tài liệu.";
+                return RedirectToAction(nameof(Details), new { id = model.ProjectId });
+            }
+
+            if (model.File == null || model.File.Length == 0)
+            {
+                TempData["Error"] = "Vui lòng chọn file cần upload.";
+                return RedirectToAction(nameof(Details), new { id = model.ProjectId });
+            }
+
+            try
+            {
+                var uploadedBy = GetDisplayName();
+                var document = await _documentService.UploadDocumentAsync(
+                    model.ProjectId,
+                    model.Category,
+                    model.Item,
+                    model.DocumentName,
+                    model.File,
+                    uploadedBy,
+                    cancellationToken);
+
+                if (document == null)
+                {
+                    TempData["Error"] = "Project không tồn tại.";
+                }
+                else
+                {
+                    TempData["Success"] = $"Upload tài liệu '{document.DocumentName}' thành công.";
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to upload document for project {ProjectId}", model.ProjectId);
+                TempData["Error"] = "Không thể upload tài liệu. Vui lòng thử lại.";
+            }
+
+            return RedirectToAction(nameof(Details), new { id = model.ProjectId });
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Download(Guid projectId, Guid documentId, Guid versionId, CancellationToken cancellationToken)
+        {
+            var fileResult = await _documentService.GetDocumentFileAsync(projectId, documentId, versionId, cancellationToken);
+            if (fileResult == null)
+            {
+                return NotFound();
+            }
+
+            var stream = System.IO.File.OpenRead(fileResult.PhysicalPath);
+            return File(stream, fileResult.ContentType, fileResult.OriginalFileName);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteVersion(Guid projectId, Guid documentId, Guid versionId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var deleted = await _documentService.DeleteVersionAsync(projectId, documentId, versionId, cancellationToken);
+                TempData[deleted ? "Success" : "Error"] = deleted
+                    ? "Xóa tài liệu thành công."
+                    : "Không tìm thấy tài liệu để xóa.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete document version {VersionId} from project {ProjectId}", versionId, projectId);
+                TempData["Error"] = "Không thể xóa tài liệu. Vui lòng thử lại.";
+            }
+
+            return RedirectToAction(nameof(Details), new { id = projectId });
+        }
+
+        private string GetDisplayName()
+        {
+            var fullName = User.FindFirst("FullName")?.Value;
+            if (!string.IsNullOrWhiteSpace(fullName))
+            {
+                return fullName;
+            }
+
+            var email = User.FindFirst(ClaimTypes.Email)?.Value;
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                return email;
+            }
+
+            return User.Identity?.Name ?? "Unknown";
+        }
+    }
+}

--- a/PESystem/Areas/NPI/Models/CreateNpiProjectViewModel.cs
+++ b/PESystem/Areas/NPI/Models/CreateNpiProjectViewModel.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class CreateNpiProjectViewModel
+    {
+        [Required]
+        [Display(Name = "Project name")]
+        [StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [Display(Name = "Owner")]
+        [StringLength(200)]
+        public string Owner { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiHomeIndexViewModel.cs
+++ b/PESystem/Areas/NPI/Models/NpiHomeIndexViewModel.cs
@@ -1,0 +1,11 @@
+using PESystem.Services;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiHomeIndexViewModel
+    {
+        public List<NpiProjectSummary> Projects { get; set; } = new();
+
+        public CreateNpiProjectViewModel NewProject { get; set; } = new();
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectDetailsViewModel.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectDetailsViewModel.cs
@@ -1,0 +1,15 @@
+using PESystem.Services;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiProjectDetailsViewModel
+    {
+        public NpiProjectSummary Project { get; set; } = new();
+
+        public List<NpiDocumentRecord> Documents { get; set; } = new();
+
+        public UploadNpiDocumentViewModel UploadModel { get; set; } = new();
+
+        public IReadOnlyList<NpiFolderTemplate> Structure { get; set; } = Array.Empty<NpiFolderTemplate>();
+    }
+}

--- a/PESystem/Areas/NPI/Models/UploadNpiDocumentViewModel.cs
+++ b/PESystem/Areas/NPI/Models/UploadNpiDocumentViewModel.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class UploadNpiDocumentViewModel
+    {
+        [Required]
+        public Guid ProjectId { get; set; }
+
+        [Required]
+        [Display(Name = "Category")]
+        public string Category { get; set; } = string.Empty;
+
+        [Required]
+        [Display(Name = "Folder")]
+        public string Item { get; set; } = string.Empty;
+
+        [Required]
+        [Display(Name = "Document name")]
+        [StringLength(200)]
+        public string DocumentName { get; set; } = string.Empty;
+
+        [Required]
+        [Display(Name = "File")]
+        public IFormFile? File { get; set; }
+    }
+}

--- a/PESystem/Areas/NPI/Views/Home/Details.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Details.cshtml
@@ -1,0 +1,234 @@
+@using System.Linq
+@model PESystem.Areas.NPI.Models.NpiProjectDetailsViewModel
+@{
+    ViewData["Title"] = Model.Project.Name;
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+@functions {
+    string FormatSize(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return $"{bytes} B";
+        }
+
+        var kb = bytes / 1024d;
+        if (kb < 1024)
+        {
+            return $"{kb:0.##} KB";
+        }
+
+        var mb = kb / 1024d;
+        if (mb < 1024)
+        {
+            return $"{mb:0.##} MB";
+        }
+
+        var gb = mb / 1024d;
+        return $"{gb:0.##} GB";
+    }
+}
+
+<div class="container py-4">
+    <div class="mb-3">
+        <a asp-action="Index" class="text-decoration-none">&larr; Back to project list</a>
+    </div>
+
+    <div class="d-flex flex-column flex-lg-row gap-3 mb-4">
+        <div class="card flex-fill shadow-sm">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-start mb-3">
+                    <div>
+                        <h2 class="card-title mb-1">@Model.Project.Name</h2>
+                        <p class="text-muted mb-0">Owner: <strong>@Model.Project.Owner</strong></p>
+                    </div>
+                    <span class="badge bg-primary">@Model.Project.DocumentCount tài liệu</span>
+                </div>
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Ngày tạo</dt>
+                    <dd class="col-sm-8">@Model.Project.CreatedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</dd>
+                </dl>
+            </div>
+        </div>
+
+        <div class="card shadow-sm" style="min-width: 320px;">
+            <div class="card-header bg-white">
+                <strong>Upload tài liệu</strong>
+            </div>
+            <div class="card-body">
+                <form asp-action="UploadDocument" method="post" enctype="multipart/form-data" class="row g-3">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" asp-for="UploadModel.ProjectId" />
+                    <div class="col-12">
+                        <label asp-for="UploadModel.Category" class="form-label"></label>
+                        <select asp-for="UploadModel.Category" class="form-select" id="categorySelect">
+                            @foreach (var category in Model.Structure)
+                            {
+                                <option value="@category.Category" @(category.Category == Model.UploadModel.Category ? "selected" : null)>@category.Category</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-12">
+                        <label asp-for="UploadModel.Item" class="form-label"></label>
+                        <select asp-for="UploadModel.Item" class="form-select" id="itemSelect">
+                            @foreach (var category in Model.Structure)
+                            {
+                                foreach (var item in category.Items)
+                                {
+                                    var selected = category.Category == Model.UploadModel.Category && item.Name == Model.UploadModel.Item;
+                                    <option value="@item.Name" data-category="@category.Category" @(selected ? "selected" : null)>@item.Name</option>
+                                }
+                            }
+                        </select>
+                    </div>
+                    <div class="col-12">
+                        <label asp-for="UploadModel.DocumentName" class="form-label"></label>
+                        <input asp-for="UploadModel.DocumentName" class="form-control" placeholder="Tên tài liệu" />
+                        <span asp-validation-for="UploadModel.DocumentName" class="text-danger"></span>
+                    </div>
+                    <div class="col-12">
+                        <label asp-for="UploadModel.File" class="form-label"></label>
+                        <input asp-for="UploadModel.File" class="form-control" type="file" />
+                        <span asp-validation-for="UploadModel.File" class="text-danger"></span>
+                    </div>
+                    <div class="col-12 text-end">
+                        <button type="submit" class="btn btn-primary">Upload</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    @if (ViewData["Error"] is string errorMessage && !string.IsNullOrWhiteSpace(errorMessage))
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @errorMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (ViewData["Success"] is string successMessage && !string.IsNullOrWhiteSpace(successMessage))
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @successMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @foreach (var category in Model.Structure)
+    {
+        <div class="card shadow-sm mb-4">
+            <div class="card-header bg-white">
+                <strong>@category.Category</strong>
+            </div>
+            <div class="card-body">
+                @foreach (var item in category.Items)
+                {
+                    var documents = Model.Documents
+                        .Where(d => string.Equals(d.Category, category.Category, StringComparison.OrdinalIgnoreCase) &&
+                                    string.Equals(d.Item, item.Name, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+
+                    <div class="mb-4">
+                        <h5 class="mb-3">@item.Name</h5>
+                        @if (documents.Any())
+                        {
+                            <div class="table-responsive">
+                                <table class="table table-striped table-hover align-middle">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th scope="col">Document</th>
+                                            <th scope="col" class="text-center">Version</th>
+                                            <th scope="col">Uploaded at</th>
+                                            <th scope="col">Uploaded by</th>
+                                            <th scope="col" class="text-end">Size</th>
+                                            <th scope="col" class="text-end">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var document in documents.OrderBy(d => d.DocumentName))
+                                        {
+                                            foreach (var version in document.Versions)
+                                            {
+                                                <tr>
+                                                    <td>@document.DocumentName</td>
+                                                    <td class="text-center">v@version.VersionNumber</td>
+                                                    <td>@version.UploadedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                                    <td>@version.UploadedBy</td>
+                                                    <td class="text-end">@FormatSize(version.FileSize)</td>
+                                                    <td class="text-end">
+                                                        <div class="btn-group" role="group">
+                                                            <a class="btn btn-sm btn-outline-success" asp-action="Download" asp-route-projectId="@Model.Project.Id" asp-route-documentId="@document.DocumentId" asp-route-versionId="@version.VersionId">Download</a>
+                                                            <form asp-action="DeleteVersion" method="post" class="d-inline delete-version-form ms-1">
+                                                                @Html.AntiForgeryToken()
+                                                                <input type="hidden" name="projectId" value="@Model.Project.Id" />
+                                                                <input type="hidden" name="documentId" value="@document.DocumentId" />
+                                                                <input type="hidden" name="versionId" value="@version.VersionId" />
+                                                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                                            </form>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            }
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="text-muted fst-italic">Chưa có tài liệu nào.</div>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script>
+        (function () {
+            const categorySelect = document.getElementById('categorySelect');
+            const itemSelect = document.getElementById('itemSelect');
+
+            function filterItems() {
+                if (!categorySelect || !itemSelect) {
+                    return;
+                }
+
+                const selectedCategory = categorySelect.value;
+                let firstVisible = null;
+                Array.from(itemSelect.options).forEach(option => {
+                    const match = option.dataset.category === selectedCategory;
+                    option.hidden = !match;
+                    if (match && firstVisible === null) {
+                        firstVisible = option;
+                    }
+                    if (!match && option.selected) {
+                        option.selected = false;
+                    }
+                });
+
+                if (firstVisible && !Array.from(itemSelect.options).some(o => o.selected && !o.hidden)) {
+                    firstVisible.selected = true;
+                }
+            }
+
+            if (categorySelect && itemSelect) {
+                categorySelect.addEventListener('change', filterItems);
+                filterItems();
+            }
+
+            document.querySelectorAll('.delete-version-form').forEach(form => {
+                form.addEventListener('submit', function (event) {
+                    if (!confirm('Bạn có chắc chắn muốn xóa tài liệu này?')) {
+                        event.preventDefault();
+                    }
+                });
+            });
+        })();
+    </script>
+}

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,0 +1,89 @@
+@using System.Linq
+@model PESystem.Areas.NPI.Models.NpiHomeIndexViewModel
+@{
+    ViewData["Title"] = "NPI Document";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2 class="mb-0">NPI Document projects</h2>
+        <a class="btn btn-outline-secondary" asp-action="Index">Refresh</a>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-white">
+            <strong>Create new project</strong>
+        </div>
+        <div class="card-body">
+            <form asp-action="CreateProject" method="post" class="row g-3">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="col-md-6">
+                    <label asp-for="NewProject.Name" class="form-label"></label>
+                    <input asp-for="NewProject.Name" class="form-control" placeholder="Project name" />
+                    <span asp-validation-for="NewProject.Name" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="NewProject.Owner" class="form-label"></label>
+                    <input asp-for="NewProject.Owner" class="form-control" placeholder="Owner" />
+                    <span asp-validation-for="NewProject.Owner" class="text-danger"></span>
+                </div>
+                <div class="col-12 text-end">
+                    <button type="submit" class="btn btn-primary">Create project</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-header bg-white d-flex justify-content-between align-items-center">
+            <strong>Existing projects</strong>
+            <span class="badge bg-light text-dark">@Model.Projects.Count project(s)</span>
+        </div>
+        <div class="card-body p-0">
+            @if (Model.Projects.Any())
+            {
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Project</th>
+                                <th scope="col">Owner</th>
+                                <th scope="col">Created</th>
+                                <th scope="col" class="text-center">Documents</th>
+                                <th scope="col" class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var project in Model.Projects.OrderByDescending(p => p.CreatedAt))
+                            {
+                                <tr>
+                                    <td>
+                                        <a asp-action="Details" asp-route-id="@project.Id" class="fw-semibold text-decoration-none">@project.Name</a>
+                                    </td>
+                                    <td>@project.Owner</td>
+                                    <td>@project.CreatedAt.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                    <td class="text-center">@project.DocumentCount</td>
+                                    <td class="text-end">
+                                        <a asp-action="Details" asp-route-id="@project.Id" class="btn btn-sm btn-outline-primary">Open</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="p-4 text-center text-muted">
+                    Chưa có project nào. Hãy tạo project mới để bắt đầu quản lý tài liệu NPI.
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/PESystem/Options/NpiDocumentOptions.cs
+++ b/PESystem/Options/NpiDocumentOptions.cs
@@ -1,0 +1,7 @@
+namespace PESystem.Options
+{
+    public class NpiDocumentOptions
+    {
+        public string RootPath { get; set; } = @"D:\\NpiDocument";
+    }
+}

--- a/PESystem/Program.cs
+++ b/PESystem/Program.cs
@@ -4,7 +4,9 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PESystem.Models;
+using PESystem.Options;
 using PESystem.Policies;
+using PESystem.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +17,9 @@ var configuration = new ConfigurationBuilder()
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllersWithViews();
+
+builder.Services.Configure<NpiDocumentOptions>(configuration.GetSection("NpiDocument"));
+builder.Services.AddSingleton<INpiDocumentService, NpiDocumentService>();
 
 // ---- HttpClient: gộp làm 1, vừa có BaseAddress vừa bypass proxy ----
 builder.Services.AddHttpClient("ApiClient", client =>
@@ -45,6 +50,7 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("ScrapAccess", p => p.Requirements.Add(new AreaAccessRequirement("Scrap")));
     options.AddPolicy("MaterialSystemAccess", p => p.Requirements.Add(new AreaAccessRequirement("MaterialSystem")));
     options.AddPolicy("SFCAccess", p => p.Requirements.Add(new AreaAccessRequirement("SFC")));
+    options.AddPolicy("NPIAccess", p => p.Requirements.Add(new AreaAccessRequirement("NPI")));
 });
 
 builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();

--- a/PESystem/Services/INpiDocumentService.cs
+++ b/PESystem/Services/INpiDocumentService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace PESystem.Services
+{
+    public interface INpiDocumentService
+    {
+        IReadOnlyList<NpiFolderTemplate> FolderTemplates { get; }
+
+        Task<IReadOnlyList<NpiProjectSummary>> GetProjectsAsync(CancellationToken cancellationToken = default);
+
+        Task<NpiProjectSummary> CreateProjectAsync(string name, string owner, CancellationToken cancellationToken = default);
+
+        Task<NpiProjectDetail?> GetProjectDetailAsync(Guid projectId, CancellationToken cancellationToken = default);
+
+        Task<NpiDocumentRecord?> UploadDocumentAsync(
+            Guid projectId,
+            string category,
+            string item,
+            string documentName,
+            IFormFile file,
+            string uploadedBy,
+            CancellationToken cancellationToken = default);
+
+        Task<NpiDocumentFileResult?> GetDocumentFileAsync(Guid projectId, Guid documentId, Guid versionId, CancellationToken cancellationToken = default);
+
+        Task<bool> DeleteVersionAsync(Guid projectId, Guid documentId, Guid versionId, CancellationToken cancellationToken = default);
+    }
+}

--- a/PESystem/Services/NpiDocumentModels.cs
+++ b/PESystem/Services/NpiDocumentModels.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace PESystem.Services
+{
+    public record NpiFolderTemplate(string Category, string CategoryFolderName, IReadOnlyList<NpiFolderItem> Items);
+
+    public record NpiFolderItem(string Name, string FolderName);
+
+    public class NpiProjectSummary
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public string FolderName { get; set; } = string.Empty;
+        public int DocumentCount { get; set; }
+    }
+
+    public class NpiProjectDetail
+    {
+        public NpiProjectSummary Project { get; set; } = new();
+        public List<NpiDocumentRecord> Documents { get; set; } = new();
+    }
+
+    public class NpiDocumentRecord
+    {
+        public Guid DocumentId { get; set; }
+        public string DocumentName { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+        public string CategoryFolder { get; set; } = string.Empty;
+        public string Item { get; set; } = string.Empty;
+        public string ItemFolder { get; set; } = string.Empty;
+        public List<NpiDocumentVersionRecord> Versions { get; set; } = new();
+    }
+
+    public class NpiDocumentVersionRecord
+    {
+        public Guid VersionId { get; set; }
+        public int VersionNumber { get; set; }
+        public string StoredFileName { get; set; } = string.Empty;
+        public string OriginalFileName { get; set; } = string.Empty;
+        public long FileSize { get; set; }
+        public DateTime UploadedAt { get; set; }
+        public string UploadedBy { get; set; } = string.Empty;
+    }
+
+    public class NpiDocumentFileResult
+    {
+        public string PhysicalPath { get; set; } = string.Empty;
+        public string OriginalFileName { get; set; } = string.Empty;
+        public string ContentType { get; set; } = "application/octet-stream";
+    }
+}

--- a/PESystem/Services/NpiDocumentService.cs
+++ b/PESystem/Services/NpiDocumentService.cs
@@ -1,0 +1,525 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Options;
+using PESystem.Options;
+
+namespace PESystem.Services
+{
+    public class NpiDocumentService : INpiDocumentService
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true
+        };
+
+        private readonly SemaphoreSlim _syncLock = new(1, 1);
+        private readonly ILogger<NpiDocumentService> _logger;
+        private readonly string _rootPath;
+        private readonly IReadOnlyList<NpiFolderTemplate> _templates;
+        private readonly FileExtensionContentTypeProvider _contentTypeProvider = new();
+
+        public IReadOnlyList<NpiFolderTemplate> FolderTemplates => _templates;
+
+        private string ProjectsStorePath => Path.Combine(_rootPath, "projects.json");
+
+        public NpiDocumentService(IOptions<NpiDocumentOptions> options, ILogger<NpiDocumentService> logger)
+        {
+            _logger = logger;
+            _rootPath = string.IsNullOrWhiteSpace(options.Value.RootPath)
+                ? @"D:\\NpiDocument"
+                : options.Value.RootPath;
+
+            Directory.CreateDirectory(_rootPath);
+            _templates = BuildTemplates();
+        }
+
+        public async Task<IReadOnlyList<NpiProjectSummary>> GetProjectsAsync(CancellationToken cancellationToken = default)
+        {
+            await _syncLock.WaitAsync(cancellationToken);
+            try
+            {
+                var store = await LoadProjectStoreAsync(cancellationToken).ConfigureAwait(false);
+                return store.Projects
+                    .OrderByDescending(p => p.CreatedAt)
+                    .Select(CloneSummary)
+                    .ToList();
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public async Task<NpiProjectSummary> CreateProjectAsync(string name, string owner, CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+            owner ??= string.Empty;
+
+            await _syncLock.WaitAsync(cancellationToken);
+            try
+            {
+                var store = await LoadProjectStoreAsync(cancellationToken).ConfigureAwait(false);
+                if (store.Projects.Any(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new InvalidOperationException($"Project '{name}' already exists.");
+                }
+
+                var folderName = GenerateFolderName(name, store.Projects.Select(p => p.FolderName));
+                var projectSummary = new NpiProjectSummary
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name.Trim(),
+                    Owner = owner.Trim(),
+                    CreatedAt = DateTime.UtcNow,
+                    FolderName = folderName,
+                    DocumentCount = 0
+                };
+
+                var projectPath = GetProjectPath(projectSummary);
+                Directory.CreateDirectory(projectPath);
+                foreach (var category in _templates)
+                {
+                    var categoryPath = Path.Combine(projectPath, category.CategoryFolderName);
+                    Directory.CreateDirectory(categoryPath);
+                    foreach (var item in category.Items)
+                    {
+                        Directory.CreateDirectory(Path.Combine(categoryPath, item.FolderName));
+                    }
+                }
+
+                var manifest = new ManifestStore();
+                await SaveManifestAsync(projectSummary, manifest, cancellationToken).ConfigureAwait(false);
+
+                store.Projects.Add(projectSummary);
+                await SaveProjectStoreAsync(store, cancellationToken).ConfigureAwait(false);
+
+                return CloneSummary(projectSummary);
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public async Task<NpiProjectDetail?> GetProjectDetailAsync(Guid projectId, CancellationToken cancellationToken = default)
+        {
+            await _syncLock.WaitAsync(cancellationToken);
+            try
+            {
+                var store = await LoadProjectStoreAsync(cancellationToken).ConfigureAwait(false);
+                var project = store.Projects.FirstOrDefault(p => p.Id == projectId);
+                if (project == null)
+                {
+                    return null;
+                }
+
+                var manifest = await LoadManifestAsync(project, cancellationToken).ConfigureAwait(false);
+                var detail = new NpiProjectDetail
+                {
+                    Project = CloneSummary(project),
+                    Documents = manifest.Documents
+                        .Select(CloneDocument)
+                        .OrderBy(d => d.Category)
+                        .ThenBy(d => d.Item)
+                        .ThenBy(d => d.DocumentName)
+                        .ToList()
+                };
+
+                return detail;
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public async Task<NpiDocumentRecord?> UploadDocumentAsync(
+            Guid projectId,
+            string category,
+            string item,
+            string documentName,
+            IFormFile file,
+            string uploadedBy,
+            CancellationToken cancellationToken = default)
+        {
+            if (file == null || file.Length == 0)
+            {
+                throw new ArgumentException("File is required", nameof(file));
+            }
+
+            await _syncLock.WaitAsync(cancellationToken);
+            try
+            {
+                var store = await LoadProjectStoreAsync(cancellationToken).ConfigureAwait(false);
+                var project = store.Projects.FirstOrDefault(p => p.Id == projectId);
+                if (project == null)
+                {
+                    return null;
+                }
+
+                var template = _templates.FirstOrDefault(t => string.Equals(t.Category, category, StringComparison.OrdinalIgnoreCase));
+                if (template == null)
+                {
+                    throw new InvalidOperationException($"Category '{category}' is not defined in the template.");
+                }
+
+                var templateItem = template.Items.FirstOrDefault(i => string.Equals(i.Name, item, StringComparison.OrdinalIgnoreCase));
+                if (templateItem == null)
+                {
+                    throw new InvalidOperationException($"Item '{item}' is not defined in the template.");
+                }
+
+                var manifest = await LoadManifestAsync(project, cancellationToken).ConfigureAwait(false);
+                var displayName = string.IsNullOrWhiteSpace(documentName)
+                    ? Path.GetFileNameWithoutExtension(file.FileName)
+                    : documentName.Trim();
+
+                var document = manifest.Documents.FirstOrDefault(d =>
+                    string.Equals(d.Category, template.Category, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(d.Item, templateItem.Name, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(d.DocumentName, displayName, StringComparison.OrdinalIgnoreCase));
+
+                if (document == null)
+                {
+                    document = new NpiDocumentRecord
+                    {
+                        DocumentId = Guid.NewGuid(),
+                        Category = template.Category,
+                        CategoryFolder = template.CategoryFolderName,
+                        Item = templateItem.Name,
+                        ItemFolder = templateItem.FolderName,
+                        DocumentName = displayName,
+                        Versions = new List<NpiDocumentVersionRecord>()
+                    };
+                    manifest.Documents.Add(document);
+                }
+
+                var nextVersion = document.Versions.Count == 0
+                    ? 1
+                    : document.Versions.Max(v => v.VersionNumber) + 1;
+
+                var extension = Path.GetExtension(file.FileName);
+                var storedFileName = $"{document.DocumentId:N}_v{nextVersion}{extension}";
+                var version = new NpiDocumentVersionRecord
+                {
+                    VersionId = Guid.NewGuid(),
+                    VersionNumber = nextVersion,
+                    StoredFileName = storedFileName,
+                    OriginalFileName = string.IsNullOrWhiteSpace(file.FileName) ? storedFileName : Path.GetFileName(file.FileName),
+                    UploadedAt = DateTime.UtcNow,
+                    UploadedBy = string.IsNullOrWhiteSpace(uploadedBy) ? "Unknown" : uploadedBy,
+                    FileSize = file.Length
+                };
+
+                var documentFolder = Path.Combine(GetProjectPath(project), document.CategoryFolder, document.ItemFolder);
+                Directory.CreateDirectory(documentFolder);
+                var physicalPath = Path.Combine(documentFolder, storedFileName);
+                await using (var stream = new FileStream(physicalPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    await file.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+                }
+
+                document.Versions.Add(version);
+                manifest.Documents = manifest.Documents
+                    .OrderBy(d => d.Category)
+                    .ThenBy(d => d.Item)
+                    .ThenBy(d => d.DocumentName)
+                    .ToList();
+
+                project.DocumentCount = manifest.Documents.Sum(d => d.Versions.Count);
+
+                await SaveManifestAsync(project, manifest, cancellationToken).ConfigureAwait(false);
+                await SaveProjectStoreAsync(store, cancellationToken).ConfigureAwait(false);
+
+                return CloneDocument(document);
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public async Task<NpiDocumentFileResult?> GetDocumentFileAsync(Guid projectId, Guid documentId, Guid versionId, CancellationToken cancellationToken = default)
+        {
+            await _syncLock.WaitAsync(cancellationToken);
+            try
+            {
+                var store = await LoadProjectStoreAsync(cancellationToken).ConfigureAwait(false);
+                var project = store.Projects.FirstOrDefault(p => p.Id == projectId);
+                if (project == null)
+                {
+                    return null;
+                }
+
+                var manifest = await LoadManifestAsync(project, cancellationToken).ConfigureAwait(false);
+                var document = manifest.Documents.FirstOrDefault(d => d.DocumentId == documentId);
+                var version = document?.Versions.FirstOrDefault(v => v.VersionId == versionId);
+                if (document == null || version == null)
+                {
+                    return null;
+                }
+
+                var physicalPath = Path.Combine(GetProjectPath(project), document.CategoryFolder, document.ItemFolder, version.StoredFileName);
+                if (!File.Exists(physicalPath))
+                {
+                    return null;
+                }
+
+                if (!_contentTypeProvider.TryGetContentType(version.OriginalFileName, out var contentType))
+                {
+                    contentType = "application/octet-stream";
+                }
+
+                return new NpiDocumentFileResult
+                {
+                    PhysicalPath = physicalPath,
+                    OriginalFileName = version.OriginalFileName,
+                    ContentType = contentType
+                };
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public async Task<bool> DeleteVersionAsync(Guid projectId, Guid documentId, Guid versionId, CancellationToken cancellationToken = default)
+        {
+            await _syncLock.WaitAsync(cancellationToken);
+            try
+            {
+                var store = await LoadProjectStoreAsync(cancellationToken).ConfigureAwait(false);
+                var project = store.Projects.FirstOrDefault(p => p.Id == projectId);
+                if (project == null)
+                {
+                    return false;
+                }
+
+                var manifest = await LoadManifestAsync(project, cancellationToken).ConfigureAwait(false);
+                var document = manifest.Documents.FirstOrDefault(d => d.DocumentId == documentId);
+                var version = document?.Versions.FirstOrDefault(v => v.VersionId == versionId);
+                if (document == null || version == null)
+                {
+                    return false;
+                }
+
+                var physicalPath = Path.Combine(GetProjectPath(project), document.CategoryFolder, document.ItemFolder, version.StoredFileName);
+                if (File.Exists(physicalPath))
+                {
+                    try
+                    {
+                        File.Delete(physicalPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to delete file {File}", physicalPath);
+                        throw;
+                    }
+                }
+
+                document.Versions.Remove(version);
+                if (document.Versions.Count == 0)
+                {
+                    manifest.Documents.Remove(document);
+                }
+
+                project.DocumentCount = manifest.Documents.Sum(d => d.Versions.Count);
+
+                await SaveManifestAsync(project, manifest, cancellationToken).ConfigureAwait(false);
+                await SaveProjectStoreAsync(store, cancellationToken).ConfigureAwait(false);
+
+                return true;
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        private async Task<ProjectStore> LoadProjectStoreAsync(CancellationToken cancellationToken)
+        {
+            if (!File.Exists(ProjectsStorePath))
+            {
+                return new ProjectStore();
+            }
+
+            await using var stream = new FileStream(ProjectsStorePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var store = await JsonSerializer.DeserializeAsync<ProjectStore>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
+            return store ?? new ProjectStore();
+        }
+
+        private async Task SaveProjectStoreAsync(ProjectStore store, CancellationToken cancellationToken)
+        {
+            await using var stream = new FileStream(ProjectsStorePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await JsonSerializer.SerializeAsync(stream, store, JsonOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ManifestStore> LoadManifestAsync(NpiProjectSummary summary, CancellationToken cancellationToken)
+        {
+            var path = GetManifestPath(summary);
+            if (!File.Exists(path))
+            {
+                return new ManifestStore();
+            }
+
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var manifest = await JsonSerializer.DeserializeAsync<ManifestStore>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
+            return manifest ?? new ManifestStore();
+        }
+
+        private async Task SaveManifestAsync(NpiProjectSummary summary, ManifestStore manifest, CancellationToken cancellationToken)
+        {
+            var path = GetManifestPath(summary);
+            await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+            await JsonSerializer.SerializeAsync(stream, manifest, JsonOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        private string GetProjectPath(NpiProjectSummary summary)
+            => Path.Combine(_rootPath, summary.FolderName);
+
+        private string GetManifestPath(NpiProjectSummary summary)
+            => Path.Combine(GetProjectPath(summary), "manifest.json");
+
+        private static string GenerateFolderName(string name, IEnumerable<string> existing)
+        {
+            var baseName = SanitizeName(name);
+            if (string.IsNullOrWhiteSpace(baseName))
+            {
+                baseName = "Project";
+            }
+
+            var candidate = baseName;
+            var index = 1;
+            var existingSet = new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase);
+            while (existingSet.Contains(candidate))
+            {
+                candidate = $"{baseName}_{index++}";
+            }
+
+            return candidate;
+        }
+
+        private static string SanitizeFolderName(string name)
+        {
+            var sanitized = SanitizeName(name);
+            return string.IsNullOrWhiteSpace(sanitized) ? "Folder" : sanitized;
+        }
+
+        private static string SanitizeName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return string.Empty;
+            }
+
+            var invalid = Path.GetInvalidFileNameChars();
+            var builder = new StringBuilder();
+            foreach (var ch in name.Trim())
+            {
+                if (invalid.Contains(ch))
+                {
+                    builder.Append('_');
+                }
+                else if (char.IsWhiteSpace(ch))
+                {
+                    builder.Append('_');
+                }
+                else
+                {
+                    builder.Append(ch);
+                }
+            }
+
+            var sanitized = builder.ToString();
+            while (sanitized.Contains("__", StringComparison.Ordinal))
+            {
+                sanitized = sanitized.Replace("__", "_", StringComparison.Ordinal);
+            }
+
+            return sanitized.Trim('_');
+        }
+
+        private static NpiProjectSummary CloneSummary(NpiProjectSummary summary)
+            => new()
+            {
+                Id = summary.Id,
+                Name = summary.Name,
+                Owner = summary.Owner,
+                CreatedAt = summary.CreatedAt,
+                FolderName = summary.FolderName,
+                DocumentCount = summary.DocumentCount
+            };
+
+        private static NpiDocumentRecord CloneDocument(NpiDocumentRecord record)
+            => new()
+            {
+                DocumentId = record.DocumentId,
+                DocumentName = record.DocumentName,
+                Category = record.Category,
+                CategoryFolder = record.CategoryFolder,
+                Item = record.Item,
+                ItemFolder = record.ItemFolder,
+                Versions = record.Versions
+                    .OrderByDescending(v => v.VersionNumber)
+                    .Select(CloneVersion)
+                    .ToList()
+            };
+
+        private static NpiDocumentVersionRecord CloneVersion(NpiDocumentVersionRecord version)
+            => new()
+            {
+                VersionId = version.VersionId,
+                VersionNumber = version.VersionNumber,
+                StoredFileName = version.StoredFileName,
+                OriginalFileName = version.OriginalFileName,
+                FileSize = version.FileSize,
+                UploadedAt = version.UploadedAt,
+                UploadedBy = version.UploadedBy
+            };
+
+        private static IReadOnlyList<NpiFolderTemplate> BuildTemplates()
+        {
+            var configuration = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["BOM"] = new[] { "NPI BOM", "MP BOM" },
+                ["Document instruction"] = new[] { "BOM layout", "ASSY + Packing instruction" },
+                ["Manufacturing process"] = new[] { "Route from NV", "Manufacturing process in Foxconn + SFC" },
+                ["Key component"] = new[] { "OPV data" },
+                ["SOP NPI"] = new[] { "SOP polarity" },
+                ["Config NPI"] = new[] { "Config 27 for BI process", "LR config", "EPAD location" },
+                ["DFX"] = new[] { "PFMEA", "PMP" },
+                ["Production plan"] = new[] { "DEV + status" },
+                ["YR report for each build"] = new[] { "YR everyday (tracker)", "YR each test station (engineer report)" },
+                ["Cook book"] = new[] { "Picture SFG + FG", "Picture AOI", "Profile SMT" },
+                ["YR 1st MP"] = new[] { "Only test station (engineer report)", "FA detail report" }
+            };
+
+            var result = new List<NpiFolderTemplate>();
+            foreach (var kvp in configuration)
+            {
+                var categoryFolder = SanitizeFolderName(kvp.Key);
+                var items = kvp.Value
+                    .Select(item => new NpiFolderItem(item, SanitizeFolderName(item)))
+                    .ToList();
+                result.Add(new NpiFolderTemplate(kvp.Key, categoryFolder, items));
+            }
+
+            return result;
+        }
+
+        private sealed class ProjectStore
+        {
+            public List<NpiProjectSummary> Projects { get; set; } = new();
+        }
+
+        private sealed class ManifestStore
+        {
+            public List<NpiDocumentRecord> Documents { get; set; } = new();
+        }
+    }
+}

--- a/PESystem/Services/NpiDocumentService.cs
+++ b/PESystem/Services/NpiDocumentService.cs
@@ -57,7 +57,7 @@ namespace PESystem.Services
 
         public async Task<NpiProjectSummary> CreateProjectAsync(string name, string owner, CancellationToken cancellationToken = default)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+            ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
             owner ??= string.Empty;
 
             await _syncLock.WaitAsync(cancellationToken);

--- a/PESystem/Services/NpiDocumentService.cs
+++ b/PESystem/Services/NpiDocumentService.cs
@@ -57,7 +57,10 @@ namespace PESystem.Services
 
         public async Task<NpiProjectSummary> CreateProjectAsync(string name, string owner, CancellationToken cancellationToken = default)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Project name is required.", nameof(name));
+            }
             owner ??= string.Empty;
 
             await _syncLock.WaitAsync(cancellationToken);

--- a/PESystem/Views/Home/Home.cshtml
+++ b/PESystem/Views/Home/Home.cshtml
@@ -158,13 +158,13 @@
                 </div>
             </a>
         </div>
-        <!-- NPI document -->
+
         <div class="col-6 col-md-4 col-lg-2">
             <a href="@Url.Action("Index", "Home", new { area = "NPI" })" class="text-decoration-none">
                 <div class="card shadow-sm text-center custom-card">
                     <div class="d-flex flex-column justify-content-center align-items-center h-100">
                         <img src="~/assets/img/Document.jpg" class="logo mb-2" />
-                        <span class="fw-bold text-muted" style="font-size:14px; color: black !important;">NPI document</span>
+                        <span class="fw-bold text-muted" style="font-size:14px; color: black !important;">NPI DOCUMENT</span>
                     </div>
                 </div>
             </a>

--- a/PESystem/mvc_appsettings.Development.json
+++ b/PESystem/mvc_appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ApiBaseUrl": "http://10.220.130.119:9090"
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }

--- a/PESystem/mvc_appsettings.json
+++ b/PESystem/mvc_appsettings.json
@@ -8,6 +8,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  ,"ApiBaseUrl": "http://10.220.130.119:9090"
+  "AllowedHosts": "*",
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }


### PR DESCRIPTION
## Summary
- add an NPI Document area with controller and Razor views that let users create projects, upload files, browse versions, download, and delete documents
- implement a filesystem-backed NpiDocumentService with manifest storage, default folder templates, and options/configuration support
- surface the new area via dependency injection, configuration updates, and a home-page navigation card

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68f627ee5ea883268542ca9b59dfbf28