### PR TITLE
Add NPI document management area

### DIFF
--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using PESystem.Areas.NPI.Models;
+using PESystem.Areas.NPI.Services;
+
+namespace PESystem.Areas.NPI.Controllers
+{
+    [Area("NPI")]
+    [Authorize(Policy = "NPIAccess")]
+    public class HomeController : Controller
+    {
+        private readonly NpiDocumentService _documentService;
+
+        public HomeController(NpiDocumentService documentService)
+        {
+            _documentService = documentService;
+        }
+
+        public IActionResult Index()
+        {
+            var projects = _documentService
+                .GetProjects()
+                .OrderByDescending(p => p.CreatedAt)
+                .ToList();
+
+            ViewBag.Success = TempData["Success"];
+            ViewBag.Error = TempData["Error"];
+
+            return View(projects);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult CreateProject(string projectName, string owner)
+        {
+            var result = _documentService.CreateProject(projectName, owner);
+            TempData[result.Success ? "Success" : "Error"] = result.Message;
+            return RedirectToAction(nameof(Index));
+        }
+
+        public IActionResult Manage(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return NotFound();
+            }
+
+            var project = _documentService.GetProject(id);
+            if (project == null)
+            {
+                return NotFound();
+            }
+
+            var structure = _documentService.GetFolderStructure().ToList();
+            var documentsByCategory = project.Documents
+                .GroupBy(d => d.CategoryPath)
+                .ToDictionary(g => g.Key, g => g.OrderBy(d => d.DocumentName).ToList());
+
+            var viewModel = new NpiProjectViewModel
+            {
+                Project = project,
+                Structure = structure,
+                DocumentsByCategory = documentsByCategory
+            };
+
+            ViewBag.Success = TempData["Success"];
+            ViewBag.Error = TempData["Error"];
+
+            return View(viewModel);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult UploadDocument(string projectId, string categoryPath, string documentName, string uploadedBy, IFormFile file)
+        {
+            var result = _documentService.AddDocumentVersion(projectId, categoryPath, documentName, uploadedBy, file);
+            TempData[result.Success ? "Success" : "Error"] = result.Message;
+            return RedirectToAction(nameof(Manage), new { id = projectId });
+        }
+
+        [HttpGet]
+        public IActionResult Download(string projectId, string categoryPath, string documentName, int version)
+        {
+            var result = _documentService.GetDocumentForDownload(projectId, categoryPath, documentName, version);
+            if (!result.Success || string.IsNullOrEmpty(result.AbsolutePath))
+            {
+                TempData["Error"] = string.IsNullOrEmpty(result.Message) ? "Không thể tải file." : result.Message;
+                return RedirectToAction(nameof(Manage), new { id = projectId });
+            }
+
+            var fileBytes = System.IO.File.ReadAllBytes(result.AbsolutePath);
+            var fileName = result.DownloadFileName ?? Path.GetFileName(result.AbsolutePath);
+            return File(fileBytes, "application/octet-stream", fileName);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult DeleteVersion(string projectId, string categoryPath, string documentName, int version)
+        {
+            var result = _documentService.DeleteVersion(projectId, categoryPath, documentName, version);
+            TempData[result.Success ? "Success" : "Error"] = result.Message;
+            return RedirectToAction(nameof(Manage), new { id = projectId });
+        }
+    }
+}

--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -41,6 +41,24 @@ namespace PESystem.Areas.NPI.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult UpdateProject(string projectId, string projectName, string owner)
+        {
+            var result = _documentService.UpdateProject(projectId, projectName, owner);
+            TempData[result.Success ? "Success" : "Error"] = result.Message;
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult DeleteProject(string projectId)
+        {
+            var result = _documentService.DeleteProject(projectId);
+            TempData[result.Success ? "Success" : "Error"] = result.Message;
+            return RedirectToAction(nameof(Index));
+        }
+
         public IActionResult Manage(string id)
         {
             if (string.IsNullOrWhiteSpace(id))

--- a/PESystem/Areas/NPI/Models/NpiProjectModels.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectModels.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace PESystem.Areas.NPI.Models
+{
+    public class NpiProject
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public List<NpiDocument> Documents { get; set; } = new();
+    }
+
+    public class NpiDocument
+    {
+        public string CategoryPath { get; set; } = string.Empty;
+        public string DocumentName { get; set; } = string.Empty;
+        public List<NpiDocumentVersion> Versions { get; set; } = new();
+    }
+
+    public class NpiDocumentVersion
+    {
+        public int Version { get; set; }
+        public string OriginalFileName { get; set; } = string.Empty;
+        public string StoredFileName { get; set; } = string.Empty;
+        public string RelativePath { get; set; } = string.Empty;
+        public DateTime UploadedAt { get; set; } = DateTime.Now;
+        public string UploadedBy { get; set; } = string.Empty;
+    }
+
+    public class NpiFolderDefinition
+    {
+        public string Name { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public List<NpiFolderDefinition> Children { get; set; } = new();
+    }
+
+    public class NpiProjectViewModel
+    {
+        public NpiProject Project { get; set; } = new();
+        public List<NpiFolderDefinition> Structure { get; set; } = new();
+        public Dictionary<string, List<NpiDocument>> DocumentsByCategory { get; set; } = new();
+    }
+
+    public class NpiCategoryCardViewModel
+    {
+        public string ProjectId { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string CategoryPath { get; set; } = string.Empty;
+        public List<NpiDocument> Documents { get; set; } = new();
+    }
+}

--- a/PESystem/Areas/NPI/Models/NpiProjectModels.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectModels.cs
@@ -49,5 +49,6 @@ namespace PESystem.Areas.NPI.Models
         public string DisplayName { get; set; } = string.Empty;
         public string CategoryPath { get; set; } = string.Empty;
         public List<NpiDocument> Documents { get; set; } = new();
+        public bool IsChildCategory { get; set; }
     }
 }

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -1,0 +1,496 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using PESystem.Areas.NPI.Models;
+
+namespace PESystem.Areas.NPI.Services
+{
+    public class NpiDocumentService
+    {
+        private const string BasePath = @"D:\\NpiDocument";
+        private const string MetadataFileName = "metadata.json";
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true
+        };
+
+        private static readonly List<NpiFolderDefinition> FolderStructure = new()
+        {
+            new NpiFolderDefinition
+            {
+                Name = "BOM",
+                DisplayName = "BOM",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "NPI BOM", DisplayName = "NPI BOM" },
+                    new NpiFolderDefinition { Name = "MP BOM", DisplayName = "MP BOM" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Document instruction",
+                DisplayName = "Document instruction",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "PCB layout", DisplayName = "PCB layout" },
+                    new NpiFolderDefinition { Name = "schematic", DisplayName = "Schematic" },
+                    new NpiFolderDefinition { Name = "ASSY + Packing instruction", DisplayName = "ASSY + Packing instruction" },
+                    new NpiFolderDefinition { Name = "Label instruction", DisplayName = "Label instruction" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Manufacturing process",
+                DisplayName = "Manufacturing process",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "Route from NV", DisplayName = "Route from NV" },
+                    new NpiFolderDefinition { Name = "Manufacturing in foxconn + SFC", DisplayName = "Manufacturing in foxconn + SFC" },
+                    new NpiFolderDefinition { Name = "SOP full process from IE", DisplayName = "SOP full process from IE" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Key component",
+                DisplayName = "Key component",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "OPV component", DisplayName = "OPV component" },
+                    new NpiFolderDefinition { Name = "EPAD location", DisplayName = "EPAD location" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "SOP NPI",
+                DisplayName = "SOP NPI",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "SOP polarity", DisplayName = "SOP polarity" },
+                    new NpiFolderDefinition { Name = "Label instruction", DisplayName = "Label instruction" },
+                    new NpiFolderDefinition { Name = "ESD data", DisplayName = "ESD data" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Config NPI",
+                DisplayName = "Config NPI",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "OPV location", DisplayName = "OPV location" },
+                    new NpiFolderDefinition { Name = "Config 27 for BI process", DisplayName = "Config 27 for BI process" },
+                    new NpiFolderDefinition { Name = "PCBA config", DisplayName = "PCBA config" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "DFX",
+                DisplayName = "DFX",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "LFM", DisplayName = "LFM" },
+                    new NpiFolderDefinition { Name = "FA config", DisplayName = "FA config" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Production plan",
+                DisplayName = "Production plan",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "DEV + status", DisplayName = "DEV + status" },
+                    new NpiFolderDefinition { Name = "YR everyday (tracker)", DisplayName = "YR everyday (tracker)" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Yield Rate NPI for each build",
+                DisplayName = "Yield Rate NPI for each build",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "Only test station (engineer report)", DisplayName = "Only test station (engineer report)" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Cook book",
+                DisplayName = "Cook book",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "Cook book document", DisplayName = "Cook book document" },
+                    new NpiFolderDefinition { Name = "Picture SFG + FG", DisplayName = "Picture SFG + FG" },
+                    new NpiFolderDefinition { Name = "Picture AOI", DisplayName = "Picture AOI" },
+                    new NpiFolderDefinition { Name = "Picture SMT", DisplayName = "Picture SMT" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Yield rate 1st MP",
+                DisplayName = "Yield rate 1st MP",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "Only test station (engineer report)", DisplayName = "Only test station (engineer report)" }
+                }
+            },
+            new NpiFolderDefinition
+            {
+                Name = "Bone pile report",
+                DisplayName = "Bone pile report",
+                Children = new List<NpiFolderDefinition>
+                {
+                    new NpiFolderDefinition { Name = "FA daily test report", DisplayName = "FA daily test report" }
+                }
+            }
+        };
+
+        public NpiDocumentService()
+        {
+            EnsureBasePath();
+        }
+
+        public IReadOnlyList<NpiFolderDefinition> GetFolderStructure()
+        {
+            return FolderStructure.Select(CloneDefinition).ToList();
+        }
+
+        public IEnumerable<NpiProject> GetProjects()
+        {
+            EnsureBasePath();
+            if (!Directory.Exists(BasePath))
+            {
+                yield break;
+            }
+
+            foreach (var directory in Directory.GetDirectories(BasePath))
+            {
+                var metadata = LoadMetadata(directory);
+                if (metadata != null)
+                {
+                    yield return metadata;
+                }
+            }
+        }
+
+        public NpiProject? GetProject(string projectId)
+        {
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                return null;
+            }
+
+            var projectFolder = Path.Combine(BasePath, projectId);
+            if (!Directory.Exists(projectFolder))
+            {
+                return null;
+            }
+
+            return LoadMetadata(projectFolder);
+        }
+
+        public (bool Success, string Message, NpiProject? Project) CreateProject(string projectName, string owner)
+        {
+            if (string.IsNullOrWhiteSpace(projectName))
+            {
+                return (false, "Tên project không được bỏ trống.", null);
+            }
+
+            var sanitizedName = SanitizeForPath(projectName);
+            if (string.IsNullOrWhiteSpace(sanitizedName))
+            {
+                sanitizedName = "Project";
+            }
+
+            var projectId = EnsureUniqueProjectId(sanitizedName);
+            var projectFolder = Path.Combine(BasePath, projectId);
+
+            try
+            {
+                Directory.CreateDirectory(projectFolder);
+                CreateFolderStructure(projectFolder);
+
+                var project = new NpiProject
+                {
+                    Id = projectId,
+                    Name = projectName.Trim(),
+                    Owner = owner?.Trim() ?? string.Empty,
+                    CreatedAt = DateTime.Now
+                };
+
+                SaveMetadata(projectFolder, project);
+                return (true, "Project được tạo thành công.", project);
+            }
+            catch (Exception ex)
+            {
+                return (false, $"Không thể tạo project: {ex.Message}", null);
+            }
+        }
+
+        public (bool Success, string Message) AddDocumentVersion(
+            string projectId,
+            string categoryPath,
+            string documentName,
+            string uploadedBy,
+            IFormFile file)
+        {
+            if (string.IsNullOrWhiteSpace(projectId) || string.IsNullOrWhiteSpace(categoryPath))
+            {
+                return (false, "Thiếu thông tin project hoặc thư mục.");
+            }
+
+            if (file == null || file.Length == 0)
+            {
+                return (false, "Tệp tải lên không hợp lệ.");
+            }
+
+            var projectFolder = Path.Combine(BasePath, projectId);
+            var metadata = LoadMetadata(projectFolder);
+            if (metadata == null)
+            {
+                return (false, "Không tìm thấy project.");
+            }
+
+            var categorySegments = SplitCategoryPath(categoryPath);
+            var categoryFolder = Path.Combine(new[] { projectFolder }.Concat(categorySegments).ToArray());
+
+            Directory.CreateDirectory(categoryFolder);
+
+            var documentFolderName = SanitizeForPath(documentName);
+            if (string.IsNullOrWhiteSpace(documentFolderName))
+            {
+                documentFolderName = "Document";
+            }
+            var documentFolder = Path.Combine(categoryFolder, documentFolderName);
+            Directory.CreateDirectory(documentFolder);
+
+            var document = metadata.Documents
+                .FirstOrDefault(d => string.Equals(d.CategoryPath, categoryPath, StringComparison.OrdinalIgnoreCase)
+                                     && string.Equals(d.DocumentName, documentName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+            if (document == null)
+            {
+                document = new NpiDocument
+                {
+                    CategoryPath = categoryPath,
+                    DocumentName = documentName.Trim()
+                };
+                metadata.Documents.Add(document);
+            }
+
+            var newVersion = document.Versions.Any() ? document.Versions.Max(v => v.Version) + 1 : 1;
+            var sanitizedFileName = SanitizeForPath(Path.GetFileNameWithoutExtension(file.FileName));
+            if (string.IsNullOrWhiteSpace(sanitizedFileName))
+            {
+                sanitizedFileName = "file";
+            }
+            var extension = Path.GetExtension(file.FileName);
+            var storedFileName = $"{sanitizedFileName}_v{newVersion}_{DateTime.Now:yyyyMMddHHmmss}{extension}";
+
+            var pathSegments = categorySegments.ToList();
+            pathSegments.Add(documentFolderName);
+            pathSegments.Add(storedFileName);
+
+            var physicalPath = Path.Combine(new[] { projectFolder }.Concat(pathSegments).ToArray());
+            using (var stream = new FileStream(physicalPath, FileMode.Create))
+            {
+                file.CopyTo(stream);
+            }
+
+            var relativePath = string.Join('/', pathSegments);
+            document.Versions.Add(new NpiDocumentVersion
+            {
+                Version = newVersion,
+                OriginalFileName = file.FileName,
+                StoredFileName = storedFileName,
+                RelativePath = relativePath,
+                UploadedAt = DateTime.Now,
+                UploadedBy = uploadedBy?.Trim() ?? string.Empty
+            });
+
+            SaveMetadata(projectFolder, metadata);
+            return (true, "Tải tài liệu thành công.");
+        }
+
+        public (bool Success, string Message, string? AbsolutePath, string? DownloadFileName) GetDocumentForDownload(
+            string projectId,
+            string categoryPath,
+            string documentName,
+            int version)
+        {
+            var projectFolder = Path.Combine(BasePath, projectId);
+            var metadata = LoadMetadata(projectFolder);
+            if (metadata == null)
+            {
+                return (false, "Không tìm thấy project.", null, null);
+            }
+
+            var document = metadata.Documents
+                .FirstOrDefault(d => string.Equals(d.CategoryPath, categoryPath, StringComparison.OrdinalIgnoreCase)
+                                     && string.Equals(d.DocumentName, documentName, StringComparison.OrdinalIgnoreCase));
+
+            if (document == null)
+            {
+                return (false, "Không tìm thấy tài liệu.", null, null);
+            }
+
+            var versionInfo = document.Versions.FirstOrDefault(v => v.Version == version);
+            if (versionInfo == null)
+            {
+                return (false, "Không tìm thấy phiên bản.", null, null);
+            }
+
+            var physicalPath = Path.Combine(projectFolder, versionInfo.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(physicalPath))
+            {
+                return (false, "File không tồn tại.", null, null);
+            }
+
+            return (true, string.Empty, physicalPath, versionInfo.OriginalFileName);
+        }
+
+        public (bool Success, string Message) DeleteVersion(string projectId, string categoryPath, string documentName, int version)
+        {
+            var projectFolder = Path.Combine(BasePath, projectId);
+            var metadata = LoadMetadata(projectFolder);
+            if (metadata == null)
+            {
+                return (false, "Không tìm thấy project.");
+            }
+
+            var document = metadata.Documents
+                .FirstOrDefault(d => string.Equals(d.CategoryPath, categoryPath, StringComparison.OrdinalIgnoreCase)
+                                     && string.Equals(d.DocumentName, documentName, StringComparison.OrdinalIgnoreCase));
+
+            if (document == null)
+            {
+                return (false, "Không tìm thấy tài liệu.");
+            }
+
+            var versionInfo = document.Versions.FirstOrDefault(v => v.Version == version);
+            if (versionInfo == null)
+            {
+                return (false, "Không tìm thấy phiên bản.");
+            }
+
+            var physicalPath = Path.Combine(projectFolder, versionInfo.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(physicalPath))
+            {
+                File.Delete(physicalPath);
+            }
+
+            document.Versions.Remove(versionInfo);
+            if (!document.Versions.Any())
+            {
+                metadata.Documents.Remove(document);
+            }
+
+            SaveMetadata(projectFolder, metadata);
+            return (true, "Đã xoá phiên bản tài liệu.");
+        }
+
+        private void EnsureBasePath()
+        {
+            if (!Directory.Exists(BasePath))
+            {
+                Directory.CreateDirectory(BasePath);
+            }
+        }
+
+        private static string SanitizeForPath(string value)
+        {
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var cleaned = new string(value
+                .Where(c => !invalidChars.Contains(c))
+                .ToArray());
+
+            cleaned = cleaned.Trim();
+            cleaned = cleaned.Replace(' ', '_');
+            return cleaned;
+        }
+
+        private string EnsureUniqueProjectId(string sanitizedName)
+        {
+            var projectId = sanitizedName;
+            var counter = 1;
+            while (Directory.Exists(Path.Combine(BasePath, projectId)))
+            {
+                counter++;
+                projectId = $"{sanitizedName}_{counter}";
+            }
+
+            return projectId;
+        }
+
+        private void CreateFolderStructure(string projectFolder)
+        {
+            foreach (var definition in FolderStructure)
+            {
+                CreateFolderRecursive(projectFolder, definition, new List<string>());
+            }
+        }
+
+        private void CreateFolderRecursive(string projectFolder, NpiFolderDefinition definition, List<string> parents)
+        {
+            var segments = new List<string>(parents) { definition.Name };
+            var folderPath = Path.Combine(new[] { projectFolder }.Concat(segments).ToArray());
+            Directory.CreateDirectory(folderPath);
+
+            foreach (var child in definition.Children)
+            {
+                CreateFolderRecursive(projectFolder, child, segments);
+            }
+        }
+
+        private static NpiFolderDefinition CloneDefinition(NpiFolderDefinition definition)
+        {
+            return new NpiFolderDefinition
+            {
+                Name = definition.Name,
+                DisplayName = definition.DisplayName,
+                Children = definition.Children.Select(CloneDefinition).ToList()
+            };
+        }
+
+        private static NpiProject? LoadMetadata(string projectFolder)
+        {
+            var metadataPath = Path.Combine(projectFolder, MetadataFileName);
+            if (!File.Exists(metadataPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(metadataPath);
+                var project = JsonSerializer.Deserialize<NpiProject>(json, JsonOptions);
+                if (project != null)
+                {
+                    project.Documents ??= new List<NpiDocument>();
+                    foreach (var doc in project.Documents)
+                    {
+                        doc.Versions ??= new List<NpiDocumentVersion>();
+                    }
+                }
+                return project;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void SaveMetadata(string projectFolder, NpiProject project)
+        {
+            var metadataPath = Path.Combine(projectFolder, MetadataFileName);
+            var json = JsonSerializer.Serialize(project, JsonOptions);
+            File.WriteAllText(metadataPath, json);
+        }
+
+        private static string[] SplitCategoryPath(string categoryPath)
+        {
+            return categoryPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -59,8 +59,7 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "Key component",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "OPV component", DisplayName = "OPV component" },
-                    new NpiFolderDefinition { Name = "EPAD location", DisplayName = "EPAD location" }
+                    new NpiFolderDefinition { Name = "OPV data", DisplayName = "OPV data" }
                 }
             },
             new NpiFolderDefinition
@@ -70,8 +69,8 @@ namespace PESystem.Areas.NPI.Services
                 Children = new List<NpiFolderDefinition>
                 {
                     new NpiFolderDefinition { Name = "SOP polarity", DisplayName = "SOP polarity" },
-                    new NpiFolderDefinition { Name = "Label instruction", DisplayName = "Label instruction" },
-                    new NpiFolderDefinition { Name = "ESD data", DisplayName = "ESD data" }
+                    new NpiFolderDefinition { Name = "EPAD location", DisplayName = "EPAD location" },
+                    new NpiFolderDefinition { Name = "ESD location", DisplayName = "ESD location" }
                 }
             },
             new NpiFolderDefinition
@@ -80,9 +79,8 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "Config NPI",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "OPV location", DisplayName = "OPV location" },
                     new NpiFolderDefinition { Name = "Config 27 for BI process", DisplayName = "Config 27 for BI process" },
-                    new NpiFolderDefinition { Name = "PCBA config", DisplayName = "PCBA config" }
+                    new NpiFolderDefinition { Name = "LCR config", DisplayName = "LCR config" }
                 }
             },
             new NpiFolderDefinition
