### PR TITLE
Add NPI document workspace area

### DIFF
--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,0 +1,181 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PESystem.Areas.NPI.Services;
+using PESystem.Areas.NPI.ViewModels;
+
+namespace PESystem.Areas.NPI.Controllers
+{
+    [Area("NPI")]
+    [Authorize(Policy = "NPIAccess")]
+    public class HomeController : Controller
+    {
+        private const string StatusMessageKey = "StatusMessage";
+        private const string ErrorMessageKey = "ErrorMessage";
+
+        private readonly INpiProjectService _projectService;
+        private readonly ILogger<HomeController> _logger;
+
+        public HomeController(INpiProjectService projectService, ILogger<HomeController> logger)
+        {
+            _projectService = projectService;
+            _logger = logger;
+        }
+
+        public IActionResult Index()
+        {
+            var projects = _projectService.GetProjects();
+            var model = new NpiProjectIndexViewModel
+            {
+                Projects = projects.Select(p => new NpiProjectListItemViewModel
+                {
+                    Id = p.Id,
+                    Name = p.Name,
+                    Owner = p.Owner,
+                    CreatedAtUtc = p.CreatedAtUtc,
+                    DocumentCount = p.Documents.Count
+                }).ToList(),
+                StatusMessage = TempData[StatusMessageKey] as string,
+                ErrorMessage = TempData[ErrorMessageKey] as string
+            };
+
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreateProject(CreateProjectInputModel input)
+        {
+            if (!ModelState.IsValid)
+            {
+                TempData[ErrorMessageKey] = "Please provide both a project name and an owner.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            try
+            {
+                var result = await _projectService.CreateProjectAsync(input.Name, input.Owner).ConfigureAwait(false);
+                TempData[result.Succeeded ? StatusMessageKey : ErrorMessageKey] = result.Message;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create NPI project {Name}", input.Name);
+                TempData[ErrorMessageKey] = "An unexpected error occurred while creating the project.";
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        public IActionResult Details(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return NotFound();
+            }
+
+            var project = _projectService.GetProject(id);
+            if (project == null)
+            {
+                return NotFound();
+            }
+
+            var groups = _projectService.FolderDefinitions
+                .GroupBy(fd => fd.Root, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new NpiFolderGroupViewModel
+                {
+                    Name = group.Key,
+                    Folders = group
+                        .OrderBy(fd => fd.DisplayName, StringComparer.OrdinalIgnoreCase)
+                        .Select(fd => new NpiLeafFolderViewModel
+                        {
+                            RelativePath = fd.RelativePath,
+                            DisplayName = fd.DisplayName,
+                            Documents = project.Documents
+                                .Where(d => string.Equals(d.Folder, fd.RelativePath, StringComparison.OrdinalIgnoreCase))
+                                .OrderByDescending(d => d.Version)
+                                .Select(d => new NpiDocumentViewModel
+                                {
+                                    Id = d.Id,
+                                    OriginalFileName = d.OriginalFileName,
+                                    Version = d.Version,
+                                    UploadedAtUtc = d.UploadedAtUtc,
+                                    UploadedBy = d.UploadedBy
+                                }).ToList()
+                        }).ToList()
+                })
+                .OrderBy(g => g.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var model = new NpiProjectDetailsViewModel
+            {
+                Project = project,
+                FolderGroups = groups,
+                StatusMessage = TempData[StatusMessageKey] as string,
+                ErrorMessage = TempData[ErrorMessageKey] as string
+            };
+
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> UploadDocument(UploadDocumentInputModel input)
+        {
+            if (!ModelState.IsValid)
+            {
+                TempData[ErrorMessageKey] = "Please choose a file and folder before uploading.";
+                return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+            }
+
+            try
+            {
+                var userName = User?.Identity?.Name;
+                var result = await _projectService
+                    .UploadDocumentAsync(input.ProjectId, input.RelativeFolder, input.File!, userName ?? "Unknown")
+                    .ConfigureAwait(false);
+                TempData[result.Succeeded ? StatusMessageKey : ErrorMessageKey] = result.Message;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to upload document for project {ProjectId}", input.ProjectId);
+                TempData[ErrorMessageKey] = "An unexpected error occurred while uploading the document.";
+            }
+
+            return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+        }
+
+        public IActionResult DownloadDocument(string projectId, string documentId)
+        {
+            var fileResult = _projectService.DownloadDocument(projectId, documentId);
+            if (fileResult == null)
+            {
+                return NotFound();
+            }
+
+            return File(fileResult.Value.Stream, fileResult.Value.ContentType, fileResult.Value.FileName);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteDocument(DeleteDocumentInputModel input)
+        {
+            if (!ModelState.IsValid)
+            {
+                TempData[ErrorMessageKey] = "Invalid document reference.";
+                return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+            }
+
+            try
+            {
+                var result = await _projectService.DeleteDocumentAsync(input.ProjectId, input.DocumentId).ConfigureAwait(false);
+                TempData[result.Succeeded ? StatusMessageKey : ErrorMessageKey] = result.Message;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete document {DocumentId} from project {ProjectId}", input.DocumentId, input.ProjectId);
+                TempData[ErrorMessageKey] = "An unexpected error occurred while deleting the document.";
+            }
+
+            return RedirectToAction(nameof(Details), new { id = input.ProjectId });
+        }
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiFolderDefinition.cs
+++ b/PESystem/Areas/NPI/Models/NpiFolderDefinition.cs
@@ -1,0 +1,9 @@
+namespace PESystem.Areas.NPI.Models
+{
+    public record NpiFolderDefinition(string RelativePath)
+    {
+        public string[] Segments => RelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        public string Root => Segments.Length > 0 ? Segments[0] : RelativePath;
+        public string DisplayName => Segments.Length > 0 ? Segments[^1] : RelativePath;
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiProject.cs
+++ b/PESystem/Areas/NPI/Models/NpiProject.cs
@@ -1,0 +1,22 @@
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiProject
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedAtUtc { get; set; }
+        public IReadOnlyList<NpiDocument> Documents { get; set; } = Array.Empty<NpiDocument>();
+    }
+
+    public class NpiDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Folder { get; set; } = string.Empty;
+        public string OriginalFileName { get; set; } = string.Empty;
+        public string StoredFileName { get; set; } = string.Empty;
+        public int Version { get; set; }
+        public DateTime UploadedAtUtc { get; set; }
+        public string UploadedBy { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectMetadata.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectMetadata.cs
@@ -1,0 +1,22 @@
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiProjectMetadata
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+        public string Name { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+        public List<NpiDocumentMetadata> Documents { get; set; } = new();
+    }
+
+    public class NpiDocumentMetadata
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+        public string Folder { get; set; } = string.Empty;
+        public string OriginalFileName { get; set; } = string.Empty;
+        public string StoredFileName { get; set; } = string.Empty;
+        public int Version { get; set; }
+        public DateTime UploadedAtUtc { get; set; } = DateTime.UtcNow;
+        public string UploadedBy { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/Services/INpiProjectService.cs
+++ b/PESystem/Areas/NPI/Services/INpiProjectService.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+using PESystem.Areas.NPI.Models;
+
+namespace PESystem.Areas.NPI.Services
+{
+    public interface INpiProjectService
+    {
+        IReadOnlyList<NpiFolderDefinition> FolderDefinitions { get; }
+        IReadOnlyList<NpiProject> GetProjects();
+        NpiProject? GetProject(string projectId);
+        Task<OperationResult> CreateProjectAsync(string name, string owner);
+        Task<OperationResult> UploadDocumentAsync(string projectId, string relativeFolder, IFormFile file, string uploadedBy);
+        Task<OperationResult> DeleteDocumentAsync(string projectId, string documentId);
+        (Stream Stream, string ContentType, string FileName)? DownloadDocument(string projectId, string documentId);
+    }
+
+    public record OperationResult(bool Succeeded, string Message)
+    {
+        public static OperationResult Success(string message) => new(true, message);
+        public static OperationResult Failure(string message) => new(false, message);
+    }
+}

--- a/PESystem/Areas/NPI/Services/NpiProjectService.cs
+++ b/PESystem/Areas/NPI/Services/NpiProjectService.cs
@@ -1,0 +1,358 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using PESystem.Areas.NPI.Models;
+using PESystem.Options;
+
+namespace PESystem.Areas.NPI.Services
+{
+    public class NpiProjectService : INpiProjectService
+    {
+        private const string MetadataFileName = ".npi.project.json";
+        private static readonly IReadOnlyList<NpiFolderDefinition> _folderDefinitions = new List<NpiFolderDefinition>
+        {
+            new("BOM/NPI BOM"),
+            new("BOM/MP BOM"),
+            new("Document instruction/PCB layout"),
+            new("Document instruction/Schematic"),
+            new("Document instruction/ASSY + Packing instruction"),
+            new("Document instruction/Label instruction"),
+            new("Manufacturing process/Route from NV"),
+            new("Manufacturing process/Manufacturing in foxconn + SFC"),
+            new("Manufacturing process/SOP full process from IE"),
+            new("Key component/OVP location"),
+            new("SOP NPI/EPAD location"),
+            new("Config NPI/PCF config"),
+            new("DFX/DFX review"),
+            new("Production plan/DEV + status"),
+            new("Yield Rate NPI for each build/YR everyday (tracker)"),
+            new("Yield Rate NPI for each build/Only test station (engineer report)"),
+            new("Cook book/Cook book document"),
+            new("Cook book/Picture SFG + FG"),
+            new("Cook book/Picture AOI"),
+            new("Cook book/Profile SMT"),
+            new("Yield rate 1st MP/Only test station (engineer report)"),
+            new("Bone pile report/FA daily report"),
+            new("Bone pile report/Bone pile summary")
+        };
+
+        private readonly ILogger<NpiProjectService> _logger;
+        private readonly string _rootPath;
+        private readonly JsonSerializerOptions _serializerOptions = new(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true
+        };
+
+        public NpiProjectService(IOptions<NpiDocumentOptions> options, ILogger<NpiProjectService> logger)
+        {
+            _logger = logger;
+            _rootPath = ResolveRootPath(options.Value.RootPath);
+            Directory.CreateDirectory(_rootPath);
+        }
+
+        public IReadOnlyList<NpiFolderDefinition> FolderDefinitions => _folderDefinitions;
+
+        public IReadOnlyList<NpiProject> GetProjects()
+        {
+            if (!Directory.Exists(_rootPath))
+            {
+                return Array.Empty<NpiProject>();
+            }
+
+            var projects = new List<NpiProject>();
+            foreach (var projectDir in Directory.EnumerateDirectories(_rootPath))
+            {
+                var project = LoadProject(projectDir);
+                if (project != null)
+                {
+                    projects.Add(project);
+                }
+            }
+
+            return projects
+                .OrderByDescending(p => p.CreatedAtUtc)
+                .ThenBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        public NpiProject? GetProject(string projectId)
+        {
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                return null;
+            }
+
+            var projectDir = GetProjectDirectory(projectId);
+            return Directory.Exists(projectDir) ? LoadProject(projectDir) : null;
+        }
+
+        public async Task<OperationResult> CreateProjectAsync(string name, string owner)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return OperationResult.Failure("Project name is required.");
+            }
+
+            owner ??= string.Empty;
+            var projectId = CreateSlug(name);
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                return OperationResult.Failure("Project name does not contain valid characters.");
+            }
+
+            var projectDir = GetProjectDirectory(projectId);
+            if (Directory.Exists(projectDir))
+            {
+                return OperationResult.Failure("A project with the same identifier already exists. Please choose another name.");
+            }
+
+            Directory.CreateDirectory(projectDir);
+            foreach (var folder in _folderDefinitions)
+            {
+                var fullPath = Path.Combine(new[] { projectDir }.Concat(folder.Segments).ToArray());
+                Directory.CreateDirectory(fullPath);
+            }
+
+            var metadata = new NpiProjectMetadata
+            {
+                Id = projectId,
+                Name = name.Trim(),
+                Owner = owner.Trim(),
+                CreatedAtUtc = DateTime.UtcNow,
+            };
+
+            await SaveMetadataAsync(metadata, projectDir).ConfigureAwait(false);
+
+            return OperationResult.Success("Project created successfully.");
+        }
+
+        public async Task<OperationResult> UploadDocumentAsync(string projectId, string relativeFolder, IFormFile file, string uploadedBy)
+        {
+            if (file == null || file.Length == 0)
+            {
+                return OperationResult.Failure("Please choose a file to upload.");
+            }
+
+            var projectDir = GetProjectDirectory(projectId);
+            if (!Directory.Exists(projectDir))
+            {
+                return OperationResult.Failure("Project not found.");
+            }
+
+            if (!_folderDefinitions.Any(f => string.Equals(f.RelativePath, relativeFolder, StringComparison.OrdinalIgnoreCase)))
+            {
+                return OperationResult.Failure("The selected folder is not part of the NPI template.");
+            }
+
+            var metadata = await LoadMetadataAsync(projectDir).ConfigureAwait(false);
+            if (metadata == null)
+            {
+                return OperationResult.Failure("Project metadata is missing or corrupted.");
+            }
+
+            var segments = relativeFolder.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var folderPath = Path.Combine(new[] { projectDir }.Concat(segments).ToArray());
+            Directory.CreateDirectory(folderPath);
+
+            var originalFileName = Path.GetFileName(file.FileName);
+            var nameWithoutExtension = Path.GetFileNameWithoutExtension(originalFileName);
+            var extension = Path.GetExtension(originalFileName);
+
+            var maxExistingVersion = metadata.Documents
+                .Where(d => string.Equals(d.Folder, relativeFolder, StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(d.OriginalFileName, originalFileName, StringComparison.OrdinalIgnoreCase))
+                .Select(d => d.Version)
+                .DefaultIfEmpty(0)
+                .Max();
+
+            var newVersion = maxExistingVersion + 1;
+            var versionedFileName = $"{nameWithoutExtension}_v{newVersion:000}{extension}";
+            var destinationPath = Path.Combine(folderPath, versionedFileName);
+
+            using (var stream = new FileStream(destinationPath, FileMode.Create, FileAccess.Write))
+            {
+                await file.CopyToAsync(stream).ConfigureAwait(false);
+            }
+
+            metadata.Documents.Add(new NpiDocumentMetadata
+            {
+                Folder = relativeFolder,
+                OriginalFileName = originalFileName,
+                StoredFileName = versionedFileName,
+                Version = newVersion,
+                UploadedAtUtc = DateTime.UtcNow,
+                UploadedBy = uploadedBy ?? string.Empty
+            });
+
+            await SaveMetadataAsync(metadata, projectDir).ConfigureAwait(false);
+
+            return OperationResult.Success($"Uploaded '{originalFileName}' (version {newVersion}).");
+        }
+
+        public async Task<OperationResult> DeleteDocumentAsync(string projectId, string documentId)
+        {
+            if (string.IsNullOrWhiteSpace(projectId) || string.IsNullOrWhiteSpace(documentId))
+            {
+                return OperationResult.Failure("Invalid document reference.");
+            }
+
+            var projectDir = GetProjectDirectory(projectId);
+            if (!Directory.Exists(projectDir))
+            {
+                return OperationResult.Failure("Project not found.");
+            }
+
+            var metadata = await LoadMetadataAsync(projectDir).ConfigureAwait(false);
+            if (metadata == null)
+            {
+                return OperationResult.Failure("Project metadata is missing or corrupted.");
+            }
+
+            var document = metadata.Documents.FirstOrDefault(d => string.Equals(d.Id, documentId, StringComparison.OrdinalIgnoreCase));
+            if (document == null)
+            {
+                return OperationResult.Failure("Document not found.");
+            }
+
+            var segments = document.Folder.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var documentPath = Path.Combine(new[] { projectDir }.Concat(segments).Append(document.StoredFileName).ToArray());
+
+            if (File.Exists(documentPath))
+            {
+                File.Delete(documentPath);
+            }
+
+            metadata.Documents.Remove(document);
+            await SaveMetadataAsync(metadata, projectDir).ConfigureAwait(false);
+
+            return OperationResult.Success($"Document '{document.OriginalFileName}' was deleted.");
+        }
+
+        public (Stream Stream, string ContentType, string FileName)? DownloadDocument(string projectId, string documentId)
+        {
+            if (string.IsNullOrWhiteSpace(projectId) || string.IsNullOrWhiteSpace(documentId))
+            {
+                return null;
+            }
+
+            var projectDir = GetProjectDirectory(projectId);
+            if (!Directory.Exists(projectDir))
+            {
+                return null;
+            }
+
+            var metadata = LoadMetadataAsync(projectDir).GetAwaiter().GetResult();
+            if (metadata == null)
+            {
+                return null;
+            }
+
+            var document = metadata.Documents.FirstOrDefault(d => string.Equals(d.Id, documentId, StringComparison.OrdinalIgnoreCase));
+            if (document == null)
+            {
+                return null;
+            }
+
+            var segments = document.Folder.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var path = Path.Combine(new[] { projectDir }.Concat(segments).Append(document.StoredFileName).ToArray());
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var contentType = GetContentType(path);
+            return (stream, contentType, document.StoredFileName);
+        }
+
+        private static string GetContentType(string path)
+        {
+            var provider = new Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider();
+            return provider.TryGetContentType(path, out var contentType) ? contentType : "application/octet-stream";
+        }
+
+        private NpiProject? LoadProject(string projectDir)
+        {
+            try
+            {
+                var metadata = LoadMetadataAsync(projectDir).GetAwaiter().GetResult();
+                if (metadata == null)
+                {
+                    return null;
+                }
+
+                return new NpiProject
+                {
+                    Id = metadata.Id,
+                    Name = metadata.Name,
+                    Owner = metadata.Owner,
+                    CreatedAtUtc = metadata.CreatedAtUtc,
+                    Documents = metadata.Documents
+                        .Select(d => new NpiDocument
+                        {
+                            Id = d.Id,
+                            Folder = d.Folder,
+                            OriginalFileName = d.OriginalFileName,
+                            StoredFileName = d.StoredFileName,
+                            Version = d.Version,
+                            UploadedAtUtc = d.UploadedAtUtc,
+                            UploadedBy = d.UploadedBy
+                        })
+                        .OrderByDescending(d => d.UploadedAtUtc)
+                        .ThenByDescending(d => d.Version)
+                        .ToList()
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load project metadata from {Directory}", projectDir);
+                return null;
+            }
+        }
+
+        private async Task<NpiProjectMetadata?> LoadMetadataAsync(string projectDir)
+        {
+            var metadataPath = Path.Combine(projectDir, MetadataFileName);
+            if (!File.Exists(metadataPath))
+            {
+                return null;
+            }
+
+            await using var stream = new FileStream(metadataPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return await JsonSerializer.DeserializeAsync<NpiProjectMetadata>(stream, _serializerOptions).ConfigureAwait(false);
+        }
+
+        private async Task SaveMetadataAsync(NpiProjectMetadata metadata, string projectDir)
+        {
+            var metadataPath = Path.Combine(projectDir, MetadataFileName);
+            await using var stream = new FileStream(metadataPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await JsonSerializer.SerializeAsync(stream, metadata, _serializerOptions).ConfigureAwait(false);
+        }
+
+        private string GetProjectDirectory(string projectId) => Path.Combine(_rootPath, projectId);
+
+        private static string CreateSlug(string value)
+        {
+            var slug = Regex.Replace(value.ToLowerInvariant(), "[^a-z0-9]+", "-");
+            slug = Regex.Replace(slug, "-+", "-").Trim('-');
+            return slug;
+        }
+
+        private static string ResolveRootPath(string? configuredPath)
+        {
+            if (!string.IsNullOrWhiteSpace(configuredPath))
+            {
+                return configuredPath;
+            }
+
+            var defaultPath = "D:\\NpiDocument";
+            if (OperatingSystem.IsWindows())
+            {
+                return defaultPath;
+            }
+
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "NpiDocument");
+        }
+    }
+}

--- a/PESystem/Areas/NPI/ViewModels/CreateProjectInputModel.cs
+++ b/PESystem/Areas/NPI/ViewModels/CreateProjectInputModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PESystem.Areas.NPI.ViewModels
+{
+    public class CreateProjectInputModel
+    {
+        [Required]
+        [StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100)]
+        public string Owner { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/ViewModels/DeleteDocumentInputModel.cs
+++ b/PESystem/Areas/NPI/ViewModels/DeleteDocumentInputModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PESystem.Areas.NPI.ViewModels
+{
+    public class DeleteDocumentInputModel
+    {
+        [Required]
+        public string ProjectId { get; set; } = string.Empty;
+
+        [Required]
+        public string DocumentId { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/ViewModels/NpiProjectDetailsViewModel.cs
+++ b/PESystem/Areas/NPI/ViewModels/NpiProjectDetailsViewModel.cs
@@ -1,0 +1,34 @@
+using PESystem.Areas.NPI.Models;
+
+namespace PESystem.Areas.NPI.ViewModels
+{
+    public class NpiProjectDetailsViewModel
+    {
+        public required NpiProject Project { get; init; }
+        public List<NpiFolderGroupViewModel> FolderGroups { get; init; } = new();
+        public string? StatusMessage { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+
+    public class NpiFolderGroupViewModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<NpiLeafFolderViewModel> Folders { get; set; } = new();
+    }
+
+    public class NpiLeafFolderViewModel
+    {
+        public string RelativePath { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public List<NpiDocumentViewModel> Documents { get; set; } = new();
+    }
+
+    public class NpiDocumentViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string OriginalFileName { get; set; } = string.Empty;
+        public int Version { get; set; }
+        public DateTime UploadedAtUtc { get; set; }
+        public string UploadedBy { get; set; } = string.Empty;
+    }
+}

--- a/PESystem/Areas/NPI/ViewModels/NpiProjectDetailsViewModel.cs
+++ b/PESystem/Areas/NPI/ViewModels/NpiProjectDetailsViewModel.cs
@@ -4,7 +4,7 @@ namespace PESystem.Areas.NPI.ViewModels
 {
     public class NpiProjectDetailsViewModel
     {
-        public required NpiProject Project { get; init; }
+        public NpiProject Project { get; init; } = null!;
         public List<NpiFolderGroupViewModel> FolderGroups { get; init; } = new();
         public string? StatusMessage { get; set; }
         public string? ErrorMessage { get; set; }

--- a/PESystem/Areas/NPI/ViewModels/NpiProjectIndexViewModel.cs
+++ b/PESystem/Areas/NPI/ViewModels/NpiProjectIndexViewModel.cs
@@ -1,0 +1,18 @@
+namespace PESystem.Areas.NPI.ViewModels
+{
+    public class NpiProjectIndexViewModel
+    {
+        public List<NpiProjectListItemViewModel> Projects { get; set; } = new();
+        public string? StatusMessage { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+
+    public class NpiProjectListItemViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedAtUtc { get; set; }
+        public int DocumentCount { get; set; }
+    }
+}

--- a/PESystem/Areas/NPI/ViewModels/UploadDocumentInputModel.cs
+++ b/PESystem/Areas/NPI/ViewModels/UploadDocumentInputModel.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+
+namespace PESystem.Areas.NPI.ViewModels
+{
+    public class UploadDocumentInputModel
+    {
+        [Required]
+        public string ProjectId { get; set; } = string.Empty;
+
+        [Required]
+        public string RelativeFolder { get; set; } = string.Empty;
+
+        [Required]
+        public IFormFile? File { get; set; }
+    }
+}

--- a/PESystem/Areas/NPI/Views/Home/Details.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Details.cshtml
@@ -1,0 +1,114 @@
+@model PESystem.Areas.NPI.ViewModels.NpiProjectDetailsViewModel
+@{
+    ViewData["Title"] = $"NPI - {Model.Project.Name}";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-start mb-4">
+        <div>
+            <a asp-area="NPI" asp-controller="Home" asp-action="Index" class="text-decoration-none text-muted">
+                <i class="bi bi-arrow-left-circle me-1"></i>Quay lại danh sách project
+            </a>
+            <h2 class="mt-2 mb-1">@Model.Project.Name</h2>
+            <div class="text-muted">
+                <span class="me-3"><strong>Owner:</strong> @Model.Project.Owner</span>
+                <span><strong>Ngày tạo:</strong> @Model.Project.CreatedAtUtc.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</span>
+            </div>
+        </div>
+        <div class="text-end">
+            <div class="badge bg-secondary text-wrap">Project ID: @Model.Project.Id</div>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.StatusMessage))
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="bi bi-check-circle me-2"></i>@Model.StatusMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <i class="bi bi-exclamation-triangle me-2"></i>@Model.ErrorMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @foreach (var group in Model.FolderGroups)
+    {
+        <div class="card shadow-sm mb-4">
+            <div class="card-header bg-light fw-semibold">
+                @group.Name
+            </div>
+            <div class="card-body">
+                @foreach (var folder in group.Folders)
+                {
+                    <div class="mb-4">
+                        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-2 gap-2">
+                            <h5 class="mb-0">@folder.DisplayName</h5>
+                            <form asp-area="NPI" asp-controller="Home" asp-action="UploadDocument" method="post" enctype="multipart/form-data" class="w-100 w-lg-auto" style="max-width: 480px;">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="ProjectId" value="@Model.Project.Id" />
+                                <input type="hidden" name="RelativeFolder" value="@folder.RelativePath" />
+                                <div class="input-group input-group-sm">
+                                    <input type="file" name="File" class="form-control" required />
+                                    <button type="submit" class="btn btn-primary">Upload</button>
+                                </div>
+                            </form>
+                        </div>
+
+                        <div class="table-responsive">
+                            <table class="table table-sm table-bordered align-middle mb-0">
+                                <thead class="table-secondary">
+                                    <tr>
+                                        <th scope="col">Tài liệu</th>
+                                        <th scope="col" class="text-center">Version</th>
+                                        <th scope="col" class="text-center">Ngày update</th>
+                                        <th scope="col">Người update</th>
+                                        <th scope="col" class="text-end">Thao tác</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @if (folder.Documents.Any())
+                                    {
+                                        foreach (var doc in folder.Documents)
+                                        {
+                                            <tr>
+                                                <td>@doc.OriginalFileName</td>
+                                                <td class="text-center">v@doc.Version</td>
+                                                <td class="text-center">@doc.UploadedAtUtc.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                                <td>@(string.IsNullOrWhiteSpace(doc.UploadedBy) ? "--" : doc.UploadedBy)</td>
+                                                <td class="text-end">
+                                                    <a class="btn btn-outline-secondary btn-sm me-2" asp-area="NPI" asp-controller="Home" asp-action="DownloadDocument" asp-route-projectId="@Model.Project.Id" asp-route-documentId="@doc.Id">
+                                                        <i class="bi bi-download"></i>
+                                                    </a>
+                                                    <form asp-area="NPI" asp-controller="Home" asp-action="DeleteDocument" method="post" class="d-inline" onsubmit="return confirm('Bạn có chắc chắn muốn xóa tài liệu này?');">
+                                                        @Html.AntiForgeryToken()
+                                                        <input type="hidden" name="ProjectId" value="@Model.Project.Id" />
+                                                        <input type="hidden" name="DocumentId" value="@doc.Id" />
+                                                        <button type="submit" class="btn btn-outline-danger btn-sm">
+                                                            <i class="bi bi-trash"></i>
+                                                        </button>
+                                                    </form>
+                                                </td>
+                                            </tr>
+                                        }
+                                    }
+                                    else
+                                    {
+                                        <tr>
+                                            <td colspan="5" class="text-center text-muted">Chưa có tài liệu nào trong thư mục này.</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,0 +1,109 @@
+@model PESystem.Areas.NPI.ViewModels.NpiProjectIndexViewModel
+@{
+    ViewData["Title"] = "NPI Document";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h2 class="mb-0">NPI Document Workspace</h2>
+            <p class="text-muted mb-0">Quản lý dự án và tài liệu cho quá trình NPI.</p>
+        </div>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+            <i class="bi bi-plus-circle me-2"></i>Tạo project mới
+        </button>
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.StatusMessage))
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="bi bi-check-circle me-2"></i>@Model.StatusMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <i class="bi bi-exclamation-triangle me-2"></i>@Model.ErrorMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            @if (Model.Projects.Any())
+            {
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Project</th>
+                                <th scope="col">Owner</th>
+                                <th scope="col" class="text-nowrap">Ngày tạo</th>
+                                <th scope="col" class="text-center">Số tài liệu</th>
+                                <th scope="col" class="text-end">Thao tác</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var project in Model.Projects)
+                            {
+                                <tr>
+                                    <td class="align-middle">
+                                        <div class="fw-semibold">@project.Name</div>
+                                        <small class="text-muted">@project.Id</small>
+                                    </td>
+                                    <td class="align-middle">@project.Owner</td>
+                                    <td class="align-middle">@project.CreatedAtUtc.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                    <td class="align-middle text-center">@project.DocumentCount</td>
+                                    <td class="align-middle text-end">
+                                        <a class="btn btn-outline-primary btn-sm" asp-area="NPI" asp-controller="Home" asp-action="Details" asp-route-id="@project.Id">
+                                            Quản lý
+                                        </a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="p-4 text-center text-muted">
+                    <i class="bi bi-inboxes display-6 d-block mb-3"></i>
+                    <p class="mb-0">Chưa có project nào. Hãy tạo project đầu tiên để bắt đầu quản lý tài liệu NPI.</p>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="createProjectModal" tabindex="-1" aria-labelledby="createProjectLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="createProjectLabel">Tạo project NPI mới</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form asp-area="NPI" asp-controller="Home" asp-action="CreateProject" method="post">
+                @Html.AntiForgeryToken()
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="project-name" class="form-label">Tên project</label>
+                        <input type="text" class="form-control" id="project-name" name="Name" maxlength="200" required />
+                        <div class="form-text">Tên project sẽ được dùng để tạo thư mục lưu trữ.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="project-owner" class="form-label">Owner</label>
+                        <input type="text" class="form-control" id="project-owner" name="Owner" maxlength="100" required />
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Hủy</button>
+                    <button type="submit" class="btn btn-primary">Tạo</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/PESystem/Options/NpiDocumentOptions.cs
+++ b/PESystem/Options/NpiDocumentOptions.cs
@@ -1,0 +1,7 @@
+namespace PESystem.Options
+{
+    public class NpiDocumentOptions
+    {
+        public string? RootPath { get; set; }
+    }
+}

--- a/PESystem/Program.cs
+++ b/PESystem/Program.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using PESystem.Areas.NPI.Services;
 using PESystem.Models;
+using PESystem.Options;
 using PESystem.Policies;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +17,9 @@ var configuration = new ConfigurationBuilder()
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllersWithViews();
+
+builder.Services.Configure<NpiDocumentOptions>(configuration.GetSection("NpiDocument"));
+builder.Services.AddSingleton<INpiProjectService, NpiProjectService>();
 
 // ---- HttpClient: gộp làm 1, vừa có BaseAddress vừa bypass proxy ----
 builder.Services.AddHttpClient("ApiClient", client =>
@@ -45,6 +50,7 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("ScrapAccess", p => p.Requirements.Add(new AreaAccessRequirement("Scrap")));
     options.AddPolicy("MaterialSystemAccess", p => p.Requirements.Add(new AreaAccessRequirement("MaterialSystem")));
     options.AddPolicy("SFCAccess", p => p.Requirements.Add(new AreaAccessRequirement("SFC")));
+    options.AddPolicy("NPIAccess", p => p.Requirements.Add(new AreaAccessRequirement("NPI")));
 });
 
 builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();

--- a/PESystem/Views/Home/Home.cshtml
+++ b/PESystem/Views/Home/Home.cshtml
@@ -85,6 +85,17 @@
         </div>
 
         <div class="col-6 col-md-4 col-lg-2">
+            <a href="@Url.Action("Index", "Home", new { area = "NPI" })" class="text-decoration-none">
+                <div class="card shadow-sm text-center custom-card">
+                    <div class="d-flex flex-column justify-content-center align-items-center h-100">
+                        <img src="~/assets/img/Document.jpg" class="logo mb-2" />
+                        <span class="fw-bold text-muted" style="font-size:14px; color: black !important;">NPI Document</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+
+        <div class="col-6 col-md-4 col-lg-2">
             <a href="@Url.Action("Index", "Home", new { area = "Scrap" })" class="text-decoration-none">
                 <div class="card shadow-sm text-center custom-card">
                     <div class="d-flex flex-column justify-content-center align-items-center h-100">

--- a/PESystem/mvc_appsettings.json
+++ b/PESystem/mvc_appsettings.json
@@ -8,6 +8,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  ,"ApiBaseUrl": "http://10.220.130.119:9090"
+  "AllowedHosts": "*",
+  "ApiBaseUrl": "http://10.220.130.119:9090",
+  "NpiDocument": {
+    "RootPath": "D:\\NpiDocument"
+  }
 }


### PR DESCRIPTION
## Summary
- add a new NPI area with project listing, project creation, and per-folder document management backed by JSON metadata
- wire up configuration and services so NPI files are created under the configured root with the default folder template
- surface the NPI workspace from the home dashboard for quick navigation

## Testing
- not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_b_68f6dbef8344832695cce6b4637f0710