### PR TITLE
Show uploaded document progress for NPI projects

### DIFF
--- a/PESystem/Areas/NPI/Controllers/HomeController.cs
+++ b/PESystem/Areas/NPI/Controllers/HomeController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
@@ -26,10 +27,30 @@ namespace PESystem.Areas.NPI.Controllers
                 .OrderByDescending(p => p.CreatedAt)
                 .ToList();
 
+            var totalCategoryCount = _documentService.GetTotalCategoryCount();
+
+            var projectSummaries = projects
+                .Select(project =>
+                {
+                    var uploadedCategories = (project.Documents ?? Enumerable.Empty<NpiDocument>())
+                        .Where(d => !string.IsNullOrWhiteSpace(d.CategoryPath))
+                        .Select(d => d.CategoryPath)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Count();
+
+                    return new NpiProjectSummaryViewModel
+                    {
+                        Project = project,
+                        UploadedCategoryCount = uploadedCategories,
+                        TotalCategoryCount = totalCategoryCount
+                    };
+                })
+                .ToList();
+
             ViewBag.Success = TempData["Success"];
             ViewBag.Error = TempData["Error"];
 
-            return View(projects);
+            return View(projectSummaries);
         }
 
         [HttpPost]

--- a/PESystem/Areas/NPI/Models/NpiProjectModels.cs
+++ b/PESystem/Areas/NPI/Models/NpiProjectModels.cs
@@ -51,4 +51,11 @@ namespace PESystem.Areas.NPI.Models
         public List<NpiDocument> Documents { get; set; } = new();
         public bool IsChildCategory { get; set; }
     }
+
+    public class NpiProjectSummaryViewModel
+    {
+        public NpiProject Project { get; set; } = new();
+        public int UploadedCategoryCount { get; set; }
+        public int TotalCategoryCount { get; set; }
+    }
 }

--- a/PESystem/Areas/NPI/Services/NpiDocumentService.cs
+++ b/PESystem/Areas/NPI/Services/NpiDocumentService.cs
@@ -156,6 +156,11 @@ namespace PESystem.Areas.NPI.Services
             return FolderStructure.Select(CloneDefinition).ToList();
         }
 
+        public int GetTotalCategoryCount()
+        {
+            return CountLeafCategories(FolderStructure);
+        }
+
         public IEnumerable<NpiProject> GetProjects()
         {
             EnsureBasePath();
@@ -500,6 +505,25 @@ namespace PESystem.Areas.NPI.Services
                 DisplayName = definition.DisplayName,
                 Children = definition.Children.Select(CloneDefinition).ToList()
             };
+        }
+
+        private static int CountLeafCategories(IEnumerable<NpiFolderDefinition> definitions)
+        {
+            var total = 0;
+
+            foreach (var definition in definitions)
+            {
+                if (definition.Children != null && definition.Children.Count > 0)
+                {
+                    total += CountLeafCategories(definition.Children);
+                }
+                else
+                {
+                    total += 1;
+                }
+            }
+
+            return total;
         }
 
         private static NpiProject? LoadMetadata(string projectFolder)

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<PESystem.Areas.NPI.Models.NpiProject>
+@model IEnumerable<PESystem.Areas.NPI.Models.NpiProjectSummaryViewModel>
 @using System
 @using System.Linq
 
@@ -43,18 +43,33 @@
                             <tr>
                                 <th scope="col">Project</th>
                                 <th scope="col">Owner</th>
+                                <th scope="col" class="text-center" style="width: 180px;">Hạng mục đã tải</th>
                                 <th scope="col" style="width: 180px;">Ngày tạo</th>
                                 <th scope="col" class="text-end" style="width: 220px;">Thao tác</th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var project in Model)
+                            @foreach (var projectSummary in Model)
                             {
+                                var project = projectSummary.Project;
+                                var totalCategories = projectSummary.TotalCategoryCount;
+                                var progressText = totalCategories > 0
+                                    ? $"{projectSummary.UploadedCategoryCount}/{totalCategories}"
+                                    : projectSummary.UploadedCategoryCount.ToString();
+                                var progressLabel = totalCategories > 0
+                                    ? $"Đã tải {projectSummary.UploadedCategoryCount}/{totalCategories} hạng mục"
+                                    : $"Đã tải {projectSummary.UploadedCategoryCount} hạng mục";
+                                var badgeStyle = projectSummary.UploadedCategoryCount > 0 ? "text-bg-primary" : "text-bg-secondary";
                                 var modalKey = new string(project.Id.Where(char.IsLetterOrDigit).ToArray());
                                 modalKey = string.IsNullOrWhiteSpace(modalKey) ? Guid.NewGuid().ToString("N") : modalKey;
                                 <tr>
                                     <td class="fw-semibold">@project.Name</td>
                                     <td>@(string.IsNullOrWhiteSpace(project.Owner) ? "-" : project.Owner)</td>
+                                    <td class="text-center">
+                                        <span class="badge rounded-pill @badgeStyle px-3 py-2" title="@progressLabel" aria-label="@progressLabel">
+                                            @progressText
+                                        </span>
+                                    </td>
                                     <td>@project.CreatedAt.ToString("dd/MM/yyyy HH:mm")</td>
                                     <td class="text-end">
                                         <div class="d-inline-flex flex-wrap gap-2 justify-content-end">

--- a/PESystem/Areas/NPI/Views/Home/Index.cshtml
+++ b/PESystem/Areas/NPI/Views/Home/Index.cshtml
@@ -59,14 +59,16 @@
                                 var progressLabel = totalCategories > 0
                                     ? $"Đã tải {projectSummary.UploadedCategoryCount}/{totalCategories} hạng mục"
                                     : $"Đã tải {projectSummary.UploadedCategoryCount} hạng mục";
-                                var badgeStyle = projectSummary.UploadedCategoryCount > 0 ? "text-bg-primary" : "text-bg-secondary";
+                                var badgeClasses = projectSummary.UploadedCategoryCount > 0
+                                    ? "badge rounded-pill bg-light text-dark border border-primary px-3 py-2"
+                                    : "badge rounded-pill bg-light text-muted border border-secondary px-3 py-2";
                                 var modalKey = new string(project.Id.Where(char.IsLetterOrDigit).ToArray());
                                 modalKey = string.IsNullOrWhiteSpace(modalKey) ? Guid.NewGuid().ToString("N") : modalKey;
                                 <tr>
                                     <td class="fw-semibold">@project.Name</td>
                                     <td>@(string.IsNullOrWhiteSpace(project.Owner) ? "-" : project.Owner)</td>
                                     <td class="text-center">
-                                        <span class="badge rounded-pill @badgeStyle px-3 py-2" title="@progressLabel" aria-label="@progressLabel">
+                                        <span class="@badgeClasses" title="@progressLabel" aria-label="@progressLabel">
                                             @progressText
                                         </span>
                                     </td>


### PR DESCRIPTION
## Summary
- add a summary view model so the index page can show project-level document progress
- expose a helper on the document service to count required document categories
- render the uploaded/total category count badge in the NPI project list

## Testing
- dotnet build (fails: dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_6909b58ec950832682235c60bc3b29e5