@@ -91,8 +89,8 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "DFX",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "LFM", DisplayName = "LFM" },
-                    new NpiFolderDefinition { Name = "FA config", DisplayName = "FA config" }
+                    new NpiFolderDefinition { Name = "PFMEA", DisplayName = "PFMEA" },
+                    new NpiFolderDefinition { Name = "PMP", DisplayName = "PMP" }
                 }
             },
             new NpiFolderDefinition
@@ -101,8 +99,7 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "Production plan",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "DEV + status", DisplayName = "DEV + status" },
-                    new NpiFolderDefinition { Name = "YR everyday (tracker)", DisplayName = "YR everyday (tracker)" }
+                    new NpiFolderDefinition { Name = "DEV + status", DisplayName = "DEV + status" }
                 }
             },
             new NpiFolderDefinition
@@ -111,7 +108,9 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "Yield Rate NPI for each build",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "Only test station (engineer report)", DisplayName = "Only test station (engineer report)" }
+                    new NpiFolderDefinition { Name = "YR everyday (tracker)", DisplayName = "YR everyday (tracker)" },
+                    new NpiFolderDefinition { Name = "Only test station (engineer report)", DisplayName = "Only test station (engineer report)" },
+                    new NpiFolderDefinition { Name = "FA detail report", DisplayName = "FA detail report" }
                 }
             },
             new NpiFolderDefinition
@@ -123,7 +122,7 @@ namespace PESystem.Areas.NPI.Services
                     new NpiFolderDefinition { Name = "Cook book document", DisplayName = "Cook book document" },
                     new NpiFolderDefinition { Name = "Picture SFG + FG", DisplayName = "Picture SFG + FG" },
                     new NpiFolderDefinition { Name = "Picture AOI", DisplayName = "Picture AOI" },
-                    new NpiFolderDefinition { Name = "Picture SMT", DisplayName = "Picture SMT" }
+                    new NpiFolderDefinition { Name = "Profile SMT", DisplayName = "Profile SMT" }
                 }
             },
             new NpiFolderDefinition
@@ -132,7 +131,8 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "Yield rate 1st MP",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "Only test station (engineer report)", DisplayName = "Only test station (engineer report)" }
+                    new NpiFolderDefinition { Name = "Only test station (engineer report)", DisplayName = "Only test station (engineer report)" },
+                    new NpiFolderDefinition { Name = "FA detail report", DisplayName = "FA detail report" }
                 }
             },
             new NpiFolderDefinition
@@ -141,7 +141,7 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = "Bone pile report",
                 Children = new List<NpiFolderDefinition>
                 {
-                    new NpiFolderDefinition { Name = "FA daily test report", DisplayName = "FA daily test report" }
+                    new NpiFolderDefinition { Name = "Bone pile report", DisplayName = "Bone pile report" }
                 }
             }
         };

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -228,6 +228,55 @@ namespace PESystem.Areas.NPI.Services
             }
         }
 
+        public (bool Success, string Message) UpdateProject(string projectId, string name, string owner)
+        {
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                return (false, "Thiếu thông tin project.");
+            }
+
+            var projectFolder = Path.Combine(BasePath, projectId);
+            var metadata = LoadMetadata(projectFolder);
+            if (metadata == null)
+            {
+                return (false, "Không tìm thấy project.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                metadata.Name = name.Trim();
+            }
+
+            metadata.Owner = owner?.Trim() ?? string.Empty;
+            SaveMetadata(projectFolder, metadata);
+
+            return (true, "Đã cập nhật thông tin project.");
+        }
+
+        public (bool Success, string Message) DeleteProject(string projectId)
+        {
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                return (false, "Thiếu thông tin project.");
+            }
+
+            var projectFolder = Path.Combine(BasePath, projectId);
+            if (!Directory.Exists(projectFolder))
+            {
+                return (false, "Không tìm thấy project.");
+            }
+
+            try
+            {
+                Directory.Delete(projectFolder, recursive: true);
+                return (true, "Đã xoá project cùng toàn bộ tài liệu.");
+            }
+            catch (Exception ex)
+            {
+                return (false, $"Không thể xoá project: {ex.Message}");
+            }
+        }
+
         public (bool Success, string Message) AddDocumentVersion(
             string projectId,
             string categoryPath,

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -472,6 +472,8 @@ namespace PESystem.Areas.NPI.Services
                     {
                         doc.Versions ??= new List<NpiDocumentVersion>();
                     }
+
+                    NormalizeDocumentVersions(project);
                 }
                 return project;
             }
@@ -491,6 +493,42 @@ namespace PESystem.Areas.NPI.Services
         private static string[] SplitCategoryPath(string categoryPath)
         {
             return categoryPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private static void NormalizeDocumentVersions(NpiProject project)
+        {
+            foreach (var document in project.Documents)
+            {
+                if (document.Versions == null || document.Versions.Count == 0)
+                {
+                    continue;
+                }
+
+                var orderedByTime = document.Versions
+                    .OrderBy(v => v.UploadedAt)
+                    .ThenBy(v => v.Version)
+                    .ToList();
+
+                var requiresRenumbering = false;
+                for (int i = 0; i < orderedByTime.Count; i++)
+                {
+                    if (orderedByTime[i].Version != i + 1)
+                    {
+                        requiresRenumbering = true;
+                        break;
+                    }
+                }
+
+                if (requiresRenumbering)
+                {
+                    for (int i = 0; i < orderedByTime.Count; i++)
+                    {
+                        orderedByTime[i].Version = i + 1;
+                    }
+                }
+
+                document.Versions = orderedByTime;
+            }
         }
     }
 }

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -10,7 +10,7 @@ namespace PESystem.Areas.NPI.Services
 {
     public class NpiDocumentService
     {
-        private const string BasePath = @"D:\\NpiDocument";
+        private const string BasePath = @"D:\NpiDocument";
         private const string MetadataFileName = "metadata.json";
 
         private static readonly JsonSerializerOptions JsonOptions = new()

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,4 +1,6 @@
 @model IEnumerable<PESystem.Areas.NPI.Models.NpiProject>
+@using System
+@using System.Linq
 
 @{
     ViewData["Title"] = "NPI Document";
@@ -42,22 +44,84 @@
                                 <th scope="col">Project</th>
                                 <th scope="col">Owner</th>
                                 <th scope="col" style="width: 180px;">Ngày tạo</th>
-                                <th scope="col" class="text-end" style="width: 120px;">Thao tác</th>
+                                <th scope="col" class="text-end" style="width: 220px;">Thao tác</th>
                             </tr>
                         </thead>
                         <tbody>
                             @foreach (var project in Model)
                             {
+                                var modalKey = new string(project.Id.Where(char.IsLetterOrDigit).ToArray());
+                                modalKey = string.IsNullOrWhiteSpace(modalKey) ? Guid.NewGuid().ToString("N") : modalKey;
                                 <tr>
                                     <td class="fw-semibold">@project.Name</td>
                                     <td>@(string.IsNullOrWhiteSpace(project.Owner) ? "-" : project.Owner)</td>
                                     <td>@project.CreatedAt.ToString("dd/MM/yyyy HH:mm")</td>
                                     <td class="text-end">
-                                        <a class="btn btn-sm btn-outline-primary" asp-area="NPI" asp-controller="Home" asp-action="Manage" asp-route-id="@project.Id">
-                                            Quản lý
-                                        </a>
+                                        <div class="d-inline-flex flex-wrap gap-2 justify-content-end">
+                                            <a class="btn btn-sm btn-outline-primary d-flex align-items-center gap-1" asp-area="NPI" asp-controller="Home" asp-action="Manage" asp-route-id="@project.Id">
+                                                <i class="bi bi-folder2-open"></i><span>Quản lý</span>
+                                            </a>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#editProjectModal_@modalKey">
+                                                <i class="bi bi-pencil-square"></i><span>Sửa</span>
+                                            </button>
+                        
+                                            <button type="button" class="btn btn-sm btn-outline-danger d-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#deleteProjectModal_@modalKey">
+                                                <i class="bi bi-trash"></i><span>Xoá</span>
+                                            </button>
+                                        </div>
                                     </td>
                                 </tr>
+
+                                <div class="modal fade" id="editProjectModal_@modalKey" tabindex="-1" aria-labelledby="editProjectModalLabel_@modalKey" aria-hidden="true">
+                                    <div class="modal-dialog">
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" id="editProjectModalLabel_@modalKey">Cập nhật project</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+                                            </div>
+                                            <form asp-area="NPI" asp-controller="Home" asp-action="UpdateProject" method="post">
+                                                <div class="modal-body">
+                                                    @Html.AntiForgeryToken()
+                                                    <input type="hidden" name="projectId" value="@project.Id" />
+                                                    <div class="mb-3">
+                                                        <label class="form-label" for="projectName_@modalKey">Tên project</label>
+                                                        <input type="text" id="projectName_@modalKey" name="projectName" class="form-control" value="@project.Name" required />
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label" for="projectOwner_@modalKey">Owner</label>
+                                                        <input type="text" id="projectOwner_@modalKey" name="owner" class="form-control" value="@project.Owner" />
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Huỷ</button>
+                                                    <button type="submit" class="btn btn-primary">Lưu thay đổi</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="modal fade" id="deleteProjectModal_@modalKey" tabindex="-1" aria-labelledby="deleteProjectModalLabel_@modalKey" aria-hidden="true">
+                                    <div class="modal-dialog modal-dialog-centered">
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" id="deleteProjectModalLabel_@modalKey">Xoá project</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+                                            </div>
+                                            <form asp-area="NPI" asp-controller="Home" asp-action="DeleteProject" method="post">
+                                                <div class="modal-body">
+                                                    @Html.AntiForgeryToken()
+                                                    <input type="hidden" name="projectId" value="@project.Id" />
+                                                    <p class="mb-0">Bạn có chắc chắn muốn xoá project <strong>@project.Name</strong>? Toàn bộ tài liệu liên quan sẽ bị xoá khỏi hệ thống.</p>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Huỷ</button>
+                                                    <button type="submit" class="btn btn-danger">Xoá project</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
                             }
                         </tbody>
                     </table>

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,0 +1,107 @@
+@model IEnumerable<PESystem.Areas.NPI.Models.NpiProject>
+
+@{
+    ViewData["Title"] = "NPI Document";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h2 class="fw-bold mb-0">NPI Document</h2>
+            <p class="text-muted mb-0">Quản lý tài liệu cho từng project NPI</p>
+        </div>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+            <i class="bi bi-plus-circle me-2"></i>Tạo project mới
+        </button>
+    </div>
+
+    @if (ViewBag.Success != null)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @ViewBag.Success
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+    else if (ViewBag.Error != null)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @ViewBag.Error
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            @if (Model != null && Model.Any())
+            {
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Project</th>
+                                <th scope="col">Owner</th>
+                                <th scope="col" style="width: 180px;">Ngày tạo</th>
+                                <th scope="col" class="text-end" style="width: 120px;">Thao tác</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var project in Model)
+                            {
+                                <tr>
+                                    <td class="fw-semibold">@project.Name</td>
+                                    <td>@(string.IsNullOrWhiteSpace(project.Owner) ? "-" : project.Owner)</td>
+                                    <td>@project.CreatedAt.ToString("dd/MM/yyyy HH:mm")</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-sm btn-outline-primary" asp-area="NPI" asp-controller="Home" asp-action="Manage" asp-route-id="@project.Id">
+                                            Quản lý
+                                        </a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="text-center py-5">
+                    <h5 class="text-muted mb-2">Chưa có project nào được tạo.</h5>
+                    <p class="text-muted mb-4">Nhấn nút "Tạo project mới" để bắt đầu lưu trữ tài liệu NPI.</p>
+                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+                        Tạo project mới
+                    </button>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="createProjectModal" tabindex="-1" aria-labelledby="createProjectModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="createProjectModalLabel">Tạo project NPI mới</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form asp-area="NPI" asp-controller="Home" asp-action="CreateProject" method="post">
+                    @Html.AntiForgeryToken()
+                    <div class="mb-3">
+                        <label for="projectName" class="form-label">Tên project <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="projectName" name="projectName" required />
+                        <div class="form-text">Tên project sẽ được sử dụng để tạo cấu trúc thư mục lưu trữ.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="owner" class="form-label">Owner</label>
+                        <input type="text" class="form-control" id="owner" name="owner" placeholder="Người phụ trách project" />
+                    </div>
+                    <div class="d-flex justify-content-end">
+                        <button type="button" class="btn btn-light me-2" data-bs-dismiss="modal">Đóng</button>
+                        <button type="submit" class="btn btn-primary">Tạo project</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/PESystem/Areas/NPI/Views/Home/Manage.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Manage.cshtml
@@ -74,6 +74,12 @@
             background-color: #0b5ed7;
         }
 
+        .npi-version-badge {
+            background-color: rgba(13, 110, 253, 0.12);
+            color: #0d6efd;
+            border: 1px solid rgba(13, 110, 253, 0.35);
+        }
+
         @@media (max-width: 768px) {
             .npi-subcategory-wrapper {
                 padding-left: 1rem;

--- a/PESystem/Areas/NPI/Views/Home/Manage.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Manage.cshtml
@@ -9,15 +9,69 @@
 
 @section Styles {
     <style>
+        .npi-overview-card h2 {
+            font-size: 1.75rem;
+        }
+
         .npi-category-stack {
             display: flex;
             flex-direction: column;
-            gap: 1.5rem;
+            gap: 1.25rem;
         }
 
         .npi-subcategory-wrapper {
-            border-left: 3px solid rgba(13, 110, 253, 0.2);
-            padding-left: 1.5rem;
+            border-left: 3px solid rgba(13, 110, 253, 0.18);
+            padding-left: 1.25rem;
+        }
+
+        .accordion-button {
+            font-size: 1.05rem;
+            font-weight: 600;
+        }
+
+        .npi-category-card__header {
+            border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+        }
+
+        .npi-category-card__title {
+            font-size: 1.05rem;
+        }
+
+        .npi-category-card--child .npi-category-card__title {
+            font-size: 1rem;
+        }
+
+        .npi-category-card--child {
+            background: linear-gradient(180deg, #f8f9ff 0%, #f1f3ff 100%);
+        }
+
+        .npi-document-name {
+            font-size: 1rem;
+        }
+
+        .npi-document-actions .btn {
+            min-width: 90px;
+        }
+
+        .npi-document-actions .btn span {
+            font-size: 0.85rem;
+        }
+
+        .npi-document-actions .btn i {
+            font-size: 0.9rem;
+        }
+
+        .npi-category-card__header .btn {
+            font-size: 0.85rem;
+        }
+
+        .npi-subcategory-wrapper .npi-category-card__header .btn {
+            background-color: #0d6efd;
+            color: #fff;
+        }
+
+        .npi-subcategory-wrapper .npi-category-card__header .btn:hover {
+            background-color: #0b5ed7;
         }
 
         @@media (max-width: 768px) {
@@ -25,12 +79,21 @@
                 padding-left: 1rem;
                 border-left-width: 2px;
             }
+
+            .npi-document-actions {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .npi-document-actions .btn {
+                width: 100%;
+            }
         }
     </style>
 }
 
 <div class="container-fluid py-4">
-    <div class="d-flex justify-content-between align-items-center mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-4 npi-overview-card">
         <div>
             <a class="btn btn-link text-decoration-none px-0" asp-area="NPI" asp-controller="Home" asp-action="Index">
                 <i class="bi bi-arrow-left"></i> Quay lại danh sách project
@@ -40,7 +103,7 @@
             <div class="text-muted">Ngày tạo: @Model.Project.CreatedAt.ToString("dd/MM/yyyy HH:mm")</div>
         </div>
         <div class="text-end">
-            <span class="badge bg-primary">@Model.Project.Documents.Sum(d => d.Versions.Count) phiên bản tài liệu</span>
+            <span class="badge text-bg-primary rounded-pill px-3 py-2">@Model.Project.Documents.Sum(d => d.Versions.Count) phiên bản tài liệu</span>
         </div>
     </div>
 

--- a/PESystem/Areas/NPI/Views/Home/Manage.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Manage.cshtml
@@ -1,0 +1,108 @@
+@model PESystem.Areas.NPI.Models.NpiProjectViewModel
+@using PESystem.Areas.NPI.Models
+@using System.Linq
+
+@{
+    ViewData["Title"] = $"{Model.Project.Name} - NPI Document";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <a class="btn btn-link text-decoration-none px-0" asp-area="NPI" asp-controller="Home" asp-action="Index">
+                <i class="bi bi-arrow-left"></i> Quay lại danh sách project
+            </a>
+            <h2 class="fw-bold mb-0 mt-2">@Model.Project.Name</h2>
+            <div class="text-muted">Owner: @(string.IsNullOrWhiteSpace(Model.Project.Owner) ? "Chưa cập nhật" : Model.Project.Owner)</div>
+            <div class="text-muted">Ngày tạo: @Model.Project.CreatedAt.ToString("dd/MM/yyyy HH:mm")</div>
+        </div>
+        <div class="text-end">
+            <span class="badge bg-primary">@Model.Project.Documents.Sum(d => d.Versions.Count) phiên bản tài liệu</span>
+        </div>
+    </div>
+
+    @if (ViewBag.Success != null)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @ViewBag.Success
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+    else if (ViewBag.Error != null)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @ViewBag.Error
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <div class="accordion" id="npiCategoryAccordion">
+        @{ var index = 0; }
+        @foreach (var category in Model.Structure)
+        {
+            var headingId = $"heading{index}";
+            var collapseId = $"collapse{index}";
+            <div class="accordion-item mb-3 shadow-sm">
+                <h2 class="accordion-header" id="@headingId">
+                    <button class="accordion-button @((index == 0 ? string.Empty : "collapsed"))" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="@(index == 0)" aria-controls="@collapseId">
+                        @category.DisplayName
+                    </button>
+                </h2>
+                <div id="@collapseId" class="accordion-collapse collapse @(index == 0 ? "show" : string.Empty)" aria-labelledby="@headingId" data-bs-parent="#npiCategoryAccordion">
+                    <div class="accordion-body">
+                        @if (category.Children != null && category.Children.Any())
+                        {
+                            <div class="row g-4">
+                                @foreach (var child in category.Children)
+                                {
+                                    var path = BuildPath(category.Name, child.Name);
+                                    var docs = GetDocuments(path);
+                                    <div class="col-12">
+                                        @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
+                                        {
+                                            ProjectId = Model.Project.Id,
+                                            DisplayName = child.DisplayName,
+                                            CategoryPath = path,
+                                            Documents = docs.OrderBy(d => d.DocumentName).ToList()
+                                        })
+                                    </div>
+                                }
+                            </div>
+                        }
+                        else
+                        {
+                            var path = BuildPath(category.Name);
+                            var docs = GetDocuments(path);
+                            @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
+                            {
+                                ProjectId = Model.Project.Id,
+                                DisplayName = category.DisplayName,
+                                CategoryPath = path,
+                                Documents = docs.OrderBy(d => d.DocumentName).ToList()
+                            })
+                        }
+                    </div>
+                </div>
+            </div>
+            index++;
+        }
+    </div>
+</div>
+
+@functions {
+    private string BuildPath(params string[] segments)
+    {
+        return string.Join('/', segments.Where(s => !string.IsNullOrWhiteSpace(s)));
+    }
+
+    private IEnumerable<NpiDocument> GetDocuments(string path)
+    {
+        if (Model.DocumentsByCategory.TryGetValue(path, out var docs))
+        {
+            return docs;
+        }
+
+        return Enumerable.Empty<NpiDocument>();
+    }
+}

--- a/PESystem/Areas/NPI/Views/Home/Manage.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Manage.cshtml
@@ -2,9 +2,31 @@
 @using PESystem.Areas.NPI.Models
 @using System.Linq
 
-@{
+@{ 
     ViewData["Title"] = $"{Model.Project.Name} - NPI Document";
     Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+@section Styles {
+    <style>
+        .npi-category-stack {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+
+        .npi-subcategory-wrapper {
+            border-left: 3px solid rgba(13, 110, 253, 0.2);
+            padding-left: 1.5rem;
+        }
+
+        @media (max-width: 768px) {
+            .npi-subcategory-wrapper {
+                padding-left: 1rem;
+                border-left-width: 2px;
+            }
+        }
+    </style>
 }
 
 <div class="container-fluid py-4">
@@ -51,41 +73,39 @@
                 </h2>
                 <div id="@collapseId" class="accordion-collapse collapse @(index == 0 ? "show" : string.Empty)" aria-labelledby="@headingId" data-bs-parent="#npiCategoryAccordion">
                     <div class="accordion-body">
-                        @if (category.Children != null && category.Children.Any())
-                        {
-                            <div class="row g-4">
+                        <div class="npi-category-stack">
+                            @if (category.Children != null && category.Children.Any())
+                            {
                                 @foreach (var child in category.Children)
                                 {
                                     var path = BuildPath(category.Name, child.Name);
                                     var docs = GetDocuments(path);
-                                    <div class="col-12 col-lg-6 col-xxl-4">
+                                    <div class="npi-subcategory-wrapper">
                                         @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
                                         {
                                             ProjectId = Model.Project.Id,
                                             DisplayName = child.DisplayName,
                                             CategoryPath = path,
-                                            Documents = docs.OrderBy(d => d.DocumentName).ToList()
+                                            Documents = docs.OrderBy(d => d.DocumentName).ToList(),
+                                            IsChildCategory = true
                                         })
                                     </div>
                                 }
-                            </div>
-                        }
-                        else
-                        {
-                            var path = BuildPath(category.Name);
-                            var docs = GetDocuments(path);
-                            <div class="row g-4">
-                                <div class="col-12 col-lg-6 col-xxl-4">
-                                    @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
-                                    {
-                                        ProjectId = Model.Project.Id,
-                                        DisplayName = category.DisplayName,
-                                        CategoryPath = path,
-                                        Documents = docs.OrderBy(d => d.DocumentName).ToList()
-                                    })
-                                </div>
-                            </div>
-                        }
+                            }
+                            else
+                            {
+                                var path = BuildPath(category.Name);
+                                var docs = GetDocuments(path);
+                                @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
+                                {
+                                    ProjectId = Model.Project.Id,
+                                    DisplayName = category.DisplayName,
+                                    CategoryPath = path,
+                                    Documents = docs.OrderBy(d => d.DocumentName).ToList(),
+                                    IsChildCategory = false
+                                })
+                            }
+                        </div>
                     </div>
                 </div>
             </div>

--- a/PESystem/Areas/NPI/Views/Home/Manage.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Manage.cshtml
@@ -58,7 +58,7 @@
                                 {
                                     var path = BuildPath(category.Name, child.Name);
                                     var docs = GetDocuments(path);
-                                    <div class="col-12">
+                                    <div class="col-12 col-lg-6 col-xxl-4">
                                         @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
                                         {
                                             ProjectId = Model.Project.Id,
@@ -74,13 +74,17 @@
                         {
                             var path = BuildPath(category.Name);
                             var docs = GetDocuments(path);
-                            @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
-                            {
-                                ProjectId = Model.Project.Id,
-                                DisplayName = category.DisplayName,
-                                CategoryPath = path,
-                                Documents = docs.OrderBy(d => d.DocumentName).ToList()
-                            })
+                            <div class="row g-4">
+                                <div class="col-12 col-lg-6 col-xxl-4">
+                                    @await Html.PartialAsync("_CategoryCard", new NpiCategoryCardViewModel
+                                    {
+                                        ProjectId = Model.Project.Id,
+                                        DisplayName = category.DisplayName,
+                                        CategoryPath = path,
+                                        Documents = docs.OrderBy(d => d.DocumentName).ToList()
+                                    })
+                                </div>
+                            </div>
                         }
                     </div>
                 </div>

--- a/PESystem/Areas/NPI/Views/Home/Manage.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Manage.cshtml
@@ -20,7 +20,7 @@
             padding-left: 1.5rem;
         }
 
-        @media (max-width: 768px) {
+        @@media (max-width: 768px) {
             .npi-subcategory-wrapper {
                 padding-left: 1rem;
                 border-left-width: 2px;

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -69,7 +69,7 @@
                                     }
                                     <td class="text-center">
                                         <div class="d-flex flex-column align-items-center gap-2">
-                                            <span class="badge rounded-pill text-bg-primary fw-semibold">V@version.Version</span>
+                                            <span class="badge rounded-pill text-bg-primary fw-semibold">@($"V{version.Version}")</span>
                                             <small class="text-muted text-break">@version.OriginalFileName</small>
                                             @if (version.Version == latestVersion)
                                             {

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -1,0 +1,80 @@
+@model PESystem.Areas.NPI.Models.NpiCategoryCardViewModel
+@using System.Linq
+
+<div class="card shadow-sm">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">@Model.DisplayName</h5>
+    </div>
+    <div class="card-body">
+        <form asp-area="NPI" asp-controller="Home" asp-action="UploadDocument" method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="projectId" value="@Model.ProjectId" />
+            <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
+            <div class="col-md-4">
+                <label class="form-label">Tên tài liệu <span class="text-danger">*</span></label>
+                <input type="text" name="documentName" class="form-control" required />
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Người cập nhật</label>
+                <input type="text" name="uploadedBy" class="form-control" placeholder="Tên người cập nhật" />
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">File <span class="text-danger">*</span></label>
+                <input type="file" name="file" class="form-control" required />
+            </div>
+            <div class="col-md-2 d-grid">
+                <button type="submit" class="btn btn-primary">Tải lên</button>
+            </div>
+        </form>
+
+        @if (Model.Documents.Any())
+        {
+            <div class="table-responsive mt-4">
+                <table class="table table-striped table-sm">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Tài liệu</th>
+                            <th scope="col">Version</th>
+                            <th scope="col">Ngày cập nhật</th>
+                            <th scope="col">Người cập nhật</th>
+                            <th scope="col" class="text-end">Thao tác</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var document in Model.Documents)
+                        {
+                            foreach (var version in document.Versions.OrderByDescending(v => v.Version))
+                            {
+                                <tr>
+                                    <td class="fw-semibold">@document.DocumentName</td>
+                                    <td>v@version.Version</td>
+                                    <td>@version.UploadedAt.ToString("dd/MM/yyyy HH:mm")</td>
+                                    <td>@(string.IsNullOrWhiteSpace(version.UploadedBy) ? "-" : version.UploadedBy)</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-sm btn-outline-secondary me-2" asp-area="NPI" asp-controller="Home" asp-action="Download" asp-route-projectId="@Model.ProjectId" asp-route-categoryPath="@Model.CategoryPath" asp-route-documentName="@document.DocumentName" asp-route-version="@version.Version">
+                                            <i class="bi bi-download"></i>
+                                        </a>
+                                        <form asp-area="NPI" asp-controller="Home" asp-action="DeleteVersion" method="post" class="d-inline" onsubmit="return confirm('Bạn có chắc muốn xoá phiên bản này?');">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="projectId" value="@Model.ProjectId" />
+                                            <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
+                                            <input type="hidden" name="documentName" value="@document.DocumentName" />
+                                            <input type="hidden" name="version" value="@version.Version" />
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+        else
+        {
+            <div class="text-muted mt-4">Chưa có tài liệu nào được tải lên.</div>
+        }
+    </div>
+</div>

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -10,22 +10,22 @@
     }
 
     var cardClasses = Model.IsChildCategory
-        ? "card shadow-sm border-0 h-100 bg-light"
-        : "card shadow-sm border-0 h-100";
+        ? "card shadow-sm border-0 h-100 bg-light npi-category-card npi-category-card--child"
+        : "card shadow-sm border-0 h-100 npi-category-card";
 
     var headerClasses = Model.IsChildCategory
-        ? "card-header d-flex justify-content-between align-items-center py-3 bg-light border-0 border-bottom"
-        : "card-header bg-white d-flex justify-content-between align-items-center py-3";
+        ? "card-header d-flex justify-content-between align-items-center py-3 bg-light border-0 border-bottom npi-category-card__header"
+        : "card-header bg-white d-flex justify-content-between align-items-center py-3 npi-category-card__header";
 }
 
 <div class="@cardClasses">
     <div class="@headerClasses">
         <div>
-            <h5 class="mb-1 fw-semibold">@Model.DisplayName</h5>
+            <h5 class="mb-1 fw-semibold npi-category-card__title">@Model.DisplayName</h5>
             <small class="text-muted">@Model.Documents.Sum(d => d.Versions.Count) phiên bản được lưu trữ</small>
         </div>
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#@modalId">
-            <i class="bi bi-upload me-1"></i> Tải lên
+        <button type="button" class="btn btn-primary btn-sm d-flex align-items-center gap-2" data-bs-toggle="modal" data-bs-target="#@modalId">
+            <i class="bi bi-upload"></i><span>Tải lên</span>
         </button>
     </div>
     <div class="card-body">
@@ -63,13 +63,13 @@
                                     @if (i == 0)
                                     {
                                         <td rowspan="@orderedVersions.Count" class="align-middle">
-                                            <div class="fw-semibold text-primary">@document.DocumentName</div>
+                                            <div class="fw-semibold text-primary npi-document-name">@document.DocumentName</div>
                                             <small class="text-muted">@orderedVersions.Count phiên bản được lưu</small>
                                         </td>
                                     }
                                     <td class="text-center">
-                                        <div class="d-flex flex-column align-items-center gap-1">
-                                            <span class="badge bg-primary fw-semibold">#@version.Version</span>
+                                        <div class="d-flex flex-column align-items-center gap-2">
+                                            <span class="badge rounded-pill text-bg-primary fw-semibold">V@version.Version</span>
                                             <small class="text-muted text-break">@version.OriginalFileName</small>
                                             @if (version.Version == latestVersion)
                                             {
@@ -80,9 +80,9 @@
                                     <td>@version.UploadedAt.ToString("dd/MM/yyyy HH:mm")</td>
                                     <td>@(string.IsNullOrWhiteSpace(version.UploadedBy) ? "-" : version.UploadedBy)</td>
                                     <td class="text-end">
-                                        <div class="btn-group" role="group">
-                                            <a class="btn btn-sm btn-outline-primary" asp-area="NPI" asp-controller="Home" asp-action="Download" asp-route-projectId="@Model.ProjectId" asp-route-categoryPath="@Model.CategoryPath" asp-route-documentName="@document.DocumentName" asp-route-version="@version.Version" title="Tải xuống">
-                                                <i class="bi bi-download"></i>
+                                        <div class="npi-document-actions d-flex justify-content-end gap-2">
+                                            <a class="btn btn-sm btn-outline-primary d-flex align-items-center gap-1" asp-area="NPI" asp-controller="Home" asp-action="Download" asp-route-projectId="@Model.ProjectId" asp-route-categoryPath="@Model.CategoryPath" asp-route-documentName="@document.DocumentName" asp-route-version="@version.Version" title="Tải xuống">
+                                                <i class="bi bi-download"></i><span>Tải</span>
                                             </a>
                                             <form asp-area="NPI" asp-controller="Home" asp-action="DeleteVersion" method="post" class="d-inline" onsubmit="return confirm('Bạn có chắc muốn xoá phiên bản này?');">
                                                 @Html.AntiForgeryToken()
@@ -90,8 +90,8 @@
                                                 <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
                                                 <input type="hidden" name="documentName" value="@document.DocumentName" />
                                                 <input type="hidden" name="version" value="@version.Version" />
-                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Xoá phiên bản">
-                                                    <i class="bi bi-trash"></i>
+                                                <button type="submit" class="btn btn-sm btn-outline-danger d-flex align-items-center gap-1" title="Xoá phiên bản">
+                                                    <i class="bi bi-trash"></i><span>Xoá</span>
                                                 </button>
                                             </form>
                                         </div>

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -69,7 +69,7 @@
                                     }
                                     <td class="text-center">
                                         <div class="d-flex flex-column align-items-center gap-2">
-                                            <span class="badge rounded-pill text-bg-primary fw-semibold">@($"V{version.Version}")</span>
+                                            <span class="badge rounded-pill fw-semibold npi-version-badge">@($"V{version.Version}")</span>
                                             <small class="text-muted text-break">@version.OriginalFileName</small>
                                             @if (version.Version == latestVersion)
                                             {

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -103,7 +103,7 @@
                 </table>
             </div>
         }
-        @else
+        else
         {
             <div class="d-flex align-items-center justify-content-center text-muted py-4">
                 <i class="bi bi-inbox me-2"></i> Chưa có tài liệu nào được tải lên.

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -8,10 +8,18 @@
     {
         modalId += Guid.NewGuid().ToString("N");
     }
+
+    var cardClasses = Model.IsChildCategory
+        ? "card shadow-sm border-0 h-100 bg-light"
+        : "card shadow-sm border-0 h-100";
+
+    var headerClasses = Model.IsChildCategory
+        ? "card-header d-flex justify-content-between align-items-center py-3 bg-light border-0 border-bottom"
+        : "card-header bg-white d-flex justify-content-between align-items-center py-3";
 }
 
-<div class="card shadow-sm border-0 h-100">
-    <div class="card-header bg-white d-flex justify-content-between align-items-center py-3">
+<div class="@cardClasses">
+    <div class="@headerClasses">
         <div>
             <h5 class="mb-1 fw-semibold">@Model.DisplayName</h5>
             <small class="text-muted">@Model.Documents.Sum(d => d.Versions.Count) phiên bản được lưu trữ</small>
@@ -21,10 +29,11 @@
         </button>
     </div>
     <div class="card-body">
-        @if (Model.Documents.Any())
+        @{ var hasAnyVersion = Model.Documents.Any(d => d.Versions != null && d.Versions.Any()); }
+        @if (hasAnyVersion)
         {
             <div class="table-responsive">
-                <table class="table align-middle table-hover">
+                <table class="table align-middle table-hover mb-0">
                     <thead class="table-light">
                         <tr>
                             <th scope="col" style="min-width: 200px;">Tài liệu</th>
@@ -37,15 +46,36 @@
                     <tbody>
                         @foreach (var document in Model.Documents.OrderBy(d => d.DocumentName))
                         {
-                            foreach (var version in document.Versions.OrderByDescending(v => v.Version))
+                            if (document.Versions == null || !document.Versions.Any())
                             {
+                                continue;
+                            }
+
+                            var orderedVersions = document.Versions
+                                .OrderByDescending(v => v.Version)
+                                .ThenByDescending(v => v.UploadedAt)
+                                .ToList();
+                            var latestVersion = orderedVersions.FirstOrDefault()?.Version ?? 0;
+                            for (int i = 0; i < orderedVersions.Count; i++)
+                            {
+                                var version = orderedVersions[i];
                                 <tr>
-                                    <td>
-                                        <div class="fw-semibold text-primary">@document.DocumentName</div>
-                                        <small class="text-muted">@version.OriginalFileName</small>
-                                    </td>
+                                    @if (i == 0)
+                                    {
+                                        <td rowspan="@orderedVersions.Count" class="align-middle">
+                                            <div class="fw-semibold text-primary">@document.DocumentName</div>
+                                            <small class="text-muted">@orderedVersions.Count phiên bản được lưu</small>
+                                        </td>
+                                    }
                                     <td class="text-center">
-                                        <span class="badge rounded-pill bg-secondary fw-semibold">v@version.Version</span>
+                                        <div class="d-flex flex-column align-items-center gap-1">
+                                            <span class="badge bg-primary fw-semibold">#@version.Version</span>
+                                            <small class="text-muted text-break">@version.OriginalFileName</small>
+                                            @if (version.Version == latestVersion)
+                                            {
+                                                <small class="text-success fw-semibold">Mới nhất</small>
+                                            }
+                                        </div>
                                     </td>
                                     <td>@version.UploadedAt.ToString("dd/MM/yyyy HH:mm")</td>
                                     <td>@(string.IsNullOrWhiteSpace(version.UploadedBy) ? "-" : version.UploadedBy)</td>
@@ -73,7 +103,7 @@
                 </table>
             </div>
         }
-        else
+        @else
         {
             <div class="d-flex align-items-center justify-content-center text-muted py-4">
                 <i class="bi bi-inbox me-2"></i> Chưa có tài liệu nào được tải lên.

--- a/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/_CategoryCard.cshtml
@@ -1,69 +1,70 @@
 @model PESystem.Areas.NPI.Models.NpiCategoryCardViewModel
+@using System
 @using System.Linq
 
-<div class="card shadow-sm">
-    <div class="card-header bg-white d-flex justify-content-between align-items-center">
-        <h5 class="mb-0">@Model.DisplayName</h5>
+@{
+    var modalId = $"uploadModal_{new string(Model.CategoryPath.Where(char.IsLetterOrDigit).ToArray())}";
+    if (string.IsNullOrEmpty(modalId) || modalId == "uploadModal_")
+    {
+        modalId += Guid.NewGuid().ToString("N");
+    }
+}
+
+<div class="card shadow-sm border-0 h-100">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center py-3">
+        <div>
+            <h5 class="mb-1 fw-semibold">@Model.DisplayName</h5>
+            <small class="text-muted">@Model.Documents.Sum(d => d.Versions.Count) phiên bản được lưu trữ</small>
+        </div>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#@modalId">
+            <i class="bi bi-upload me-1"></i> Tải lên
+        </button>
     </div>
     <div class="card-body">
-        <form asp-area="NPI" asp-controller="Home" asp-action="UploadDocument" method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
-            @Html.AntiForgeryToken()
-            <input type="hidden" name="projectId" value="@Model.ProjectId" />
-            <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
-            <div class="col-md-4">
-                <label class="form-label">Tên tài liệu <span class="text-danger">*</span></label>
-                <input type="text" name="documentName" class="form-control" required />
-            </div>
-            <div class="col-md-3">
-                <label class="form-label">Người cập nhật</label>
-                <input type="text" name="uploadedBy" class="form-control" placeholder="Tên người cập nhật" />
-            </div>
-            <div class="col-md-3">
-                <label class="form-label">File <span class="text-danger">*</span></label>
-                <input type="file" name="file" class="form-control" required />
-            </div>
-            <div class="col-md-2 d-grid">
-                <button type="submit" class="btn btn-primary">Tải lên</button>
-            </div>
-        </form>
-
         @if (Model.Documents.Any())
         {
-            <div class="table-responsive mt-4">
-                <table class="table table-striped table-sm">
+            <div class="table-responsive">
+                <table class="table align-middle table-hover">
                     <thead class="table-light">
                         <tr>
-                            <th scope="col">Tài liệu</th>
-                            <th scope="col">Version</th>
+                            <th scope="col" style="min-width: 200px;">Tài liệu</th>
+                            <th scope="col" class="text-center">Phiên bản</th>
                             <th scope="col">Ngày cập nhật</th>
                             <th scope="col">Người cập nhật</th>
                             <th scope="col" class="text-end">Thao tác</th>
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var document in Model.Documents)
+                        @foreach (var document in Model.Documents.OrderBy(d => d.DocumentName))
                         {
                             foreach (var version in document.Versions.OrderByDescending(v => v.Version))
                             {
                                 <tr>
-                                    <td class="fw-semibold">@document.DocumentName</td>
-                                    <td>v@version.Version</td>
+                                    <td>
+                                        <div class="fw-semibold text-primary">@document.DocumentName</div>
+                                        <small class="text-muted">@version.OriginalFileName</small>
+                                    </td>
+                                    <td class="text-center">
+                                        <span class="badge rounded-pill bg-secondary fw-semibold">v@version.Version</span>
+                                    </td>
                                     <td>@version.UploadedAt.ToString("dd/MM/yyyy HH:mm")</td>
                                     <td>@(string.IsNullOrWhiteSpace(version.UploadedBy) ? "-" : version.UploadedBy)</td>
                                     <td class="text-end">
-                                        <a class="btn btn-sm btn-outline-secondary me-2" asp-area="NPI" asp-controller="Home" asp-action="Download" asp-route-projectId="@Model.ProjectId" asp-route-categoryPath="@Model.CategoryPath" asp-route-documentName="@document.DocumentName" asp-route-version="@version.Version">
-                                            <i class="bi bi-download"></i>
-                                        </a>
-                                        <form asp-area="NPI" asp-controller="Home" asp-action="DeleteVersion" method="post" class="d-inline" onsubmit="return confirm('Bạn có chắc muốn xoá phiên bản này?');">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="projectId" value="@Model.ProjectId" />
-                                            <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
-                                            <input type="hidden" name="documentName" value="@document.DocumentName" />
-                                            <input type="hidden" name="version" value="@version.Version" />
-                                            <button type="submit" class="btn btn-sm btn-outline-danger">
-                                                <i class="bi bi-trash"></i>
-                                            </button>
-                                        </form>
+                                        <div class="btn-group" role="group">
+                                            <a class="btn btn-sm btn-outline-primary" asp-area="NPI" asp-controller="Home" asp-action="Download" asp-route-projectId="@Model.ProjectId" asp-route-categoryPath="@Model.CategoryPath" asp-route-documentName="@document.DocumentName" asp-route-version="@version.Version" title="Tải xuống">
+                                                <i class="bi bi-download"></i>
+                                            </a>
+                                            <form asp-area="NPI" asp-controller="Home" asp-action="DeleteVersion" method="post" class="d-inline" onsubmit="return confirm('Bạn có chắc muốn xoá phiên bản này?');">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="projectId" value="@Model.ProjectId" />
+                                                <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
+                                                <input type="hidden" name="documentName" value="@document.DocumentName" />
+                                                <input type="hidden" name="version" value="@version.Version" />
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Xoá phiên bản">
+                                                    <i class="bi bi-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
                                     </td>
                                 </tr>
                             }
@@ -74,7 +75,50 @@
         }
         else
         {
-            <div class="text-muted mt-4">Chưa có tài liệu nào được tải lên.</div>
+            <div class="d-flex align-items-center justify-content-center text-muted py-4">
+                <i class="bi bi-inbox me-2"></i> Chưa có tài liệu nào được tải lên.
+            </div>
         }
+    </div>
+</div>
+
+<div class="modal fade" id="@modalId" tabindex="-1" aria-labelledby="@($"{modalId}Label")" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content shadow">
+            <div class="modal-header">
+                <h5 class="modal-title" id="@($"{modalId}Label")">Tải tài liệu mới - @Model.DisplayName</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+            </div>
+            <form asp-area="NPI" asp-controller="Home" asp-action="UploadDocument" method="post" enctype="multipart/form-data">
+                <div class="modal-body">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="projectId" value="@Model.ProjectId" />
+                    <input type="hidden" name="categoryPath" value="@Model.CategoryPath" />
+
+                    <div class="mb-3">
+                        <label class="form-label">Tên tài liệu <span class="text-danger">*</span></label>
+                        <input type="text" name="documentName" class="form-control" placeholder="Nhập tên tài liệu" required />
+                        <div class="form-text">Tên tài liệu sẽ được sử dụng để gom nhóm các phiên bản.</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Người cập nhật</label>
+                        <input type="text" name="uploadedBy" class="form-control" placeholder="Tên người cập nhật" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">File tải lên <span class="text-danger">*</span></label>
+                        <input type="file" name="file" class="form-control" required />
+                        <div class="form-text">Mỗi lần tải lên hệ thống sẽ tự động đánh số phiên bản (v1, v2, ...).</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Huỷ</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-upload me-1"></i> Tải lên
+                    </button>
+                </div>
+            </form>
+        </div>
     </div>
 </div>

--- a/PESystem/Areas/NPI/Views/_ViewImports.cshtml
+++ b/PESystem/Areas/NPI/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using PESystem.Areas.NPI.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/PESystem/Program.cs
+++ b/PESystem/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PESystem.Models;
+using PESystem.Areas.NPI.Services;
 using PESystem.Policies;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +16,8 @@ var configuration = new ConfigurationBuilder()
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllersWithViews();
+
+builder.Services.AddSingleton<NpiDocumentService>();
 
 // ---- HttpClient: gộp làm 1, vừa có BaseAddress vừa bypass proxy ----
 builder.Services.AddHttpClient("ApiClient", client =>
@@ -45,6 +48,7 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("ScrapAccess", p => p.Requirements.Add(new AreaAccessRequirement("Scrap")));
     options.AddPolicy("MaterialSystemAccess", p => p.Requirements.Add(new AreaAccessRequirement("MaterialSystem")));
     options.AddPolicy("SFCAccess", p => p.Requirements.Add(new AreaAccessRequirement("SFC")));
+    options.AddPolicy("NPIAccess", p => p.Requirements.Add(new AreaAccessRequirement("NPI")));
 });
 
 builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();

--- a/PESystem/Views/Home/Home.cshtml
+++ b/PESystem/Views/Home/Home.cshtml
@@ -164,7 +164,7 @@
                 <div class="card shadow-sm text-center custom-card">
                     <div class="d-flex flex-column justify-content-center align-items-center h-100">
                         <img src="~/assets/img/Document.jpg" class="logo mb-2" />
-                        <span class="fw-bold text-muted" style="font-size:14px; color: black !important;">NPI document</span>
+                        <span class="fw-bold text-muted" style="font-size:14px; color: black !important;">NPI DOCUMENT</span>
                     </div>
                 </div>
             </a>

--- a/PESystem/Views/Shared/_Layout.cshtml
+++ b/PESystem/Views/Shared/_Layout.cshtml
@@ -10,6 +10,8 @@
     <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="~/lib/all-fa-icon/css/all.min.css" rel="stylesheet" />
 
+    @await RenderSectionAsync("Styles", required: false)
+
 </head>
 <body>
     <!-- Áp dụng trạng thái ban đầu từ localStorage -->


### PR DESCRIPTION
## Summary
- introduce an NPI area with controllers, models, and services to manage NPI document projects stored under `D:\\NpiDocument`
- provide views to create projects, upload versioned files per predefined category structure, and manage downloads/deletions
- register the NPI area in the application configuration and update the home navigation tile for quick access

## Testing
- dotnet build (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68f6f8fc8dcc83268325a0374686673f